### PR TITLE
Implemented support for dfn aliases and scoping

### DIFF
--- a/examples/getusermedia.html
+++ b/examples/getusermedia.html
@@ -4,7 +4,6 @@
 <head>
   <meta name="generator" content=
   "HTML Tidy for HTML5 (experimental) for Linux https://github.com/w3c/tidy-html5/tree/68a9e74">
-  <link href="getusermedia.css" rel="stylesheet" type="text/css">
 
   <title>Media Capture and Streams</title>
   <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
@@ -70,14 +69,13 @@
           <p>
             The concepts <dfn><a href="http://dev.w3.org/html5/spec/webappapis.html#queue-a-task">
             queue a task</a></dfn> and
-            <dfn><a href="http://dev.w3.org/html5/spec/webappapis.html#fire-a-simple-event">
+            <dfn data-title='fire a simple event|fires a simple event'><a href="http://dev.w3.org/html5/spec/webappapis.html#fire-a-simple-event">
             fires a simple event</a></dfn> are defined in [[!HTML5]].
           </p>
 
           <p>
-            The terms <dfn><a href="http://dev.w3.org/html5/spec/webappapis.html#event-handlers">
-            event handlers</a></dfn> and
-            <dfn><a href="http://dev.w3.org/html5/spec/webappapis.html#event-handler-event-type">
+            The terms <dfn data-title='event handler|event handlers'><a href="http://dev.w3.org/html5/spec/webappapis.html#event-handlers">
+            event handlers</a></dfn> and <dfn data-title='event handler event type|event handler event types'><a href="http://dev.w3.org/html5/spec/webappapis.html#event-handler-event-type">
             event handler event types</a></dfn> are defined in [[!HTML5]].
           </p>
         </dd>

--- a/examples/getusermedia.js
+++ b/examples/getusermedia.js
@@ -27,11 +27,6 @@ var respecConfig = {
    // if this is a LCWD, uncomment and set the end of its review period
    // lcEnd: "2009-08-05",
 
-   // if you want to have extra CSS, append them to this list
-   // it is recommended that the respec.css stylesheet be kept
-   extraCSS:             ["http://dev.w3.org/2009/dap/ReSpec.js/css/respec.css"],
-   //extraCSS:           ["../../../2009/dap/ReSpec.js/css/respec.css"],
-
    // editors, add as many as you like
    // only "name" is required
    editors:  [

--- a/js/core/dfn.js
+++ b/js/core/dfn.js
@@ -64,9 +64,9 @@ define(
                             conf.exportedDefs[scope+":"+title] = theID;
                         }
                     }) ;
-                    if ($t.attr('data-local-title')) {
-                        a = $t.dfnTitle('data-local-title');
-                        if (a != '') {
+                    if ($t.attr('local-title')) {
+                        a = $t.dfnTitle('local-title');
+                        if (a) {
                             titles = a.split(/\|/) ;
                             $.each(titles, function (i, title) {
                                 title = title.replace(/^\s+/, "").replace(/\s+$/, "");
@@ -74,7 +74,7 @@ define(
                                 conf.definitionMap[scope][title] = theID ;
                             }) ;
                         }
-                        $t.removeAttr('data-local-title') ;
+                        $t.removeAttr('local-title') ;
                     }
                 });
                 $("a:not([href])").each(function () {
@@ -82,7 +82,7 @@ define(
                     if ($ant.hasClass("externalDFN")) return;
                     var title = $ant.dfnTitle();
                     var scope = $ant.dfnScope() ;
-                    if (conf.definitionMap[scope][title] && !(conf.definitionMap[scope][title] instanceof Function)) {
+                    if (conf.definitionMap[scope][title] && !(typeof conf.definitionMap[scope][title] == "function" )) {
                         $ant.attr("href", "#" + conf.definitionMap[scope][title]).addClass("internalDFN");
                     }
                     else {

--- a/js/core/dfn.js
+++ b/js/core/dfn.js
@@ -1,6 +1,11 @@
 
 // Module core/dfn
 // Handles the processing and linking of <dfn> and <a> elements.
+// Note that each dfn has a "scope" that is determined from the
+// dfnScope method in the Util module.  A definition can be 
+// scoped with a local attribute or a parent attribute that 
+// scopes the definitions into a vocabulary space.  See the 
+// dfnScope method for more information.    
 define(
     [],
     function () {
@@ -9,22 +14,81 @@ define(
                 msg.pub("start", "core/dfn");
                 doc.normalize();
                 if (!conf.definitionMap) conf.definitionMap = {};
+                if (!conf.exportedDefs) conf.exportedDefs = {};
+                if (!conf.localDefs) conf.localDefs = {};
                 $("dfn").each(function () {
-                    var title = $(this).dfnTitle();
-                    if (conf.definitionMap[title]) msg.pub("error", "Duplicate definition of '" + title + "'");
-                    conf.definitionMap[title] = $(this).makeID("dfn", title);
+                    var $t = $(this) ;
+                    // find our scope
+                    var scope = $t.dfnScope();
+                    if (!conf.definitionMap[scope]) conf.definitionMap[scope] = {} ;
+                    // should this be exported?
+                    var x = $t.dfnExport( scope ) ;
+                    // memorialize the state for later scraping
+                    if (x) {
+                        $t.attr('data-export', '') ;
+                    }
+                    else {
+                        $t.attr('data-noexport', '') ;
+                    }
+
+                    // data-title is the primary way of
+                    // declaring the ways this definition can be
+                    // referenced
+                    var a ;
+                    if ($t.attr('data-title')) {
+                        a = $t.dfnTitle('data-title') ;
+                    }
+                    // if there is no data-title attribute, then
+                    // use the (legacy) regular title attribute or the
+                    // contents
+                    else {
+                        a = $t.dfnTitle();
+                        // set the data-title attribute so that 
+                        // bikeshed and others can find us
+                        $t.attr('data-title', a) ;
+                    }
+
+                    // Note - this permits aliases even in the
+                    // regular title attribute
+                    var titles = a.split(/\|/) ;
+                    var prefix = 'dfn' ;
+                    if ( scope != 'dfn' ) {
+                        prefix += '-'+scope ;
+                    }
+                    var theID = $t.makeID(prefix, titles[0]);
+                    $.each(titles, function (i, title) {
+                        title = title.replace(/^\s+/, "").replace(/\s+$/, "");
+                        if (conf.definitionMap[scope][title]) msg.pub("error", "Duplicate definition of '" + scope + ":" + title + "'");
+                        conf.definitionMap[scope][title] = theID ;
+                        if (x) {
+                            conf.exportedDefs[scope+":"+title] = theID;
+                        }
+                    }) ;
+                    if ($t.attr('data-local-title')) {
+                        a = $t.dfnTitle('data-local-title');
+                        if (a != '') {
+                            titles = a.split(/\|/) ;
+                            $.each(titles, function (i, title) {
+                                title = title.replace(/^\s+/, "").replace(/\s+$/, "");
+                                if (conf.definitionMap[scope][title]) msg.pub("error", "Duplicate definition of '" + scope + ":" + title + "'");
+                                conf.definitionMap[scope][title] = theID ;
+                            }) ;
+                        }
+                        $t.removeAttr('data-local-title') ;
+                    }
                 });
                 $("a:not([href])").each(function () {
                     var $ant = $(this);
                     if ($ant.hasClass("externalDFN")) return;
                     var title = $ant.dfnTitle();
-                    if (conf.definitionMap[title] && !(conf.definitionMap[title] instanceof Function)) {
-                        $ant.attr("href", "#" + conf.definitionMap[title]).addClass("internalDFN");
+                    var scope = $ant.dfnScope() ;
+                    if (conf.definitionMap[scope][title] && !(conf.definitionMap[scope][title] instanceof Function)) {
+                        $ant.attr("href", "#" + conf.definitionMap[scope][title]).addClass("internalDFN");
                     }
                     else {
                         // ignore WebIDL
                         if (!$ant.parents(".idl, dl.methods, dl.attributes, dl.constants, dl.constructors, dl.fields, dl.dictionary-members, span.idlMemberType, span.idlTypedefType, div.idlImplementsDesc").length) {
-                            msg.pub("warn", "Found linkless <a> element with text '" + title + "' but no matching <dfn>.");
+                            msg.pub("warn", "Found linkless <a> element with text '" + scope + ":" + title + "' but no matching <dfn>.");
                         }
                         $ant.replaceWith($ant.contents());
                     }

--- a/js/core/utils.js
+++ b/js/core/utils.js
@@ -33,7 +33,7 @@ define(
         // attrName is optional and defaults to 'title'
         $.fn.dfnTitle = function ( attrName ) {
             var title;
-            if (attrName == null) attrName = 'title' ;
+            if (!attrName) attrName = 'title' ;
             if (this.attr(attrName)) title = this.attr(attrName);
             else if (this.contents().length == 1 && this.children("abbr, acronym").length == 1 &&
                      this.find(":first-child").attr(attrName)) title = this.find(":first-child").attr(attrName);
@@ -46,59 +46,21 @@ define(
         // would be placed
 
         $.fn.dfnScope = function () {
-            var scope = '';
-            var $e = $(this) ;
             // TODO - define a list of local attribute names
             // that can be used to indicate scope.
-            if ($e.attr("data-dfn-type")) {
-                scope = $e.attr("data-dfn-type") ;
-            }
-
-            if (scope == "") {
-                var p = $(this).parents("[data-dfn-type]") ;
-                if (p.length && p[0]) {
-                    scope = $(p[0]).attr("data-dfn-type") ;
-                }
-            }
-
-            if (scope == "") {
-                scope = 'dfn' ;
-            }
-
-            return scope.toLowerCase().replace(/^\s/, "");
+            var scope = $(this).closest("[dfn-type]").attr("dfn-type");
+            return (scope || "dfn").toLowerCase().replace(/^\s/, "");
         };
 
         // For any element, returns whether a defintion should
         // be exported or not.  By default we export
 
         $.fn.dfnExport = function ( scope ) {
-            // default to yes we are exporting
-            var r = true;
-            if ( scope && scope == 'dfn' ) {
-                r = false ; // by default basic definitions are NOT exported
-            }
-            var $e = $(this) ;
-            // do we have a local attribute that controls export
-            if ($e.attr("noexport")) {
-                r = false ;
-            }
-            else if ($e.attr("export")) {
-                r = true ;
-            }
-            // is there any parent with either of the 
-            // controls
-            else {
-                var p = $e.parents("[export][noexport]") ;
-                if (p.length && p[0]) {
-                    if ($(p[0]).attr("noexport")) {
-                        r = false ;
-                    }
-                    else {
-                        r = true;
-                    }
-                }
-            }
-            return r ;
+            // is export explicit?
+            var $e = $(this).closest("[export],[noexport]");
+            if ($e.length) return !!$e.attr("export");
+            // by default basic definitions are NOT exported
+            return scope != "dfn";
         };
 
         // Applied to an element, sets an ID for it (and returns it), using a specific prefix

--- a/js/core/utils.js
+++ b/js/core/utils.js
@@ -27,17 +27,79 @@ define(
             return $(arr);
         };
 
-        // For any element, returns a title string that applies the algorithm used for determining the
-        // actual title of a <dfn> element (but can apply to other as well).
-        $.fn.dfnTitle = function () {
+        // For any element, returns a title string that applies the 
+        // algorithm used for determining the actual title of a <dfn> 
+        // element (but can apply to other as well).
+        // attrName is optional and defaults to 'title'
+        $.fn.dfnTitle = function ( attrName ) {
             var title;
-            if (this.attr("title")) title = this.attr("title");
+            if (attrName == null) attrName = 'title' ;
+            if (this.attr(attrName)) title = this.attr(attrName);
             else if (this.contents().length == 1 && this.children("abbr, acronym").length == 1 &&
-                     this.find(":first-child").attr("title")) title = this.find(":first-child").attr("title");
+                     this.find(":first-child").attr(attrName)) title = this.find(":first-child").attr(attrName);
             else title = this.text();
             return title.toLowerCase().replace(/^\s+/, "").replace(/\s+$/, "").split(/\s+/).join(" ");
         };
 
+        // For any element, returns the definition "scope" for
+        // that element; the bucket into which a definition
+        // would be placed
+
+        $.fn.dfnScope = function () {
+            var scope = '';
+            var $e = $(this) ;
+            // TODO - define a list of local attribute names
+            // that can be used to indicate scope.
+            if ($e.attr("data-dfn-type")) {
+                scope = $e.attr("data-dfn-type") ;
+            }
+
+            if (scope == "") {
+                var p = $(this).parents("[data-dfn-type]") ;
+                if (p.length && p[0]) {
+                    scope = $(p[0]).attr("data-dfn-type") ;
+                }
+            }
+
+            if (scope == "") {
+                scope = 'dfn' ;
+            }
+
+            return scope.toLowerCase().replace(/^\s/, "");
+        };
+
+        // For any element, returns whether a defintion should
+        // be exported or not.  By default we export
+
+        $.fn.dfnExport = function ( scope ) {
+            // default to yes we are exporting
+            var r = true;
+            if ( scope && scope == 'dfn' ) {
+                r = false ; // by default basic definitions are NOT exported
+            }
+            var $e = $(this) ;
+            // do we have a local attribute that controls export
+            if ($e.attr("noexport")) {
+                r = false ;
+            }
+            else if ($e.attr("export")) {
+                r = true ;
+            }
+            // is there any parent with either of the 
+            // controls
+            else {
+                var p = $e.parents("[export][noexport]") ;
+                if (p.length && p[0]) {
+                    if ($(p[0]).attr("noexport")) {
+                        r = false ;
+                    }
+                    else {
+                        r = true;
+                    }
+                }
+            }
+            return r ;
+        };
 
         // Applied to an element, sets an ID for it (and returns it), using a specific prefix
         // if provided, and a specific text if given.

--- a/tests/spec/core/dfn-spec.js
+++ b/tests/spec/core/dfn-spec.js
@@ -14,6 +14,52 @@ describe("Core — Definitions", function () {
         runs(function () {
             var $sec = $("#dfn", doc);
             expect($sec.find("dfn").attr("id")).toEqual("dfn-text");
+            expect($sec.find("dfn").attr("data-title")).toEqual("text");
+            expect($sec.find("a").attr("href")).toEqual("#dfn-text");
+            flushIframes();
+        });
+    });
+    it("should allow aliases", function () {
+        var doc;
+        runs(function () {
+            makeRSDoc({ config: basicConfig, body: $("<section id='dfn'><dfn data-title='text|the text|  more text'>text</dfn><a>more text</a></section>") }, 
+                      function (rsdoc) { doc = rsdoc; });
+        });
+        waitsFor(function () { return doc; }, MAXOUT);
+        runs(function () {
+            var $sec = $("#dfn", doc);
+            expect($sec.find("dfn").attr("id")).toEqual("dfn-text");
+            expect($sec.find("dfn").attr("data-title")).toEqual("text|the text|  more text");
+            expect($sec.find("a").attr("href")).toEqual("#dfn-text");
+            flushIframes();
+        });
+    });
+    it("should allow scoping", function () {
+        var doc;
+        runs(function () {
+            makeRSDoc({ config: basicConfig, body: $("<section id='dfn' data-dfn-type='myScope'><dfn data-title='text|the text|  more text'>text</dfn></section><section id='ref' data-dfn-type='myScope'><a>more text</a></section>") }, 
+                      function (rsdoc) { doc = rsdoc; });
+        });
+        waitsFor(function () { return doc; }, MAXOUT);
+        runs(function () {
+            var $sec = $("#dfn", doc);
+            expect($sec.find("dfn").attr("id")).toEqual("dfn-myscope-text");
+            var $ref = $("#ref", doc);
+            expect($ref.find("a").attr("href")).toEqual("#dfn-myscope-text");
+            flushIframes();
+        });
+    });
+    it("should allow local aliases", function () {
+        var doc;
+        runs(function () {
+            makeRSDoc({ config: basicConfig, body: $("<section id='dfn'><dfn data-local-title='local' title='text|the text|  more text'>text</dfn><a>local</a></section>") }, 
+                      function (rsdoc) { doc = rsdoc; });
+        });
+        waitsFor(function () { return doc; }, MAXOUT);
+        runs(function () {
+            var $sec = $("#dfn", doc);
+            expect($sec.find("dfn").attr("id")).toEqual("dfn-text");
+            expect($sec.find("dfn").attr("data-local-title")).toBeUndefined();
             expect($sec.find("a").attr("href")).toEqual("#dfn-text");
             flushIframes();
         });

--- a/tests/spec/core/dfn-spec.js
+++ b/tests/spec/core/dfn-spec.js
@@ -37,7 +37,7 @@ describe("Core — Definitions", function () {
     it("should allow scoping", function () {
         var doc;
         runs(function () {
-            makeRSDoc({ config: basicConfig, body: $("<section id='dfn' data-dfn-type='myScope'><dfn data-title='text|the text|  more text'>text</dfn></section><section id='ref' data-dfn-type='myScope'><a>more text</a></section>") }, 
+            makeRSDoc({ config: basicConfig, body: $("<section id='dfn' dfn-type='myScope'><dfn data-title='text|the text|  more text'>text</dfn></section><section id='ref' dfn-type='myScope'><a>more text</a></section>") }, 
                       function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);
@@ -52,14 +52,14 @@ describe("Core — Definitions", function () {
     it("should allow local aliases", function () {
         var doc;
         runs(function () {
-            makeRSDoc({ config: basicConfig, body: $("<section id='dfn'><dfn data-local-title='local' title='text|the text|  more text'>text</dfn><a>local</a></section>") }, 
+            makeRSDoc({ config: basicConfig, body: $("<section id='dfn'><dfn local-title='local' title='text|the text|  more text'>text</dfn><a>local</a></section>") }, 
                       function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);
         runs(function () {
             var $sec = $("#dfn", doc);
             expect($sec.find("dfn").attr("id")).toEqual("dfn-text");
-            expect($sec.find("dfn").attr("data-local-title")).toBeUndefined();
+            expect($sec.find("dfn").attr("local-title")).toBeUndefined();
             expect($sec.find("a").attr("href")).toEqual("#dfn-text");
             flushIframes();
         });


### PR DESCRIPTION
Added support for data-title='foo|bar|bat' style aliases for
definitions.
Added support for data-local-title='s|p|t' style local aliases for
definitions.
Added support for data-dfn-type to specify the scope of a
definition or group of definitions.
Added support for export and noexport to flag that a definition should
be made available outside of the document being generated.

Note that these changes are all backward compatible.  Current documents
should see no changes in their output.

If you start using the new data-dfn-type to define the type of a
definition or of a reference, it will cause the typeName to be included
in the ID / IDREF.  Otherwise there are no current effects.