### PR TITLE
Allow to specify editors id in doc configuration

### DIFF
--- a/js/w3c/headers.js
+++ b/js/w3c/headers.js
@@ -97,7 +97,8 @@ define(
     function (hb, utils, headersTmpl, sotdTmpl, cgbgHeadersTmpl, cgbgSotdTmpl) {
         Handlebars.registerHelper("showPeople", function (name, items) {
             // stuff to handle RDFa
-            var re = "", rp = "", rm = "", rn = "", rwu = "", rpu = "", bn = "";
+            var re = "", rp = "", rm = "", rn = "", rwu = "", rpu = "", bn = "",
+            editorid = "";
             if (this.doRDFa) {
                 if (name === "Editor") {
                     bn = "_:editor0";
@@ -115,15 +116,18 @@ define(
             var ret = "";
             for (var i = 0, n = items.length; i < n; i++) {
                 var p = items[i];
+                if (p.w3cid) {
+                    editorid = " data-editor-id='" + parseInt(p.w3cid, 10) + "'";
+                }
                 if (this.doRDFa) {
-                  ret += "<dd class='p-author h-card vcard' " + re + "><span" + rp + ">";
+                  ret += "<dd class='p-author h-card vcard' " + re + editorid + "><span" + rp + ">";
                   if (name === "Editor") {
                     // Update to next sequence in rdf:List
                     bn = (i < n - 1) ? ("_:editor" + (i + 1)) : "rdf:nil";
                     re = " resource='" + bn + "'";
                   }
                 } else {
-                  ret += "<dd class='p-author h-card vcard'>";
+                  ret += "<dd class='p-author h-card vcard'" + editorid + ">";
                 }
                 if (p.url) {
                     if (this.doRDFa) {

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -56,6 +56,7 @@ describe("W3C — Headers", function () {
             ,   companyURL: "http://COMPANY"
             ,   mailto:     "EMAIL"
             ,   note:       "NOTE"
+            ,   w3cid:       "1234"
             }] }, function ($ifr) {
                 expect($("dt:contains('Editors:')", $ifr[0].contentDocument).length).toEqual(0);
                 expect($("dt:contains('Editor:')", $ifr[0].contentDocument).length).toEqual(1);
@@ -66,6 +67,7 @@ describe("W3C — Headers", function () {
                 expect($dd.find("a[href='http://COMPANY']").text()).toEqual("COMPANY");
                 expect($dd.find("a[href='mailto:EMAIL']").length).toEqual(1);
                 expect($dd.find("a[href='mailto:EMAIL']").text()).toEqual("EMAIL");
+                expect($dd.get(0).dataset.editorId).toEqual("1234");
                 expect($dd.text()).toMatch(/\(NOTE\)/);
         });
         loadWithConfig({ specStatus: "REC", doRDFa: false, "editors[]": [{ name: "NAME1" }, { name: "NAME2" }] }, function ($ifr) {


### PR DESCRIPTION
The new [automated publication workflow](http://www.w3.org/2014/08/pubworkflow.html) will rely on a new feature in [specberus](https://github.com/w3c/specberus/#emitting-metadata-about-the-document) to look up editors by their W3C ids.

This patch reads (optionally) that information from the document configuration