### PR TITLE
Fixed test warnings

### DIFF
--- a/tests/spec/core/best-practices-spec.js
+++ b/tests/spec/core/best-practices-spec.js
@@ -3,14 +3,20 @@ describe("Core — Best Practices", function () {
     ,   basicConfig = {
             editors:    [{ name: "Robin Berjon" }]
         ,   specStatus: "WD"
-        };
+        ,   shortName: "mydoc"
+        ,   previousURI:  "http://www.example.com"
+        ,   previousMaturity: "WD"
+        ,   previousPublishDate:  "2014-01-01"
+        }
+    ;
     it("should process examples", function () {
         var doc;
         runs(function () {
             makeRSDoc({
                         config: basicConfig
                     ,   body: $("<section><span class='practicelab'>BP1</span><span class='practicelab'>BP2</span>"
-                            +   "<section id='bp-summary'></section></section>")
+                            +   "<section id='bp-summary'></section></section>"
+                            +   "<section id='sotd'>Custom status</section>")
                     }, 
                     function (rsdoc) { doc = rsdoc; });
         });

--- a/tests/spec/core/default-root-attr-spec.js
+++ b/tests/spec/core/default-root-attr-spec.js
@@ -3,11 +3,17 @@ describe("Core — Default Root Attribute", function () {
     ,   basicConfig = {
             editors:    [{ name: "Robin Berjon" }]
         ,   specStatus: "WD"
-        };
+        ,   shortName: "mydoc"
+        ,   previousURI:  "http://www.example.com"
+        ,   previousMaturity: "WD"
+        ,   previousPublishDate:  "2014-01-01"
+        }
+    ,   body = "<section id='sotd'>Custom SOTD</section>"
+    ;
     it("should apply en and ltr defaults", function () {
         var doc;
         runs(function () {
-            makeRSDoc({ config: basicConfig }, function (rsdoc) { doc = rsdoc; });
+            makeRSDoc({ body: body, config: basicConfig }, function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);
         runs(function () {
@@ -19,7 +25,7 @@ describe("Core — Default Root Attribute", function () {
     it("should not override existing dir", function () {
         var doc;
         runs(function () {
-            makeRSDoc({ config: basicConfig, htmlAttrs: { dir: "rtl" } }, function (rsdoc) { doc = rsdoc; });
+            makeRSDoc({ body: body, config: basicConfig, htmlAttrs: { dir: "rtl" } }, function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);
         runs(function () {
@@ -31,7 +37,7 @@ describe("Core — Default Root Attribute", function () {
     it("should not override existing lang and not set dir", function () {
         var doc;
         runs(function () {
-            makeRSDoc({ config: basicConfig, htmlAttrs: { lang: "fr" } }, function (rsdoc) { doc = rsdoc; });
+            makeRSDoc({ body: body, config: basicConfig, htmlAttrs: { lang: "fr" } }, function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);
         runs(function () {

--- a/tests/spec/core/dfn-spec.js
+++ b/tests/spec/core/dfn-spec.js
@@ -3,11 +3,17 @@ describe("Core — Definitions", function () {
     ,   basicConfig = {
             editors:    [{ name: "Robin Berjon" }]
         ,   specStatus: "WD"
-        };
+        ,   shortName: "mydoc"
+        ,   previousURI:  "http://www.example.com"
+        ,   previousMaturity: "WD"
+        ,   previousPublishDate:  "2014-01-01"
+        }
+    ,   body = "<section id='sotd'>Custom SOTD</section>"
+    ;
     it("should process definitions", function () {
         var doc;
         runs(function () {
-            makeRSDoc({ config: basicConfig, body: $("<section id='dfn'><dfn>text</dfn><a>text</a></section>") }, 
+            makeRSDoc({ config: basicConfig, body: $("<section id='dfn'><dfn>text</dfn><a>text</a></section><section id='sotd'><p>Custom SOTD</p></section>") }, 
                       function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);

--- a/tests/spec/core/examples-spec.js
+++ b/tests/spec/core/examples-spec.js
@@ -3,13 +3,19 @@ describe("Core — Examples", function () {
     ,   basicConfig = {
             editors:    [{ name: "Robin Berjon" }]
         ,   specStatus: "WD"
-        };
+        ,   shortName: "mydoc"
+        ,   previousURI:  "http://www.example.com"
+        ,   previousMaturity: "WD"
+        ,   previousPublishDate:  "2014-01-01"
+        }
+    ,   body = "<section id='sotd'>Custom SOTD</section>"
+    ;
     it("should process examples", function () {
         var doc;
         runs(function () {
             makeRSDoc({
                         config: basicConfig
-                    ,   body: $("<section><pre class='example' title='EX'>\n  {\n    CONTENT\n  }\n  </pre></section>")
+                    ,   body: $("<section><pre class='example' title='EX'>\n  {\n    CONTENT\n  }\n  </pre></section><section id='sotd'>Custom SOTD</section>")
                     }, 
                     function (rsdoc) { doc = rsdoc; });
         });

--- a/tests/spec/core/figures-spec.js
+++ b/tests/spec/core/figures-spec.js
@@ -3,13 +3,19 @@ describe("Core - Figures", function () {
     ,   basicConfig = {
             editors:    [{ name: "Robin Berjon" }]
         ,   specStatus: "WD"
-        };
+        ,   shortName: "mydoc"
+        ,   previousURI:  "http://www.example.com"
+        ,   previousMaturity: "WD"
+        ,   previousPublishDate:  "2014-01-01"
+        }
+    ;
     it("should have handled figures", function () {
         var doc;
         runs(function () {
             makeRSDoc({ config: basicConfig,
                         body: "<section><section id='figs'><div class='figure'><pre title='PREFIG'>PRE</pre></div>" +
-                              "<img src='IMG' title='IMGTIT' class='figure'/></section><section id='tof'></section></section>"
+                              "<img src='IMG' title='IMGTIT' class='figure'/></section><section id='tof'></section></section>" +
+                              "<section id='sotd'>Custom SOTD</section>"
                     }, function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);

--- a/tests/spec/core/fix-headers-spec.js
+++ b/tests/spec/core/fix-headers-spec.js
@@ -3,13 +3,19 @@ describe("Core - Fix headers", function () {
     ,   basicConfig = {
             editors:    [{ name: "Robin Berjon" }]
         ,   specStatus: "WD"
-        };
+        ,   shortName: "mydoc"
+        ,   previousURI:  "http://www.example.com"
+        ,   previousMaturity: "WD"
+        ,   previousPublishDate:  "2014-01-01"
+        }
+    ;
     it("should have set the correct header level", function () {
         var doc;
         runs(function () {
             makeRSDoc({ config: basicConfig,
                         body: "<section id='turtles'><h1>ONE</h1><section><h1>TWO</h1><section><h1>THREE</h1><section><h1>FOUR</h1>" +
-                              "<section><h1>FIVE</h1><section><h1>SIX</h1></section></section></section></section></section></section>"
+                              "<section><h1>FIVE</h1><section><h1>SIX</h1></section></section></section></section></section></section>" +
+                              "<section id='sotd'>Custom SOTD</section>"
                     }, function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);

--- a/tests/spec/core/highlight-spec.js
+++ b/tests/spec/core/highlight-spec.js
@@ -3,13 +3,19 @@ describe("Core — Highlight", function () {
     ,   basicConfig = {
             editors:    [{ name: "Robin Berjon" }]
         ,   specStatus: "WD"
-        };
+        ,   shortName: "mydoc"
+        ,   previousURI:  "http://www.example.com"
+        ,   previousMaturity: "WD"
+        ,   previousPublishDate:  "2014-01-01"
+        }
+    ;
     it("should process highlights", function () {
         var doc;
         runs(function () {
             makeRSDoc({
                         config: basicConfig
-                    ,   body: $("<section><pre class='example sh_javascript'>function () {\n  alert('foo');\n}</pre></section>")
+                    ,   body: $("<section><pre class='example highlight'>function () {\n  alert('foo');\n}</pre></section>" +
+                                "<section id='sotd'>Custom SOTD</section>")
                     }, 
                     function (rsdoc) { doc = rsdoc; });
         });

--- a/tests/spec/core/id-headers-spec.js
+++ b/tests/spec/core/id-headers-spec.js
@@ -3,11 +3,16 @@ describe("Core - ID headers", function () {
     ,   basicConfig = {
             editors:    [{ name: "Robin Berjon" }]
         ,   specStatus: "WD"
-        };
+        ,   shortName: "mydoc"
+        ,   previousURI:  "http://www.example.com"
+        ,   previousMaturity: "WD"
+        ,   previousPublishDate:  "2014-01-01"
+        }
+    ;
     it("should have set ID on header", function () {
         var doc;
         runs(function () {
-            makeRSDoc({ config: basicConfig, body: "<section><p>BLAH</p><h6>FOO</h6></section>" }, function (rsdoc) { doc = rsdoc; });
+            makeRSDoc({ config: basicConfig, body: "<section><p>BLAH</p><h6>FOO</h6></section><section id='sotd'>Custom SOTD</section>" }, function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);
         runs(function () {

--- a/tests/spec/core/includer.html
+++ b/tests/spec/core/includer.html
@@ -22,6 +22,9 @@
           ,   wgPublicList: "none"
           ,   wgPatentURI:  "XXX"
           ,   edDraftURI:   "http://darobin.github.com/respec"
+          ,   previousURI:  "http://www.example.com"
+          ,   previousMaturity: "WD"
+          ,   previousPublishDate:  "2014-01-01"
         };
     </script>
   </head>

--- a/tests/spec/core/informative-spec.js
+++ b/tests/spec/core/informative-spec.js
@@ -3,13 +3,18 @@ describe("Core — Informative", function () {
     ,   basicConfig = {
             editors:    [{ name: "Robin Berjon" }]
         ,   specStatus: "WD"
-        };
+        ,   shortName: "mydoc"
+        ,   previousURI:  "http://www.example.com"
+        ,   previousMaturity: "WD"
+        ,   previousPublishDate:  "2014-01-01"
+        }
+    ;
     it("should process informative sections", function () {
         var doc;
         runs(function () {
             makeRSDoc({
                         config: basicConfig
-                    ,   body: $("<section class='informative'><h2>TITLE</h2></section>")
+                    ,   body: $("<section class='informative'><h2>TITLE</h2></section><section id='sotd'>Custom SOTD</section>")
                     }, 
                     function (rsdoc) { doc = rsdoc; });
         });

--- a/tests/spec/core/inlines-spec.js
+++ b/tests/spec/core/inlines-spec.js
@@ -4,14 +4,20 @@ describe("Core - Inlines", function () {
             editors:    [{ name: "Robin Berjon" }]
         ,   specStatus: "WD"
         ,   doRDFa:  false
-        };
+        ,   shortName: "mydoc"
+        ,   previousURI:  "http://www.example.com"
+        ,   previousMaturity: "WD"
+        ,   previousPublishDate:  "2014-01-01"
+        }
+    ;
     it("should process all inline content", function () {
         var doc;
         runs(function () {
             makeRSDoc({ config: basicConfig,
                         body: "<section id='inlines'><p><acronym title='ACRO-TIT'>ACRO</acronym> ACRO</p><p>" +
                               "<abbr title='ABBR-TIT'>ABBR</abbr> ABBR</p><p>MUST and NOT RECOMMENDED</p>" +
-                              "<p>[[!DAHU]] [[REX]]</p></section>"
+                              "<p>[[!DAHU]] [[REX]]</p></section>" +
+                              "<section id='sotd'>Custom SOTD</section>"
                     }, function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);

--- a/tests/spec/core/issues-notes-spec.js
+++ b/tests/spec/core/issues-notes-spec.js
@@ -3,18 +3,30 @@ describe("Core — Issues and Notes", function () {
     ,   basicConfig = {
             editors:    [{ name: "Robin Berjon" }]
         ,   specStatus: "WD"
+        ,   shortName: "mydoc"
+        ,   previousURI:  "http://www.example.com"
+        ,   previousMaturity: "WD"
+        ,   previousPublishDate:  "2014-01-01"
         }
     ,   issueBaseConfig = {
             editors:    [{ name: "Gregg Kellogg" }]
         ,   issueBase:  "http://example.com/issues/"
         ,   specStatus: "WD"
-      }
+        ,   shortName: "mydoc"
+        ,   previousURI:  "http://www.example.com"
+        ,   previousMaturity: "WD"
+        ,   previousPublishDate:  "2014-01-01"
+        }
     ,   atRiskBaseConfig = {
             editors:    [{ name: "Markus Lanthaler" }]
         ,   issueBase:  "http://example.com/issues/"
         ,   atRiskBase: "http://example.com/atrisk/"
         ,   specStatus: "WD"
-      };
+        ,   shortName: "mydoc"
+        ,   previousURI:  "http://www.example.com"
+        ,   previousMaturity: "WD"
+        ,   previousPublishDate:  "2014-01-01"
+    };
     it("should process issues and notes", function () {
         var doc;
         runs(function () {
@@ -22,7 +34,8 @@ describe("Core — Issues and Notes", function () {
                         config: basicConfig
                     ,   body: $("<section><p>BLAH <span class='issue'>ISS-INLINE</span></p><p class='issue' title='ISS-TIT'>ISSUE</p>" +
                                 "<p>BLAH <span class='issue atrisk'>ATR-INLINE</span></p><p class='issue atrisk' title='ATR-TIT'>FEATURE AT RISK</p>" +
-                                "<p>BLAH <span class='note'>NOT-INLINE</span></p><p class='note' title='NOT-TIT'>NOTE</p></section>")
+                                "<p>BLAH <span class='note'>NOT-INLINE</span></p><p class='note' title='NOT-TIT'>NOTE</p></section>" +
+                                "<section id='sotd'>Custom SOTD</section>" )
                     },
                     function (rsdoc) { doc = rsdoc; });
         });
@@ -67,7 +80,8 @@ describe("Core — Issues and Notes", function () {
       runs(function () {
           makeRSDoc({
                       config: basicConfig
-                  ,   body: $("<section><p id='i10' class='issue' data-number='10'>Numbered ISSUE</p><p id='i11' class='issue' title='ISS-TIT' data-number='11'>Titled and Numbered Issue</p><p id='ixx' class='issue'>Unnumbered ISSUE</p></section>")
+                  ,   body: $("<section><p id='i10' class='issue' data-number='10'>Numbered ISSUE</p><p id='i11' class='issue' title='ISS-TIT' data-number='11'>Titled and Numbered Issue</p><p id='ixx' class='issue'>Unnumbered ISSUE</p></section>" +
+                  "<section id='sotd'>Custom SOTD</section>" )
                   },
                   function (rsdoc) { doc = rsdoc; });
       });
@@ -94,7 +108,8 @@ describe("Core — Issues and Notes", function () {
         runs(function () {
             makeRSDoc({
                         config: issueBaseConfig
-                    ,   body: $("<section><p class='issue' data-number='10'>ISSUE</p></section>")
+                    ,   body: $("<section><p class='issue' data-number='10'>ISSUE</p></section>" +
+                    "<section id='sotd'>Custom SOTD</section>" )
                     },
                     function (rsdoc) { doc = rsdoc; });
         });
@@ -117,7 +132,8 @@ describe("Core — Issues and Notes", function () {
         runs(function () {
             makeRSDoc({
                         config: atRiskBaseConfig
-                    ,   body: $("<section><p class='issue atrisk' data-number='10'>FEATURE AT RISK</p></section>")
+                    ,   body: $("<section><p class='issue atrisk' data-number='10'>FEATURE AT RISK</p></section>" +
+                    "<section id='sotd'>Custom SOTD</section>" )
                     },
                     function (rsdoc) { doc = rsdoc; });
         });

--- a/tests/spec/core/markdown-spec.js
+++ b/tests/spec/core/markdown-spec.js
@@ -4,12 +4,18 @@ describe("Core - Markdown", function () {
             editors:    [{ name: "Robin Berjon" }]
         ,   specStatus: "WD"
         ,   format: "markdown"
-        };
+        ,   shortName: "mydoc"
+        ,   previousURI:  "http://www.example.com"
+        ,   previousMaturity: "WD"
+        ,   previousPublishDate:  "2014-01-01"
+        }
+    ,   body = "<section id='sotd'>Custom SOTD</section>"
+    ;
     it("should process standard markdown content", function () {
         var doc;
         runs(function () {
             makeRSDoc({ config: basicConfig,
-                        body: '\nFoo\n===\n'
+                        body: '\nFoo\n===\n' + body
                     }, function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);
@@ -26,7 +32,7 @@ describe("Core - Markdown", function () {
         var doc;
         runs(function () {
             makeRSDoc({ config: basicConfig,
-                        body: '<section>\nFoo\n===\n</section>'
+                        body: '<section>\nFoo\n===\n</section>' + body
                     }, function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);
@@ -42,7 +48,7 @@ describe("Core - Markdown", function () {
         var doc;
         runs(function () {
             makeRSDoc({ config: basicConfig,
-                        body: '<p class=note>_foo_</p><div class=issue>_foo_</div><ul><li class=req>\n### _foo_###\n</li></ul>'
+                        body: '<p class=note>_foo_</p><div class=issue>_foo_</div><ul><li class=req>\n### _foo_###\n</li></ul>' + body
                     }, function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);
@@ -59,7 +65,7 @@ describe("Core - Markdown", function () {
         var doc;
         runs(function () {
             makeRSDoc({ config: basicConfig,
-                        body: '\n    Foo\n    ===\n'
+                        body: '\n    Foo\n    ===\n'+body
                     }, function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);
@@ -73,7 +79,7 @@ describe("Core - Markdown", function () {
         var doc;
         runs(function () {
             makeRSDoc({ config: basicConfig,
-                        body: '\nFoo\n===\n\nBar\n---\n\nBaz\n---\n\n### Foobar ###\n\n#### Foobaz ####\n\nZing\n---\n\n'
+                        body: '\nFoo\n===\n\nBar\n---\n\nBaz\n---\n\n### Foobar ###\n\n#### Foobaz ####\n\nZing\n---\n\n' + body
                     }, function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);
@@ -110,7 +116,7 @@ describe("Core - Markdown", function () {
         var doc;
         runs(function () {
             makeRSDoc({ config: basicConfig,
-                        body: '\nFoo\n===\n\nBar\n---\n\nBaz\n===\n\n### Foobar ###\n\n'
+                        body: '\nFoo\n===\n\nBar\n---\n\nBaz\n===\n\n### Foobar ###\n\n' + body
                     }, function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);
@@ -124,7 +130,7 @@ describe("Core - Markdown", function () {
         var doc;
         runs(function () {
             makeRSDoc({ config: basicConfig,
-                        body: '\n\nFoo\n===\n\nsome text\n\n<section>\n\nBar\n===\n</section>\n'
+                        body: '\n\nFoo\n===\n\nsome text\n\n<section>\n\nBar\n===\n</section>\n' + body
                     }, function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);
@@ -139,7 +145,7 @@ describe("Core - Markdown", function () {
         var doc;
         runs(function () {
             makeRSDoc({ config: basicConfig,
-                        body: '\n\nFoo\n===\n\nsome text\n\n<section>\n\nBar\n---\n</section>\n'
+                        body: '\n\nFoo\n===\n\nsome text\n\n<section>\n\nBar\n---\n</section>\n' + body
                     }, function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);
@@ -156,7 +162,7 @@ describe("Core - Markdown", function () {
         var doc;
         runs(function () {
             makeRSDoc({ config: basicConfig,
-                        body: '\n\nFoo\n===\n\nsome text\n\n<section>\n\nBar\n---\n</section>\n\nBaz\n===\n\nsome text\n\n<'
+                        body: body + '\n\nFoo\n===\n\nsome text\n\n<section>\n\nBar\n---\n</section>\n\nBaz\n===\n\nsome text\n\n<'
                     }, function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);
@@ -173,7 +179,7 @@ describe("Core - Markdown", function () {
         var doc;
         runs(function () {
             makeRSDoc({ config: basicConfig,
-                        body: '\n\nFoo\n---\n\nsome text\n\n<section>\n\nBar\n---\n</section>\n'
+                        body: '\n\nFoo\n---\n\nsome text\n\n<section>\n\nBar\n---\n</section>\n' + body
                     }, function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);
@@ -190,7 +196,7 @@ describe("Core - Markdown", function () {
         var doc;
         runs(function () {
             makeRSDoc({ config: basicConfig,
-                        body: '\n\nFoo\n===\n\nsome text\n\n<section id=bar>no header</section>\n'
+                        body: '\n\nFoo\n===\n\nsome text\n\n<section id=bar>no header</section>\n' + body
                     }, function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);

--- a/tests/spec/core/remove-respec-spec.js
+++ b/tests/spec/core/remove-respec-spec.js
@@ -3,11 +3,17 @@ describe("Core — Remove ReSpec", function () {
     ,   basicConfig = {
             editors:    [{ name: "Robin Berjon" }]
         ,   specStatus: "WD"
-        };
+        ,   shortName: "mydoc"
+        ,   previousURI:  "http://www.example.com"
+        ,   previousMaturity: "WD"
+        ,   previousPublishDate:  "2014-01-01"
+        }
+    ,   body = "<section id='sotd'>Custom SOTD</section>"
+    ;
     it("should have removed all artefacts", function () {
         var doc;
         runs(function () {
-            makeRSDoc({ config: basicConfig }, function (rsdoc) { doc = rsdoc; });
+            makeRSDoc({ config: basicConfig, body: body }, function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);
         runs(function () {

--- a/tests/spec/core/requirements-spec.js
+++ b/tests/spec/core/requirements-spec.js
@@ -3,18 +3,28 @@ describe("Core — Requirements", function () {
     ,   basicConfig = {
             editors:    [{ name: "Robin Berjon" }]
         ,   specStatus: "WD"
+        ,   shortName: "mydoc"
+        ,   previousURI:  "http://www.example.com"
+        ,   previousMaturity: "WD"
+        ,   previousPublishDate:  "2014-01-01"
         }
+    ,   body = "<section id='sotd'>Custom SOTD</section>"
     ,   issueBaseConfig = {
             editors:    [{ name: "Gregg Kellogg" }]
         ,   issueBase:  "http://example.com/issues/"
         ,   specStatus: "WD"
-      };
+        ,   shortName: "mydoc"
+        ,   previousURI:  "http://www.example.com"
+        ,   previousMaturity: "WD"
+        ,   previousPublishDate:  "2014-01-01"
+        }
+    ;
     it("should process requirements", function () {
         var doc;
         runs(function () {
             makeRSDoc({
                         config: basicConfig
-                    ,   body: $("<p class='req' id='req-id'>REQ</p>")
+                    ,   body: $("<p class='req' id='req-id'>REQ</p>" + body)
                     },
                     function (rsdoc) { doc = rsdoc; });
         });
@@ -36,7 +46,7 @@ describe("Core — Requirements", function () {
       runs(function () {
           makeRSDoc({
                       config: basicConfig
-                      ,   body: $("<a href='#req-id' class='reqRef'></a><a href='#foo' class='reqRef'></a><p class='req' id='req-id'>REQ</p>")
+                      ,   body: $("<a href='#req-id' class='reqRef'></a><a href='#foo' class='reqRef'></a><p class='req' id='req-id'>REQ</p>" + body)
                   },
                   function (rsdoc) { doc = rsdoc; });
       });

--- a/tests/spec/core/section-refs-spec.js
+++ b/tests/spec/core/section-refs-spec.js
@@ -3,12 +3,18 @@ describe("Core - Section References", function () {
     ,   basicConfig = {
             editors:    [{ name: "Robin Berjon" }]
         ,   specStatus: "WD"
-        };
+        ,   shortName: "mydoc"
+        ,   previousURI:  "http://www.example.com"
+        ,   previousMaturity: "WD"
+        ,   previousPublishDate:  "2014-01-01"
+        }
+    ,   body = "<section id='sotd'>Custom SOTD</section>"
+    ;
     it("should have produced the section reference", function () {
         var doc;
         runs(function () {
             makeRSDoc({ config: basicConfig,
-                        body: "<section id='ONE'><h2>ONE</h2></section><section id='TWO'><a href='#ONE' class='sectionRef'></a></section>"
+                        body: "<section id='ONE'><h2>ONE</h2></section><section id='TWO'><a href='#ONE' class='sectionRef'></a></section>" + body
                     }, function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);

--- a/tests/spec/core/simple.html
+++ b/tests/spec/core/simple.html
@@ -22,6 +22,12 @@
           ,   wgPublicList: "none"
           ,   wgPatentURI:  "XXX"
           ,   edDraftURI:   "http://darobin.github.com/respec"
+          ,   shortName: "mydoc"
+          ,   previousURI:  "http://www.example.com"
+          ,   previousMaturity: "WD"
+          ,   previousPublishDate:  "2014-01-01"
+          ,   implementationReportURI: "http://www.example.com/impReport.html"
+          ,   errata:  "http://www.example.com/errata.html"
         };
     </script>
   </head>

--- a/tests/spec/core/structure-spec.js
+++ b/tests/spec/core/structure-spec.js
@@ -4,8 +4,13 @@ describe("Core - Structure", function () {
             editors:    [{ name: "Robin Berjon" }]
         ,   specStatus: "WD"
 //        ,   doRDFa:  false
+        ,   shortName: "mydoc"
+        ,   previousURI:  "http://www.example.com"
+        ,   previousMaturity: "WD"
+        ,   previousPublishDate:  "2014-01-01"
         }
     ,   body = "<section class='introductory'><h2>INTRO</h2></section>" +
+              "<section id='sotd'>Custom SOTD</section>" +
               "<section><h2>ONE</h2><section><h2>TWO</h2><section><h2>THREE</h2><section><h2>FOUR</h2>" +
               "<section><h2>FIVE</h2><section><h2>SIX</h2></section></section></section></section></section></section>" +
               "<section class='appendix'><h2>ONE</h2><section><h2>TWO</h2><section><h2>THREE</h2><section>" +

--- a/tests/spec/core/style-spec.js
+++ b/tests/spec/core/style-spec.js
@@ -3,11 +3,17 @@ describe("Core — Style", function () {
     ,   basicConfig = {
             editors:    [{ name: "Robin Berjon" }]
         ,   specStatus: "WD"
-        };
+        ,   shortName: "mydoc"
+        ,   previousURI:  "http://www.example.com"
+        ,   previousMaturity: "WD"
+        ,   previousPublishDate:  "2014-01-01"
+        }
+    ,   body = "<section id='sotd'>Custom SOTD</section>"
+    ;
     it("should have included a style element", function () {
         var doc;
         runs(function () {
-            makeRSDoc({ config: basicConfig }, function (rsdoc) { doc = rsdoc; });
+            makeRSDoc({ body: body, config: basicConfig }, function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);
         runs(function () {

--- a/tests/spec/w3c/abstract-spec.js
+++ b/tests/spec/w3c/abstract-spec.js
@@ -3,11 +3,17 @@ describe("W3C — Abstract", function () {
     ,   basicConfig = {
             editors:    [{ name: "Robin Berjon" }]
         ,   specStatus: "WD"
-        };
+        ,   shortName: "mydoc"
+        ,   previousURI:  "http://www.example.com"
+        ,   previousMaturity: "WD"
+        ,   previousPublishDate:  "2014-01-01"
+        }
+    ,   body = "<section id='sotd'>Custom SOTD</section>"
+    ;
     it("should include an h2, set the class, and wrap the content", function () {
         var doc;
         runs(function () {
-            makeRSDoc({ config: basicConfig, abstract: $("<section id='abstract'>test abstract</section>") }, function (rsdoc) { doc = rsdoc; });
+            makeRSDoc({ config: basicConfig, abstract: $("<section id='abstract'>test abstract</section>"), body: body }, function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);
         runs(function () {

--- a/tests/spec/w3c/conformance-spec.js
+++ b/tests/spec/w3c/conformance-spec.js
@@ -4,11 +4,17 @@ describe("W3C — Conformance", function () {
             editors:    [{ name: "Robin Berjon" }]
         ,   specStatus: "WD"
         ,   doRDFa:  false
-        };
+        ,   shortName: "mydoc"
+        ,   previousURI:  "http://www.example.com"
+        ,   previousMaturity: "WD"
+        ,   previousPublishDate:  "2014-01-01"
+        }
+    ,   body = "<section id='sotd'>Custom SOTD</section>"
+    ;
     it("should include an h2 and inject its content", function () {
         var doc;
         runs(function () {
-            makeRSDoc({ config: basicConfig, body: $("<section id='conformance'><p>CONFORMANCE</p></section><section><h2>my section</h2><p>No terms are used except SHOULD.</p></section>") }, 
+            makeRSDoc({ config: basicConfig, body: $("<section id='conformance'><p>CONFORMANCE</p></section><section><h2>my section</h2><p>No terms are used except SHOULD.</p></section>" + body) }, 
                       function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);
@@ -25,7 +31,7 @@ describe("W3C — Conformance", function () {
     it("should include only referenced 2119 terms", function () {
         var doc;
         runs(function () {
-            makeRSDoc({ config: basicConfig, body: $("<section id='conformance'><p>CONFORMANCE</p></section><section><h2>my section</h2><p>Terms are MUST, SHOULD, SHOULD NOT, and SHOULD  NOT.</p></section>") }, 
+            makeRSDoc({ config: basicConfig, body: $("<section id='conformance'><p>CONFORMANCE</p></section><section><h2>my section</h2><p>Terms are MUST, SHOULD, SHOULD NOT, and SHOULD  NOT.</p></section>" + body) }, 
                       function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);
@@ -39,7 +45,7 @@ describe("W3C — Conformance", function () {
     it("should omit the 2119 reference when there are no terms", function () {
         var doc;
         runs(function () {
-            makeRSDoc({ config: basicConfig, body: $("<section id='conformance'><p>CONFORMANCE</p></section><section><h2>my section</h2><p>Terms are not used.</p></section>") }, 
+            makeRSDoc({ config: basicConfig, body: $("<section id='conformance'><p>CONFORMANCE</p></section><section><h2>my section</h2><p>Terms are not used.</p></section>" + body) }, 
                       function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);

--- a/tests/spec/w3c/local-aliases-spec.js
+++ b/tests/spec/w3c/local-aliases-spec.js
@@ -3,17 +3,24 @@ describe("W3C — Aliased References", function () {
         , basicConfig = {
             editors: [
                 { name: "Robin Berjon" }
-            ], specStatus: "WD",
-            localBiblio: {
+            ]
+            ,   specStatus: "WD"
+            ,   shortName: "mydoc"
+            ,   previousURI:  "http://www.example.com"
+            ,   previousMaturity: "WD"
+            ,   previousPublishDate:  "2014-01-01"
+            ,   localBiblio: {
                 "FOOBARGLOP": {
                     "aliasOf": "RFC2119"
                 }
+                }
             }
-        };
+        ,   body = "<section id='sotd'>Custom SOTD</section>"
+        ;
     it("aliased spec must be resolved", function () {
         var doc;
         runs(function () {
-            makeRSDoc({ config: basicConfig, body: $("<section id='sample'><p>foo [[!FOOBARGLOP]] bar</p></section>") },
+            makeRSDoc({ config: basicConfig, body: $("<section id='sample'><p>foo [[!FOOBARGLOP]] bar</p></section>" + body) },
                 function (rsdoc) {
                     doc = rsdoc;
                 });


### PR DESCRIPTION
When run with TRACE=1, many many tests emitted errors or warnings
that could color the results of testing or result in false
positives.  As it turned out, none of them actually did but it was
still worth fixing. Now the TRACE output does not contain spurious
warnings.