### PR TITLE
Update ReSpec to heroku URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Want to change a bibliographical reference?
 ===========================================
 
 Bibliographical references have been moved out of ReSpec. You want to use this: 
-https://github.com/tobie/specref
+http://www.specref.org/
 
 Want to see complete documentation?
 ===================================

--- a/examples/respec-debug.js
+++ b/examples/respec-debug.js
@@ -5909,7 +5909,7 @@ var sn;
             refs = refs.normativeReferences.concat(refs.informativeReferences).concat(this.findLocalAliases(conf));
             if (refs.length) {
                 count++;
-                src = conf.httpScheme + "://specref.heroku.com/bibrefs?callback=setBerjonBiblio&refs=" + refs.join(',');
+                src = conf.httpScheme + "://specref.herokuapp.com/bibrefs?callback=setBerjonBiblio&refs=" + refs.join(',');
                 this.loadScript(src, loadHandler);
             }
 

--- a/examples/respec-debug.js
+++ b/examples/respec-debug.js
@@ -5909,7 +5909,7 @@ var sn;
             refs = refs.normativeReferences.concat(refs.informativeReferences).concat(this.findLocalAliases(conf));
             if (refs.length) {
                 count++;
-                src = conf.httpScheme + "://specref.jit.su/bibrefs?callback=setBerjonBiblio&refs=" + refs.join(',');
+                src = conf.httpScheme + "://specref.heroku.com/bibrefs?callback=setBerjonBiblio&refs=" + refs.join(',');
                 this.loadScript(src, loadHandler);
             }
 

--- a/js/ui/search-specref.js
+++ b/js/ui/search-specref.js
@@ -50,8 +50,8 @@ define(
                     $status.html("Searching…");
                     var query = $search.val();
                     $.when(
-                        $.getJSON("https://specref.jit.su/search-refs", { q: query }),
-                        $.getJSON("https://specref.jit.su/reverse-lookup", { urls: query })
+                        $.getJSON("https://specref.heroku.com/search-refs", { q: query }),
+                        $.getJSON("https://specref.heroku.com/reverse-lookup", { urls: query })
                     ).done(function(search, revLookup) {
                         var ref;
                         search = search[0],

--- a/js/ui/search-specref.js
+++ b/js/ui/search-specref.js
@@ -50,8 +50,8 @@ define(
                     $status.html("Searching…");
                     var query = $search.val();
                     $.when(
-                        $.getJSON("https://specref.heroku.com/search-refs", { q: query }),
-                        $.getJSON("https://specref.heroku.com/reverse-lookup", { urls: query })
+                        $.getJSON("https://specref.herokuapp.com/search-refs", { q: query }),
+                        $.getJSON("https://specref.herokuapp.com/reverse-lookup", { urls: query })
                     ).done(function(search, revLookup) {
                         var ref;
                         search = search[0],


### PR DESCRIPTION
As nodejitsu's been acquihired, they're closing down their service in about half a year, so went ahead and mirrored this on heroku until I figure out how to properly send HTTPS over a full domain name.