### PR TITLE
Ensure that apostrophes in headers are escaped

### DIFF
--- a/js/w3c/permalinks.js
+++ b/js/w3c/permalinks.js
@@ -53,9 +53,11 @@ define(
                                 if (!conf.permalinkEdge) {
                                     content += "&nbsp;";
                                 }
+                                var ctext = $item.text().replace("'", "&apos;") ;
+
                                 content += "<a href='#"+resourceID+"' " + urlprop + "aria-label='Permalink for "
                                         +resourceID+"' title='Permalink for "+resourceID+"'>" 
-                                        + "<span " + titprop + "content='"+$item.text()+"'>"
+                                        + "<span " + titprop + "content='"+ctext+"'>"
                                         + symbol + "</span></a></span>";
                                 $item.append(content);
                             }

--- a/js/w3c/permalinks.js
+++ b/js/w3c/permalinks.js
@@ -24,19 +24,19 @@ define(
                 msg.pub("start", "w3c/permalinks");
                 if (conf.includePermalinks) {
                     var symbol = conf.permalinkSymbol || '§';
-                    var style = "<style>" + css(conf) + "</style>" ;
+                    var style = "<style>" + css(conf) + "</style>";
 
-                    $(doc).find("head link").first().before(style) ;
+                    $(doc).find("head link").first().before(style);
                     var $secs = $(doc).find("h2, h3, h4, h5, h6");
                     $secs.each(function(i, item) {
-                        var $item = $(item) ;
+                        var $item = $(item);
                         if (!$item.hasClass("nolink")) {
                             var resourceID = $item.attr('id');
 
                             var $par = $item.parent();
                             if ($par.is("section") || $par.is("div")) {
                                 if (!$par.hasClass("introductory") && !$par.hasClass("nolink")) {
-                                    resourceID = $par.attr('id') ;
+                                    resourceID = $par.attr('id');
                                 } else {
                                     resourceID = null;
                                 }
@@ -46,42 +46,32 @@ define(
                             if (resourceID != null) {
                                 // we have an id.  add a permalink
                                 // right after the h* element
-                                var theNode = $(document.createElement('span')) ;
-                                theNode.attr('class', 'permalink') ;
-                                if (conf.doRDFa) {
-                                    theNode.attr('typeof', 'bookmark')
-                                }
-
-
-                                var ctext = $item.text().replace("'", "&apos;") ;
-
-                                var el = $(document.createElement('a')) ;
+                                var theNode = $("<span></span>");
+                                theNode.attr('class', 'permalink');
+                                if (conf.doRDFa) theNode.attr('typeof', 'bookmark');
+                                var ctext = $item.text().replace("'", "'");
+                                var el = $("<a></a>");
                                 el.attr({
-                                    href: '#'+resourceID,
-                                    'aria-label': 'Permalink for '+ctext,
-                                    title: 'Permalink for '+ctext } ) ;
-
-                                if (conf.doRDFa) {
-                                    el.attr('property', 'url') ;
-                                }
-                                
-                                var sym = $(document.createElement('span')) ;
+                                    href:         '#' + resourceID,
+                                    'aria-label': 'Permalink for ' + ctext,
+                                    title:        'Permalink for ' + ctext });
+                                if (conf.doRDFa) el.attr('property', 'url');
+                                var sym = $("<span></span>");
                                 if (conf.doRDFa) {
                                     sym.attr({
                                         property: 'title',
-                                        content: ctext } ) ;
-                                        
+                                        content:  ctext });
                                 }
-                                sym.append(symbol) ;
-                                el.append(sym) ;
-                                theNode.append(el) ;
+                                sym.append(symbol);
+                                el.append(sym);
+                                theNode.append(el);
 
                                 // if this is not being put at
                                 // page edge, then separate it
                                 // from the heading with a
                                 // non-breaking space
                                 if (!conf.permalinkEdge) {
-                                   $item.append("&nbsp;") ;
+                                   $item.append("&nbsp;");
                                 }
                                 $item.append(theNode);
                             }

--- a/js/w3c/permalinks.js
+++ b/js/w3c/permalinks.js
@@ -49,7 +49,7 @@ define(
                                 var theNode = $("<span></span>");
                                 theNode.attr('class', 'permalink');
                                 if (conf.doRDFa) theNode.attr('typeof', 'bookmark');
-                                var ctext = $item.text().replace("'", "'");
+                                var ctext = $item.text();
                                 var el = $("<a></a>");
                                 el.attr({
                                     href:         '#' + resourceID,

--- a/js/w3c/permalinks.js
+++ b/js/w3c/permalinks.js
@@ -46,20 +46,44 @@ define(
                             if (resourceID != null) {
                                 // we have an id.  add a permalink
                                 // right after the h* element
-                                var type = conf.doRDFa ? "typeof='bookmark' " : "";
-                                var urlprop = conf.doRDFa ? "property='url' " : "";
-                                var titprop = conf.doRDFa ? "property='title' " : "";
-                                var content = "<span " + type + "class='permalink'>";
-                                if (!conf.permalinkEdge) {
-                                    content += "&nbsp;";
+                                var theNode = $(document.createElement('span')) ;
+                                theNode.attr('class', 'permalink') ;
+                                if (conf.doRDFa) {
+                                    theNode.attr('typeof', 'bookmark')
                                 }
+
+
                                 var ctext = $item.text().replace("'", "&apos;") ;
 
-                                content += "<a href='#"+resourceID+"' " + urlprop + "aria-label='Permalink for "
-                                        +resourceID+"' title='Permalink for "+resourceID+"'>" 
-                                        + "<span " + titprop + "content='"+ctext+"'>"
-                                        + symbol + "</span></a></span>";
-                                $item.append(content);
+                                var el = $(document.createElement('a')) ;
+                                el.attr({
+                                    href: '#'+resourceID,
+                                    'aria-label': 'Permalink for '+ctext,
+                                    title: 'Permalink for '+ctext } ) ;
+
+                                if (conf.doRDFa) {
+                                    el.attr('property', 'url') ;
+                                }
+                                
+                                var sym = $(document.createElement('span')) ;
+                                if (conf.doRDFa) {
+                                    sym.attr({
+                                        property: 'title',
+                                        content: ctext } ) ;
+                                        
+                                }
+                                sym.append(symbol) ;
+                                el.append(sym) ;
+                                theNode.append(el) ;
+
+                                // if this is not being put at
+                                // page edge, then separate it
+                                // from the heading with a
+                                // non-breaking space
+                                if (!conf.permalinkEdge) {
+                                   $item.append("&nbsp;") ;
+                                }
+                                $item.append(theNode);
                             }
                         }
                     });

--- a/tests/spec/w3c/permalinks-spec.js
+++ b/tests/spec/w3c/permalinks-spec.js
@@ -137,4 +137,20 @@ describe("W3C — Permalinks", function () {
             flushIframes();
         });
     });
+    it("permalinks content attribute should have special characters escaped", function () {
+        var doc;
+        runs(function () {
+            makeRSDoc({ config: basicConfig, body: $("<section class='introductory' id='sotd'>Some unique SOTD content</section><div id='testing'><h2>a heading with "+'"'+" and '</h2><p>some content</p></div>") }, 
+                      function (rsdoc) { doc = rsdoc; });
+        });
+        waitsFor(function () { return doc; }, MAXOUT);
+        runs(function () {
+            var $c = $("#testing", doc);
+            var list = $("span.permalink a span", $c) ;
+            expect(list.length).toEqual(1);
+            expect($(list[0]).attr("content")).toMatch(/'/);
+            expect($(list[0]).attr("content")).toMatch(/"/);
+            flushIframes();
+        });
+    });
 });

--- a/tests/spec/w3c/permalinks-spec.js
+++ b/tests/spec/w3c/permalinks-spec.js
@@ -148,8 +148,23 @@ describe("W3C — Permalinks", function () {
             var $c = $("#testing", doc);
             var list = $("span.permalink a span", $c) ;
             expect(list.length).toEqual(1);
-            expect($(list[0]).attr("content")).toMatch(/&apos;/);
+            expect($(list[0]).attr("content")).toMatch(/'/);
             expect($(list[0]).attr("content")).toMatch(/"/);
+            flushIframes();
+        });
+    });
+    it("permalinks not on edge will have non-breaking space after heading", function () {
+        var doc;
+        runs(function () {
+            makeRSDoc({ config: basicConfig, body: $("<section class='introductory' id='sotd'>Some unique SOTD content</section><div id='testing'><h2>a heading with "+'"'+" and '</h2><p>some content</p></div>") }, 
+                      function (rsdoc) { doc = rsdoc; });
+        });
+        waitsFor(function () { return doc; }, MAXOUT);
+        runs(function () {
+            var $c = $("#testing", doc);
+            var list = $("h2", $c) ;
+            expect(list.length).toEqual(1);
+            expect(list[0].innerHTML).toMatch(/&nbsp;/);
             flushIframes();
         });
     });

--- a/tests/spec/w3c/permalinks-spec.js
+++ b/tests/spec/w3c/permalinks-spec.js
@@ -40,7 +40,7 @@ describe("W3C — Permalinks", function () {
         ,   specStatus: "PER"
         ,   wgPatentURI:  "http://www.w3.org/fake-patent-uri"
         ,   includePermalinks: true
-        ,   doRDFa: false
+        ,   doRDFa: 1.1
         }
     ,   noConfig = {
             editors:    [{ name: "Shane McCarron",
@@ -148,7 +148,7 @@ describe("W3C — Permalinks", function () {
             var $c = $("#testing", doc);
             var list = $("span.permalink a span", $c) ;
             expect(list.length).toEqual(1);
-            expect($(list[0]).attr("content")).toMatch(/'/);
+            expect($(list[0]).attr("content")).toMatch(/&apos;/);
             expect($(list[0]).attr("content")).toMatch(/"/);
             flushIframes();
         });


### PR DESCRIPTION
Issue #389 reported that the content attribute for permalinks was
being incorrectly populated with embedded apostrophes.  This change
escapes those.