### PR TITLE
Cleanup write as html

### DIFF
--- a/js/core/webidl-oldschool.js
+++ b/js/core/webidl-oldschool.js
@@ -678,6 +678,214 @@ define(
                 return { type: matched[1], parameter: matched[2] };
             },
 
+            writeInterfaceAsHTML: function (obj) {
+                var df = sn.documentFragment();
+                var curLnk = "widl-" + obj.refId + "-";
+                var types = ["constructor", "attribute", "method", "constant", "serializer"];
+                var filterFunc = function (it) { return it.type == type; }
+                ,   sortFunc = function (a, b) {
+                        if (a.unescapedId < b.unescapedId) return -1;
+                        if (a.unescapedId > b.unescapedId) return 1;
+                        return 0;
+                    }
+                ;
+                for (var i = 0; i < types.length; i++) {
+                    var type = types[i];
+                    var things = obj.children.filter(filterFunc);
+                    if (things.length === 0) continue;
+                    if (!this.noIDLSorting) things.sort(sortFunc);
+
+                    var sec = sn.element("section", {}, df);
+                    var secTitle = type;
+                    secTitle = secTitle.substr(0, 1).toUpperCase() + secTitle.substr(1) + (type != "serializer" ? "s" : "");
+                    if (!this.conf.noIDLSectionTitle) sn.element("h2", {}, sec, secTitle);
+                    if (type != "serializer") {
+                        var dl = sn.element("dl", { "class": type + "s" }, sec);
+                        for (var j = 0; j < things.length; j++) {
+                            var it = things[j];
+                            var id = (type == "method") ? this.makeMethodID(curLnk, it) :
+                                (type == "constructor") ? this.makeMethodID("widl-ctor-", it)
+                                : sn.idThatDoesNotExist(curLnk + it.refId);
+                            var dt = sn.element("dt", { id: id }, dl);
+                            sn.element("code", {}, dt, it.unescapedId);
+                            if (it.isStatic) dt.append(this.doc.createTextNode(", static"));
+                            var desc = sn.element("dd", {}, dl, [it.description]);
+                            if (type == "method" || type == "constructor") {
+                                if (it.params.length) {
+                                    var table = sn.element("table", { "class": "parameters" }, desc);
+                                    var tr = sn.element("tr", {}, table);
+                                    ["Parameter", "Type", "Nullable", "Optional", "Description"].forEach(function (tit) { sn.element("th", {}, tr, tit); });
+                                    for (var k = 0; k < it.params.length; k++) {
+                                        var prm = it.params[k];
+                                        var tr = sn.element("tr", {}, table);
+                                        sn.element("td", { "class": "prmName" }, tr, prm.id);
+                                        var tyTD = sn.element("td", { "class": "prmType" }, tr);
+                                        var code = sn.element("code", {}, tyTD);
+                                        var codeHTML = datatype(prm.datatype);
+                                        if (prm.array) codeHTML += arrsq(prm);
+                                        if (prm.defaultValue) {
+                                            codeHTML += " = " + prm.defaultValue;
+                                        }
+                                        code.html(codeHTML);
+                                        if (prm.nullable) sn.element("td", { "class": "prmNullTrue" }, tr, $("<span role='img' aria-label='True'>\u2714</span>"));
+                                        else              sn.element("td", { "class": "prmNullFalse" }, tr, $("<span role='img' aria-label='False'>\u2718</span>"));
+                                        if (prm.optional) sn.element("td", { "class": "prmOptTrue" }, tr,  $("<span role='img' aria-label='True'>\u2714</span>"));
+                                        else              sn.element("td", { "class": "prmOptFalse" }, tr, $("<span role='img' aria-label='False'>\u2718</span>"));
+                                        var cnt = prm.description ? [prm.description] : "";
+                                        sn.element("td", { "class": "prmDesc" }, tr, cnt);
+                                    }
+                                }
+                                else {
+                                    sn.element("div", {}, desc, [sn.element("em", {}, null, "No parameters.")]);
+                                }
+                                if (this.conf.idlOldStyleExceptions && it.raises.length) {
+                                    var table = sn.element("table", { "class": "exceptions" }, desc);
+                                    var tr = sn.element("tr", {}, table);
+                                    ["Exception", "Description"].forEach(function (tit) { sn.element("th", {}, tr, tit); });
+                                    for (var k = 0; k < it.raises.length; k++) {
+                                        var exc = it.raises[k];
+                                        var tr = sn.element("tr", {}, table);
+                                        sn.element("td", { "class": "excName" }, tr, [sn.element("a", {}, null, exc.id)]);
+                                        var dtd = sn.element("td", { "class": "excDesc" }, tr);
+                                        if (exc.type == "simple") {
+                                            dtd.append(exc.description);
+                                        }
+                                        else {
+                                            var ctab = sn.element("table", { "class": "exceptionCodes" }, dtd );
+                                            for (var m = 0; m < exc.description.length; m++) {
+                                                var cd = exc.description[m];
+                                                var tr = sn.element("tr", {}, ctab);
+                                                sn.element("td", { "class": "excCodeName" }, tr, [sn.element("code", {}, null, cd.id)]);
+                                                sn.element("td", { "class": "excCodeDesc" }, tr, [cd.description]);
+                                            }
+                                        }
+                                    }
+                                }
+                                // else {
+                                //     sn.element("div", {}, desc, [sn.element("em", {}, null, "No exceptions.")]);
+                                // }
+                                 if (type !== "constructor") {
+                                    var reDiv = sn.element("div", {}, desc);
+                                    sn.element("em", {}, reDiv, "Return type: ");
+                                    var code = sn.element("code", {}, reDiv);
+                                    var codeHTML = datatype(it.datatype);
+                                    if (it.array) codeHTML += arrsq(it);
+                                    if (it.nullable) sn.text(", nullable", reDiv);
+                                    code.html(codeHTML);
+                                }
+                            }
+                            else if (type == "attribute") {
+                                sn.text(" of type ", dt);
+                                if (it.array) {
+                                    for (var m = 0, n = it.arrayCount; m < n; m++) sn.text("array of ", dt);
+                                }
+                                var span = sn.element("span", { "class": "idlAttrType" }, dt);
+                                var parameterized = this.parseParameterized(it.datatype);
+                                if (parameterized) {
+                                    sn.text(parameterized.type + "<", span);
+                                    sn.element("a", {}, span, parameterized.parameter);
+                                    sn.text(">", span);
+                                }
+                                else {
+                                    sn.element("a", {}, span, it.isUnionType ? "(" + it.datatype.join(" or ") + ")" : it.datatype);
+                                }
+                                if (it.declaration) sn.text(", " + it.declaration, dt);
+                                if (it.nullable) sn.text(", nullable", dt);
+
+                                if (this.conf.idlOldStyleExceptions && it.raises.length) {
+                                    var table = sn.element("table", { "class": "exceptions" }, desc);
+                                    var tr = sn.element("tr", {}, table);
+                                    ["Exception", "On Get", "On Set", "Description"].forEach(function (tit) { sn.element("th", {}, tr, tit); });
+                                    for (var k = 0; k < it.raises.length; k++) {
+                                        var exc = it.raises[k];
+                                        var tr = sn.element("tr", {}, table);
+                                        sn.element("td", { "class": "excName" }, tr, [sn.element("a", {}, null, exc.id)]);
+                                        ["onGet", "onSet"].forEach(function (gs) {
+                                            if (exc[gs]) sn.element("td", { "class": "excGetSetTrue" }, tr, $("<span role='img' aria-label='True'>\u2714</span>"));
+                                            else         sn.element("td", { "class": "excGetSetFalse" }, tr, $("<span role='img' aria-label='False'>\u2718</span>"));
+                                        });
+                                        var dtd = sn.element("td", { "class": "excDesc" }, tr);
+                                        if (exc.type == "simple") {
+                                            dtd.append(exc.description);
+                                        }
+                                        else {
+                                            var ctab = sn.element("table", { "class": "exceptionCodes" }, dtd );
+                                            for (var m = 0; m < exc.description.length; m++) {
+                                                var cd = exc.description[m];
+                                                var tr = sn.element("tr", {}, ctab);
+                                                sn.element("td", { "class": "excCodeName" }, tr, [sn.element("code", {}, null, cd.id)]);
+                                                sn.element("td", { "class": "excCodeDesc" }, tr, [cd.description]);
+                                            }
+                                        }
+                                    }
+                                }
+                                // else {
+                                //     sn.element("div", {}, desc, [sn.element("em", {}, null, "No exceptions.")]);
+                                // }
+                            }
+                            else if (type == "constant") {
+                                sn.text(" of type ", dt);
+                                sn.element("span", { "class": "idlConstType" }, dt, [sn.element("a", {}, null, it.datatype)]);
+                                if (it.nullable) sn.text(", nullable", dt);
+                            }
+                        }
+                    }
+                    // Serializer
+                    else {
+                        var div = sn.element("div", {}, sec);
+                        var it = things[0];
+                        if (it.serializertype != "prose") {
+                            var generatedDescription = "Instances of this interface are serialized as ";
+                            if (it.serializertype == "map") {
+                                var mapDescription = "a map ";
+                                if (it.getter) {
+                                    mapDescription += "with entries corresponding to the named properties";
+                                }
+                                else {
+                                    var and = "";
+                                    if (it.inherit) {
+                                        mapDescription += "with entries from the closest inherited interface ";
+                                        and = "and ";
+                                    }
+                                    if (it.all) {
+                                        mapDescription += and + "with entries for each of the serializable attributes";
+                                    }
+                                    else if (it.values && it.values.length) {
+                                        mapDescription += and + "with entries for the following attributes: " + it.values.join(", ");
+                                    }
+                                    else {
+                                        mapDescription = "an empty map";
+                                    }
+                                }
+                                generatedDescription += mapDescription;
+                            }
+                            else if (it.serializertype == "list") {
+                                var listDescription = "a list ";
+                                if (it.getter) {
+                                    listDescription += "with values corresponding to the indexed properties";
+                                }
+                                else {
+                                    if (it.values && it.values.length) {
+                                        listDescription += "with the values of the following attributes: " + it.values.join(", ");
+                                    }
+                                    else {
+                                        listDescription = "an empty list";
+                                    }
+                                }
+                                generatedDescription += listDescription;
+                            }
+                            else if (it.serializertype == "attribute") {
+                                generatedDescription += "the value of the attribute " + it.values[0];
+                            }
+                            generatedDescription += ".";
+                            sn.element("p", {}, div, generatedDescription);
+                        }
+                        sn.element("p", {}, div, [it.description]);
+                    }
+                }
+                return df;
+            },
+
             writeAsHTML:    function (obj) {
                 if (obj.type == "module") {
                     if (obj.id == "outermost") {
@@ -884,212 +1092,7 @@ define(
                 }
 
                 else if (obj.type == "interface") {
-                    var df = sn.documentFragment();
-                    var curLnk = "widl-" + obj.refId + "-";
-                    var types = ["constructor", "attribute", "method", "constant", "serializer"];
-                    var filterFunc = function (it) { return it.type == type; }
-                    ,   sortFunc = function (a, b) {
-                            if (a.unescapedId < b.unescapedId) return -1;
-                            if (a.unescapedId > b.unescapedId) return 1;
-                            return 0;
-                        }
-                    ;
-                    for (var i = 0; i < types.length; i++) {
-                        var type = types[i];
-                        var things = obj.children.filter(filterFunc);
-                        if (things.length === 0) continue;
-                        if (!this.noIDLSorting) things.sort(sortFunc);
-
-                        var sec = sn.element("section", {}, df);
-                        var secTitle = type;
-                        secTitle = secTitle.substr(0, 1).toUpperCase() + secTitle.substr(1) + (type != "serializer" ? "s" : "");
-                        if (!this.conf.noIDLSectionTitle) sn.element("h2", {}, sec, secTitle);
-                        if (type != "serializer") {
-                            var dl = sn.element("dl", { "class": type + "s" }, sec);
-                            for (var j = 0; j < things.length; j++) {
-                                var it = things[j];
-                                var id = (type == "method") ? this.makeMethodID(curLnk, it) :
-                                    (type == "constructor") ? this.makeMethodID("widl-ctor-", it)
-                                    : sn.idThatDoesNotExist(curLnk + it.refId);
-                                var dt = sn.element("dt", { id: id }, dl);
-                                sn.element("code", {}, dt, it.unescapedId);
-                                if (it.isStatic) dt.append(this.doc.createTextNode(", static"));
-                                var desc = sn.element("dd", {}, dl, [it.description]);
-                                if (type == "method" || type == "constructor") {
-                                    if (it.params.length) {
-                                        var table = sn.element("table", { "class": "parameters" }, desc);
-                                        var tr = sn.element("tr", {}, table);
-                                        ["Parameter", "Type", "Nullable", "Optional", "Description"].forEach(function (tit) { sn.element("th", {}, tr, tit); });
-                                        for (var k = 0; k < it.params.length; k++) {
-                                            var prm = it.params[k];
-                                            var tr = sn.element("tr", {}, table);
-                                            sn.element("td", { "class": "prmName" }, tr, prm.id);
-                                            var tyTD = sn.element("td", { "class": "prmType" }, tr);
-                                            var code = sn.element("code", {}, tyTD);
-                                            var codeHTML = datatype(prm.datatype);
-                                            if (prm.array) codeHTML += arrsq(prm);
-                                            if (prm.defaultValue) {
-                                                codeHTML += " = " + prm.defaultValue;
-                                            }
-                                            code.html(codeHTML);
-                                            if (prm.nullable) sn.element("td", { "class": "prmNullTrue" }, tr, $("<span role='img' aria-label='True'>\u2714</span>"));
-                                            else              sn.element("td", { "class": "prmNullFalse" }, tr, $("<span role='img' aria-label='False'>\u2718</span>"));
-                                            if (prm.optional) sn.element("td", { "class": "prmOptTrue" }, tr,  $("<span role='img' aria-label='True'>\u2714</span>"));
-                                            else              sn.element("td", { "class": "prmOptFalse" }, tr, $("<span role='img' aria-label='False'>\u2718</span>"));
-                                            var cnt = prm.description ? [prm.description] : "";
-                                            sn.element("td", { "class": "prmDesc" }, tr, cnt);
-                                        }
-                                    }
-                                    else {
-                                        sn.element("div", {}, desc, [sn.element("em", {}, null, "No parameters.")]);
-                                    }
-                                    if (this.conf.idlOldStyleExceptions && it.raises.length) {
-                                        var table = sn.element("table", { "class": "exceptions" }, desc);
-                                        var tr = sn.element("tr", {}, table);
-                                        ["Exception", "Description"].forEach(function (tit) { sn.element("th", {}, tr, tit); });
-                                        for (var k = 0; k < it.raises.length; k++) {
-                                            var exc = it.raises[k];
-                                            var tr = sn.element("tr", {}, table);
-                                            sn.element("td", { "class": "excName" }, tr, [sn.element("a", {}, null, exc.id)]);
-                                            var dtd = sn.element("td", { "class": "excDesc" }, tr);
-                                            if (exc.type == "simple") {
-                                                dtd.append(exc.description);
-                                            }
-                                            else {
-                                                var ctab = sn.element("table", { "class": "exceptionCodes" }, dtd );
-                                                for (var m = 0; m < exc.description.length; m++) {
-                                                    var cd = exc.description[m];
-                                                    var tr = sn.element("tr", {}, ctab);
-                                                    sn.element("td", { "class": "excCodeName" }, tr, [sn.element("code", {}, null, cd.id)]);
-                                                    sn.element("td", { "class": "excCodeDesc" }, tr, [cd.description]);
-                                                }
-                                            }
-                                        }
-                                    }
-                                    // else {
-                                    //     sn.element("div", {}, desc, [sn.element("em", {}, null, "No exceptions.")]);
-                                    // }
-
-                                    if (type !== "constructor") {
-                                        var reDiv = sn.element("div", {}, desc);
-                                        sn.element("em", {}, reDiv, "Return type: ");
-                                        var code = sn.element("code", {}, reDiv);
-                                        var codeHTML = datatype(it.datatype);
-                                        if (it.array) codeHTML += arrsq(it);
-                                        if (it.nullable) sn.text(", nullable", reDiv);
-                                        code.html(codeHTML);
-                                    }
-                                }
-                                else if (type == "attribute") {
-                                    sn.text(" of type ", dt);
-                                    if (it.array) {
-                                        for (var m = 0, n = it.arrayCount; m < n; m++) sn.text("array of ", dt);
-                                    }
-                                    var span = sn.element("span", { "class": "idlAttrType" }, dt);
-                                    var parameterized = this.parseParameterized(it.datatype);
-                                    if (parameterized) {
-                                        sn.text(parameterized.type + "<", span);
-                                        sn.element("a", {}, span, parameterized.parameter);
-                                        sn.text(">", span);
-                                    }
-                                    else {
-                                        sn.element("a", {}, span, it.isUnionType ? "(" + it.datatype.join(" or ") + ")" : it.datatype);
-                                    }
-                                    if (it.declaration) sn.text(", " + it.declaration, dt);
-                                    if (it.nullable) sn.text(", nullable", dt);
-
-                                    if (this.conf.idlOldStyleExceptions && it.raises.length) {
-                                        var table = sn.element("table", { "class": "exceptions" }, desc);
-                                        var tr = sn.element("tr", {}, table);
-                                        ["Exception", "On Get", "On Set", "Description"].forEach(function (tit) { sn.element("th", {}, tr, tit); });
-                                        for (var k = 0; k < it.raises.length; k++) {
-                                            var exc = it.raises[k];
-                                            var tr = sn.element("tr", {}, table);
-                                            sn.element("td", { "class": "excName" }, tr, [sn.element("a", {}, null, exc.id)]);
-                                            ["onGet", "onSet"].forEach(function (gs) {
-                                                if (exc[gs]) sn.element("td", { "class": "excGetSetTrue" }, tr, $("<span role='img' aria-label='True'>\u2714</span>"));
-                                                else         sn.element("td", { "class": "excGetSetFalse" }, tr, $("<span role='img' aria-label='False'>\u2718</span>"));
-                                            });
-                                            var dtd = sn.element("td", { "class": "excDesc" }, tr);
-                                            if (exc.type == "simple") {
-                                                dtd.append(exc.description);
-                                            }
-                                            else {
-                                                var ctab = sn.element("table", { "class": "exceptionCodes" }, dtd );
-                                                for (var m = 0; m < exc.description.length; m++) {
-                                                    var cd = exc.description[m];
-                                                    var tr = sn.element("tr", {}, ctab);
-                                                    sn.element("td", { "class": "excCodeName" }, tr, [sn.element("code", {}, null, cd.id)]);
-                                                    sn.element("td", { "class": "excCodeDesc" }, tr, [cd.description]);
-                                                }
-                                            }
-                                        }
-                                    }
-                                    // else {
-                                    //     sn.element("div", {}, desc, [sn.element("em", {}, null, "No exceptions.")]);
-                                    // }
-                                }
-                                else if (type == "constant") {
-                                    sn.text(" of type ", dt);
-                                    sn.element("span", { "class": "idlConstType" }, dt, [sn.element("a", {}, null, it.datatype)]);
-                                    if (it.nullable) sn.text(", nullable", dt);
-                                }
-                            }
-                        }
-                        // Serializer
-                        else {
-                            var div = sn.element("div", {}, sec);
-                            var it = things[0];
-                            if (it.serializertype != "prose") {
-                                var generatedDescription = "Instances of this interface are serialized as ";
-                                if (it.serializertype == "map") {
-                                    var mapDescription = "a map ";
-                                    if (it.getter) {
-                                        mapDescription += "with entries corresponding to the named properties";
-                                    }
-                                    else {
-                                        var and = "";
-                                        if (it.inherit) {
-                                            mapDescription += "with entries from the closest inherited interface ";
-                                            and = "and ";
-                                        }
-                                        if (it.all) {
-                                            mapDescription += and + "with entries for each of the serializable attributes";
-                                        }
-                                        else if (it.values && it.values.length) {
-                                            mapDescription += and + "with entries for the following attributes: " + it.values.join(", ");
-                                        }
-                                        else {
-                                            mapDescription = "an empty map";
-                                        }
-                                    }
-                                    generatedDescription += mapDescription;
-                                }
-                                else if (it.serializertype == "list") {
-                                    var listDescription = "a list ";
-                                    if (it.getter) {
-                                        listDescription += "with values corresponding to the indexed properties";
-                                    }
-                                    else {
-                                        if (it.values && it.values.length) {
-                                            listDescription += "with the values of the following attributes: " + it.values.join(", ");
-                                        }
-                                        else {
-                                            listDescription = "an empty list";
-                                        }
-                                    }
-                                    generatedDescription += listDescription;
-                                }
-                                else if (it.serializertype == "attribute") {
-                                    generatedDescription += "the value of the attribute " + it.values[0];
-                                }
-                                generatedDescription += ".";
-                                sn.element("p", {}, div, generatedDescription);
-                            }
-                            sn.element("p", {}, div, [it.description]);
-                        }
-                    }
-                    return df;
+                    return this.writeInterfaceAsHTML(obj);
                 }
             },
 

--- a/js/core/webidl-oldschool.js
+++ b/js/core/webidl-oldschool.js
@@ -678,191 +678,192 @@ define(
                 return { type: matched[1], parameter: matched[2] };
             },
 
-            writeTypeFilteredThingsInInterfaceAsHTML: function (obj, curLnk, sec, type, things) {
-                var secTitle = type;
-                secTitle = secTitle.substr(0, 1).toUpperCase() + secTitle.substr(1) + (type != "serializer" ? "s" : "");
-                if (!this.conf.noIDLSectionTitle) sn.element("h2", {}, sec, secTitle);
-                if (type != "serializer") {
-                    var dl = sn.element("dl", { "class": type + "s" }, sec);
-                    for (var j = 0; j < things.length; j++) {
-                        var it = things[j];
-                        var id = (type == "method") ? this.makeMethodID(curLnk, it) :
-                            (type == "constructor") ? this.makeMethodID("widl-ctor-", it)
-                            : sn.idThatDoesNotExist(curLnk + it.refId);
-                        var dt = sn.element("dt", { id: id }, dl);
-                        sn.element("code", {}, dt, it.unescapedId);
-                        if (it.isStatic) dt.append(this.doc.createTextNode(", static"));
-                        var desc = sn.element("dd", {}, dl, [it.description]);
-                        if (type == "method" || type == "constructor") {
-                            if (it.params.length) {
-                                var table = sn.element("table", { "class": "parameters" }, desc);
-                                var tr = sn.element("tr", {}, table);
-                                ["Parameter", "Type", "Nullable", "Optional", "Description"].forEach(function (tit) { sn.element("th", {}, tr, tit); });
-                                for (var k = 0; k < it.params.length; k++) {
-                                    var prm = it.params[k];
-                                    var tr = sn.element("tr", {}, table);
-                                    sn.element("td", { "class": "prmName" }, tr, prm.id);
-                                    var tyTD = sn.element("td", { "class": "prmType" }, tr);
-                                    var code = sn.element("code", {}, tyTD);
-                                    var codeHTML = datatype(prm.datatype);
-                                    if (prm.array) codeHTML += arrsq(prm);
-                                    if (prm.defaultValue) {
-                                        codeHTML += " = " + prm.defaultValue;
-                                    }
-                                    code.html(codeHTML);
-                                    if (prm.nullable) sn.element("td", { "class": "prmNullTrue" }, tr, $("<span role='img' aria-label='True'>\u2714</span>"));
-                                    else              sn.element("td", { "class": "prmNullFalse" }, tr, $("<span role='img' aria-label='False'>\u2718</span>"));
-                                    if (prm.optional) sn.element("td", { "class": "prmOptTrue" }, tr,  $("<span role='img' aria-label='True'>\u2714</span>"));
-                                    else              sn.element("td", { "class": "prmOptFalse" }, tr, $("<span role='img' aria-label='False'>\u2718</span>"));
-                                    var cnt = prm.description ? [prm.description] : "";
-                                    sn.element("td", { "class": "prmDesc" }, tr, cnt);
-                                }
+            writeSerializerAsHTML: function (div, it) {
+                if (it.serializertype != "prose") {
+                    var generatedDescription = "Instances of this interface are serialized as ";
+                    if (it.serializertype == "map") {
+                        var mapDescription = "a map ";
+                        if (it.getter) {
+                            mapDescription += "with entries corresponding to the named properties";
+                        }
+                        else {
+                            var and = "";
+                            if (it.inherit) {
+                                mapDescription += "with entries from the closest inherited interface ";
+                                and = "and ";
+                            }
+                            if (it.all) {
+                                mapDescription += and + "with entries for each of the serializable attributes";
+                            }
+                            else if (it.values && it.values.length) {
+                                mapDescription += and + "with entries for the following attributes: " + it.values.join(", ");
                             }
                             else {
-                                sn.element("div", {}, desc, [sn.element("em", {}, null, "No parameters.")]);
-                            }
-                            if (this.conf.idlOldStyleExceptions && it.raises.length) {
-                                var table = sn.element("table", { "class": "exceptions" }, desc);
-                                var tr = sn.element("tr", {}, table);
-                                ["Exception", "Description"].forEach(function (tit) { sn.element("th", {}, tr, tit); });
-                                for (var k = 0; k < it.raises.length; k++) {
-                                    var exc = it.raises[k];
-                                    var tr = sn.element("tr", {}, table);
-                                    sn.element("td", { "class": "excName" }, tr, [sn.element("a", {}, null, exc.id)]);
-                                    var dtd = sn.element("td", { "class": "excDesc" }, tr);
-                                    if (exc.type == "simple") {
-                                        dtd.append(exc.description);
-                                    }
-                                    else {
-                                        var ctab = sn.element("table", { "class": "exceptionCodes" }, dtd );
-                                        for (var m = 0; m < exc.description.length; m++) {
-                                            var cd = exc.description[m];
-                                            var tr = sn.element("tr", {}, ctab);
-                                            sn.element("td", { "class": "excCodeName" }, tr, [sn.element("code", {}, null, cd.id)]);
-                                            sn.element("td", { "class": "excCodeDesc" }, tr, [cd.description]);
-                                        }
-                                    }
-                                }
-                            }
-                            // else {
-                            //     sn.element("div", {}, desc, [sn.element("em", {}, null, "No exceptions.")]);
-                            // }
-                             if (type !== "constructor") {
-                                var reDiv = sn.element("div", {}, desc);
-                                sn.element("em", {}, reDiv, "Return type: ");
-                                var code = sn.element("code", {}, reDiv);
-                                var codeHTML = datatype(it.datatype);
-                                if (it.array) codeHTML += arrsq(it);
-                                if (it.nullable) sn.text(", nullable", reDiv);
-                                code.html(codeHTML);
+                                mapDescription = "an empty map";
                             }
                         }
-                        else if (type == "attribute") {
-                            sn.text(" of type ", dt);
-                            if (it.array) {
-                                for (var m = 0, n = it.arrayCount; m < n; m++) sn.text("array of ", dt);
-                            }
-                            var span = sn.element("span", { "class": "idlAttrType" }, dt);
-                            var parameterized = this.parseParameterized(it.datatype);
-                            if (parameterized) {
-                                sn.text(parameterized.type + "<", span);
-                                sn.element("a", {}, span, parameterized.parameter);
-                                sn.text(">", span);
-                            }
-                            else {
-                                sn.element("a", {}, span, it.isUnionType ? "(" + it.datatype.join(" or ") + ")" : it.datatype);
-                            }
-                            if (it.declaration) sn.text(", " + it.declaration, dt);
-                            if (it.nullable) sn.text(", nullable", dt);
-                             if (this.conf.idlOldStyleExceptions && it.raises.length) {
-                                var table = sn.element("table", { "class": "exceptions" }, desc);
-                                var tr = sn.element("tr", {}, table);
-                                ["Exception", "On Get", "On Set", "Description"].forEach(function (tit) { sn.element("th", {}, tr, tit); });
-                                for (var k = 0; k < it.raises.length; k++) {
-                                    var exc = it.raises[k];
-                                    var tr = sn.element("tr", {}, table);
-                                    sn.element("td", { "class": "excName" }, tr, [sn.element("a", {}, null, exc.id)]);
-                                    ["onGet", "onSet"].forEach(function (gs) {
-                                        if (exc[gs]) sn.element("td", { "class": "excGetSetTrue" }, tr, $("<span role='img' aria-label='True'>\u2714</span>"));
-                                        else         sn.element("td", { "class": "excGetSetFalse" }, tr, $("<span role='img' aria-label='False'>\u2718</span>"));
-                                    });
-                                    var dtd = sn.element("td", { "class": "excDesc" }, tr);
-                                    if (exc.type == "simple") {
-                                        dtd.append(exc.description);
-                                    }
-                                    else {
-                                        var ctab = sn.element("table", { "class": "exceptionCodes" }, dtd );
-                                        for (var m = 0; m < exc.description.length; m++) {
-                                            var cd = exc.description[m];
-                                            var tr = sn.element("tr", {}, ctab);
-                                            sn.element("td", { "class": "excCodeName" }, tr, [sn.element("code", {}, null, cd.id)]);
-                                            sn.element("td", { "class": "excCodeDesc" }, tr, [cd.description]);
-                                        }
-                                    }
-                                }
-                            }
-                            // else {
-                            //     sn.element("div", {}, desc, [sn.element("em", {}, null, "No exceptions.")]);
-                            // }
-                        }
-                        else if (type == "constant") {
-                            sn.text(" of type ", dt);
-                            sn.element("span", { "class": "idlConstType" }, dt, [sn.element("a", {}, null, it.datatype)]);
-                            if (it.nullable) sn.text(", nullable", dt);
-                        }
+                        generatedDescription += mapDescription;
                     }
+                    else if (it.serializertype == "list") {
+                        var listDescription = "a list ";
+                        if (it.getter) {
+                            listDescription += "with values corresponding to the indexed properties";
+                        }
+                        else {
+                            if (it.values && it.values.length) {
+                                listDescription += "with the values of the following attributes: " + it.values.join(", ");
+                            }
+                            else {
+                                listDescription = "an empty list";
+                            }
+                        }
+                        generatedDescription += listDescription;
+                    }
+                    else if (it.serializertype == "attribute") {
+                        generatedDescription += "the value of the attribute " + it.values[0];
+                    }
+                    generatedDescription += ".";
+                    sn.element("p", {}, div, generatedDescription);
                 }
-                // Serializer
-                else {
-                    var div = sn.element("div", {}, sec);
-                    var it = things[0];
-                    if (it.serializertype != "prose") {
-                        var generatedDescription = "Instances of this interface are serialized as ";
-                        if (it.serializertype == "map") {
-                            var mapDescription = "a map ";
-                            if (it.getter) {
-                                mapDescription += "with entries corresponding to the named properties";
+                sn.element("p", {}, div, [it.description]);
+            },
+
+            writeTypeFilteredThingsInInterfaceAsHTML: function (obj, curLnk, sec, type, things) {
+                var secTitle = type.substr(0, 1).toUpperCase() + type.substr(1) + (type != "serializer" ? "s" : "");
+                if (!this.conf.noIDLSectionTitle) sn.element("h2", {}, sec, secTitle);
+                if (type == "serializer") {
+                    this.writeSerializerAsHTML(sn.element("div", {}, sec), things[0]);
+                    return;
+                }
+
+                var dl = sn.element("dl", { "class": type + "s" }, sec);
+                for (var j = 0; j < things.length; j++) {
+                    var it = things[j];
+                    var id = (type == "method") ? this.makeMethodID(curLnk, it) :
+                        (type == "constructor") ? this.makeMethodID("widl-ctor-", it)
+                        : sn.idThatDoesNotExist(curLnk + it.refId);
+                    var dt = sn.element("dt", { id: id }, dl);
+                    sn.element("code", {}, dt, it.unescapedId);
+                    if (it.isStatic) dt.append(this.doc.createTextNode(", static"));
+                    var desc = sn.element("dd", {}, dl, [it.description]);
+                    if (type == "method" || type == "constructor") {
+                        if (it.params.length) {
+                            var table = sn.element("table", { "class": "parameters" }, desc);
+                            var tr = sn.element("tr", {}, table);
+                            ["Parameter", "Type", "Nullable", "Optional", "Description"].forEach(function (tit) { sn.element("th", {}, tr, tit); });
+                            for (var k = 0; k < it.params.length; k++) {
+                                var prm = it.params[k];
+                                var tr = sn.element("tr", {}, table);
+                                sn.element("td", { "class": "prmName" }, tr, prm.id);
+                                var tyTD = sn.element("td", { "class": "prmType" }, tr);
+                                var code = sn.element("code", {}, tyTD);
+                                var codeHTML = datatype(prm.datatype);
+                                if (prm.array) codeHTML += arrsq(prm);
+                                if (prm.defaultValue) {
+                                    codeHTML += " = " + prm.defaultValue;
+                                }
+                                code.html(codeHTML);
+                                if (prm.nullable) sn.element("td", { "class": "prmNullTrue" }, tr, $("<span role='img' aria-label='True'>\u2714</span>"));
+                                else              sn.element("td", { "class": "prmNullFalse" }, tr, $("<span role='img' aria-label='False'>\u2718</span>"));
+                                if (prm.optional) sn.element("td", { "class": "prmOptTrue" }, tr,  $("<span role='img' aria-label='True'>\u2714</span>"));
+                                else              sn.element("td", { "class": "prmOptFalse" }, tr, $("<span role='img' aria-label='False'>\u2718</span>"));
+                                var cnt = prm.description ? [prm.description] : "";
+                                sn.element("td", { "class": "prmDesc" }, tr, cnt);
                             }
-                            else {
-                                var and = "";
-                                if (it.inherit) {
-                                    mapDescription += "with entries from the closest inherited interface ";
-                                    and = "and ";
-                                }
-                                if (it.all) {
-                                    mapDescription += and + "with entries for each of the serializable attributes";
-                                }
-                                else if (it.values && it.values.length) {
-                                    mapDescription += and + "with entries for the following attributes: " + it.values.join(", ");
+                        }
+                        else {
+                            sn.element("div", {}, desc, [sn.element("em", {}, null, "No parameters.")]);
+                        }
+                        if (this.conf.idlOldStyleExceptions && it.raises.length) {
+                            var table = sn.element("table", { "class": "exceptions" }, desc);
+                            var tr = sn.element("tr", {}, table);
+                            ["Exception", "Description"].forEach(function (tit) { sn.element("th", {}, tr, tit); });
+                            for (var k = 0; k < it.raises.length; k++) {
+                                var exc = it.raises[k];
+                                var tr = sn.element("tr", {}, table);
+                                sn.element("td", { "class": "excName" }, tr, [sn.element("a", {}, null, exc.id)]);
+                                var dtd = sn.element("td", { "class": "excDesc" }, tr);
+                                if (exc.type == "simple") {
+                                    dtd.append(exc.description);
                                 }
                                 else {
-                                    mapDescription = "an empty map";
+                                    var ctab = sn.element("table", { "class": "exceptionCodes" }, dtd );
+                                    for (var m = 0; m < exc.description.length; m++) {
+                                        var cd = exc.description[m];
+                                        var tr = sn.element("tr", {}, ctab);
+                                        sn.element("td", { "class": "excCodeName" }, tr, [sn.element("code", {}, null, cd.id)]);
+                                        sn.element("td", { "class": "excCodeDesc" }, tr, [cd.description]);
+                                    }
                                 }
                             }
-                            generatedDescription += mapDescription;
                         }
-                        else if (it.serializertype == "list") {
-                            var listDescription = "a list ";
-                            if (it.getter) {
-                                listDescription += "with values corresponding to the indexed properties";
-                            }
-                            else {
-                                if (it.values && it.values.length) {
-                                    listDescription += "with the values of the following attributes: " + it.values.join(", ");
-                                }
-                                else {
-                                    listDescription = "an empty list";
-                                }
-                            }
-                            generatedDescription += listDescription;
+                        // else {
+                        //     sn.element("div", {}, desc, [sn.element("em", {}, null, "No exceptions.")]);
+                        // }
+
+                        if (type !== "constructor") {
+                            var reDiv = sn.element("div", {}, desc);
+                            sn.element("em", {}, reDiv, "Return type: ");
+                            var code = sn.element("code", {}, reDiv);
+                            var codeHTML = datatype(it.datatype);
+                            if (it.array) codeHTML += arrsq(it);
+                            if (it.nullable) sn.text(", nullable", reDiv);
+                            code.html(codeHTML);
                         }
-                        else if (it.serializertype == "attribute") {
-                            generatedDescription += "the value of the attribute " + it.values[0];
-                        }
-                        generatedDescription += ".";
-                        sn.element("p", {}, div, generatedDescription);
                     }
-                    sn.element("p", {}, div, [it.description]);
+                    else if (type == "attribute") {
+                        sn.text(" of type ", dt);
+                        if (it.array) {
+                            for (var m = 0, n = it.arrayCount; m < n; m++) sn.text("array of ", dt);
+                        }
+                        var span = sn.element("span", { "class": "idlAttrType" }, dt);
+                        var parameterized = this.parseParameterized(it.datatype);
+                        if (parameterized) {
+                            sn.text(parameterized.type + "<", span);
+                            sn.element("a", {}, span, parameterized.parameter);
+                            sn.text(">", span);
+                        }
+                        else {
+                            sn.element("a", {}, span, it.isUnionType ? "(" + it.datatype.join(" or ") + ")" : it.datatype);
+                        }
+                        if (it.declaration) sn.text(", " + it.declaration, dt);
+                        if (it.nullable) sn.text(", nullable", dt);
+                         if (this.conf.idlOldStyleExceptions && it.raises.length) {
+                            var table = sn.element("table", { "class": "exceptions" }, desc);
+                            var tr = sn.element("tr", {}, table);
+                            ["Exception", "On Get", "On Set", "Description"].forEach(function (tit) { sn.element("th", {}, tr, tit); });
+                            for (var k = 0; k < it.raises.length; k++) {
+                                var exc = it.raises[k];
+                                var tr = sn.element("tr", {}, table);
+                                sn.element("td", { "class": "excName" }, tr, [sn.element("a", {}, null, exc.id)]);
+                                ["onGet", "onSet"].forEach(function (gs) {
+                                    if (exc[gs]) sn.element("td", { "class": "excGetSetTrue" }, tr, $("<span role='img' aria-label='True'>\u2714</span>"));
+                                    else         sn.element("td", { "class": "excGetSetFalse" }, tr, $("<span role='img' aria-label='False'>\u2718</span>"));
+                                });
+                                var dtd = sn.element("td", { "class": "excDesc" }, tr);
+                                if (exc.type == "simple") {
+                                    dtd.append(exc.description);
+                                }
+                                else {
+                                    var ctab = sn.element("table", { "class": "exceptionCodes" }, dtd );
+                                    for (var m = 0; m < exc.description.length; m++) {
+                                        var cd = exc.description[m];
+                                        var tr = sn.element("tr", {}, ctab);
+                                        sn.element("td", { "class": "excCodeName" }, tr, [sn.element("code", {}, null, cd.id)]);
+                                        sn.element("td", { "class": "excCodeDesc" }, tr, [cd.description]);
+                                    }
+                                }
+                            }
+                        }
+                        // else {
+                        //     sn.element("div", {}, desc, [sn.element("em", {}, null, "No exceptions.")]);
+                        // }
+                    }
+                    else if (type == "constant") {
+                        sn.text(" of type ", dt);
+                        sn.element("span", { "class": "idlConstType" }, dt, [sn.element("a", {}, null, it.datatype)]);
+                        if (it.nullable) sn.text(", nullable", dt);
+                    }
                 }
             },
 

--- a/js/core/webidl-oldschool.js
+++ b/js/core/webidl-oldschool.js
@@ -678,6 +678,194 @@ define(
                 return { type: matched[1], parameter: matched[2] };
             },
 
+            writeTypeFilteredThingsInInterfaceAsHTML: function (obj, curLnk, sec, type, things) {
+                var secTitle = type;
+                secTitle = secTitle.substr(0, 1).toUpperCase() + secTitle.substr(1) + (type != "serializer" ? "s" : "");
+                if (!this.conf.noIDLSectionTitle) sn.element("h2", {}, sec, secTitle);
+                if (type != "serializer") {
+                    var dl = sn.element("dl", { "class": type + "s" }, sec);
+                    for (var j = 0; j < things.length; j++) {
+                        var it = things[j];
+                        var id = (type == "method") ? this.makeMethodID(curLnk, it) :
+                            (type == "constructor") ? this.makeMethodID("widl-ctor-", it)
+                            : sn.idThatDoesNotExist(curLnk + it.refId);
+                        var dt = sn.element("dt", { id: id }, dl);
+                        sn.element("code", {}, dt, it.unescapedId);
+                        if (it.isStatic) dt.append(this.doc.createTextNode(", static"));
+                        var desc = sn.element("dd", {}, dl, [it.description]);
+                        if (type == "method" || type == "constructor") {
+                            if (it.params.length) {
+                                var table = sn.element("table", { "class": "parameters" }, desc);
+                                var tr = sn.element("tr", {}, table);
+                                ["Parameter", "Type", "Nullable", "Optional", "Description"].forEach(function (tit) { sn.element("th", {}, tr, tit); });
+                                for (var k = 0; k < it.params.length; k++) {
+                                    var prm = it.params[k];
+                                    var tr = sn.element("tr", {}, table);
+                                    sn.element("td", { "class": "prmName" }, tr, prm.id);
+                                    var tyTD = sn.element("td", { "class": "prmType" }, tr);
+                                    var code = sn.element("code", {}, tyTD);
+                                    var codeHTML = datatype(prm.datatype);
+                                    if (prm.array) codeHTML += arrsq(prm);
+                                    if (prm.defaultValue) {
+                                        codeHTML += " = " + prm.defaultValue;
+                                    }
+                                    code.html(codeHTML);
+                                    if (prm.nullable) sn.element("td", { "class": "prmNullTrue" }, tr, $("<span role='img' aria-label='True'>\u2714</span>"));
+                                    else              sn.element("td", { "class": "prmNullFalse" }, tr, $("<span role='img' aria-label='False'>\u2718</span>"));
+                                    if (prm.optional) sn.element("td", { "class": "prmOptTrue" }, tr,  $("<span role='img' aria-label='True'>\u2714</span>"));
+                                    else              sn.element("td", { "class": "prmOptFalse" }, tr, $("<span role='img' aria-label='False'>\u2718</span>"));
+                                    var cnt = prm.description ? [prm.description] : "";
+                                    sn.element("td", { "class": "prmDesc" }, tr, cnt);
+                                }
+                            }
+                            else {
+                                sn.element("div", {}, desc, [sn.element("em", {}, null, "No parameters.")]);
+                            }
+                            if (this.conf.idlOldStyleExceptions && it.raises.length) {
+                                var table = sn.element("table", { "class": "exceptions" }, desc);
+                                var tr = sn.element("tr", {}, table);
+                                ["Exception", "Description"].forEach(function (tit) { sn.element("th", {}, tr, tit); });
+                                for (var k = 0; k < it.raises.length; k++) {
+                                    var exc = it.raises[k];
+                                    var tr = sn.element("tr", {}, table);
+                                    sn.element("td", { "class": "excName" }, tr, [sn.element("a", {}, null, exc.id)]);
+                                    var dtd = sn.element("td", { "class": "excDesc" }, tr);
+                                    if (exc.type == "simple") {
+                                        dtd.append(exc.description);
+                                    }
+                                    else {
+                                        var ctab = sn.element("table", { "class": "exceptionCodes" }, dtd );
+                                        for (var m = 0; m < exc.description.length; m++) {
+                                            var cd = exc.description[m];
+                                            var tr = sn.element("tr", {}, ctab);
+                                            sn.element("td", { "class": "excCodeName" }, tr, [sn.element("code", {}, null, cd.id)]);
+                                            sn.element("td", { "class": "excCodeDesc" }, tr, [cd.description]);
+                                        }
+                                    }
+                                }
+                            }
+                            // else {
+                            //     sn.element("div", {}, desc, [sn.element("em", {}, null, "No exceptions.")]);
+                            // }
+                             if (type !== "constructor") {
+                                var reDiv = sn.element("div", {}, desc);
+                                sn.element("em", {}, reDiv, "Return type: ");
+                                var code = sn.element("code", {}, reDiv);
+                                var codeHTML = datatype(it.datatype);
+                                if (it.array) codeHTML += arrsq(it);
+                                if (it.nullable) sn.text(", nullable", reDiv);
+                                code.html(codeHTML);
+                            }
+                        }
+                        else if (type == "attribute") {
+                            sn.text(" of type ", dt);
+                            if (it.array) {
+                                for (var m = 0, n = it.arrayCount; m < n; m++) sn.text("array of ", dt);
+                            }
+                            var span = sn.element("span", { "class": "idlAttrType" }, dt);
+                            var parameterized = this.parseParameterized(it.datatype);
+                            if (parameterized) {
+                                sn.text(parameterized.type + "<", span);
+                                sn.element("a", {}, span, parameterized.parameter);
+                                sn.text(">", span);
+                            }
+                            else {
+                                sn.element("a", {}, span, it.isUnionType ? "(" + it.datatype.join(" or ") + ")" : it.datatype);
+                            }
+                            if (it.declaration) sn.text(", " + it.declaration, dt);
+                            if (it.nullable) sn.text(", nullable", dt);
+                             if (this.conf.idlOldStyleExceptions && it.raises.length) {
+                                var table = sn.element("table", { "class": "exceptions" }, desc);
+                                var tr = sn.element("tr", {}, table);
+                                ["Exception", "On Get", "On Set", "Description"].forEach(function (tit) { sn.element("th", {}, tr, tit); });
+                                for (var k = 0; k < it.raises.length; k++) {
+                                    var exc = it.raises[k];
+                                    var tr = sn.element("tr", {}, table);
+                                    sn.element("td", { "class": "excName" }, tr, [sn.element("a", {}, null, exc.id)]);
+                                    ["onGet", "onSet"].forEach(function (gs) {
+                                        if (exc[gs]) sn.element("td", { "class": "excGetSetTrue" }, tr, $("<span role='img' aria-label='True'>\u2714</span>"));
+                                        else         sn.element("td", { "class": "excGetSetFalse" }, tr, $("<span role='img' aria-label='False'>\u2718</span>"));
+                                    });
+                                    var dtd = sn.element("td", { "class": "excDesc" }, tr);
+                                    if (exc.type == "simple") {
+                                        dtd.append(exc.description);
+                                    }
+                                    else {
+                                        var ctab = sn.element("table", { "class": "exceptionCodes" }, dtd );
+                                        for (var m = 0; m < exc.description.length; m++) {
+                                            var cd = exc.description[m];
+                                            var tr = sn.element("tr", {}, ctab);
+                                            sn.element("td", { "class": "excCodeName" }, tr, [sn.element("code", {}, null, cd.id)]);
+                                            sn.element("td", { "class": "excCodeDesc" }, tr, [cd.description]);
+                                        }
+                                    }
+                                }
+                            }
+                            // else {
+                            //     sn.element("div", {}, desc, [sn.element("em", {}, null, "No exceptions.")]);
+                            // }
+                        }
+                        else if (type == "constant") {
+                            sn.text(" of type ", dt);
+                            sn.element("span", { "class": "idlConstType" }, dt, [sn.element("a", {}, null, it.datatype)]);
+                            if (it.nullable) sn.text(", nullable", dt);
+                        }
+                    }
+                }
+                // Serializer
+                else {
+                    var div = sn.element("div", {}, sec);
+                    var it = things[0];
+                    if (it.serializertype != "prose") {
+                        var generatedDescription = "Instances of this interface are serialized as ";
+                        if (it.serializertype == "map") {
+                            var mapDescription = "a map ";
+                            if (it.getter) {
+                                mapDescription += "with entries corresponding to the named properties";
+                            }
+                            else {
+                                var and = "";
+                                if (it.inherit) {
+                                    mapDescription += "with entries from the closest inherited interface ";
+                                    and = "and ";
+                                }
+                                if (it.all) {
+                                    mapDescription += and + "with entries for each of the serializable attributes";
+                                }
+                                else if (it.values && it.values.length) {
+                                    mapDescription += and + "with entries for the following attributes: " + it.values.join(", ");
+                                }
+                                else {
+                                    mapDescription = "an empty map";
+                                }
+                            }
+                            generatedDescription += mapDescription;
+                        }
+                        else if (it.serializertype == "list") {
+                            var listDescription = "a list ";
+                            if (it.getter) {
+                                listDescription += "with values corresponding to the indexed properties";
+                            }
+                            else {
+                                if (it.values && it.values.length) {
+                                    listDescription += "with the values of the following attributes: " + it.values.join(", ");
+                                }
+                                else {
+                                    listDescription = "an empty list";
+                                }
+                            }
+                            generatedDescription += listDescription;
+                        }
+                        else if (it.serializertype == "attribute") {
+                            generatedDescription += "the value of the attribute " + it.values[0];
+                        }
+                        generatedDescription += ".";
+                        sn.element("p", {}, div, generatedDescription);
+                    }
+                    sn.element("p", {}, div, [it.description]);
+                }
+            },
+
             writeInterfaceAsHTML: function (obj) {
                 var df = sn.documentFragment();
                 var curLnk = "widl-" + obj.refId + "-";
@@ -695,193 +883,7 @@ define(
                     if (things.length === 0) continue;
                     if (!this.noIDLSorting) things.sort(sortFunc);
 
-                    var sec = sn.element("section", {}, df);
-                    var secTitle = type;
-                    secTitle = secTitle.substr(0, 1).toUpperCase() + secTitle.substr(1) + (type != "serializer" ? "s" : "");
-                    if (!this.conf.noIDLSectionTitle) sn.element("h2", {}, sec, secTitle);
-                    if (type != "serializer") {
-                        var dl = sn.element("dl", { "class": type + "s" }, sec);
-                        for (var j = 0; j < things.length; j++) {
-                            var it = things[j];
-                            var id = (type == "method") ? this.makeMethodID(curLnk, it) :
-                                (type == "constructor") ? this.makeMethodID("widl-ctor-", it)
-                                : sn.idThatDoesNotExist(curLnk + it.refId);
-                            var dt = sn.element("dt", { id: id }, dl);
-                            sn.element("code", {}, dt, it.unescapedId);
-                            if (it.isStatic) dt.append(this.doc.createTextNode(", static"));
-                            var desc = sn.element("dd", {}, dl, [it.description]);
-                            if (type == "method" || type == "constructor") {
-                                if (it.params.length) {
-                                    var table = sn.element("table", { "class": "parameters" }, desc);
-                                    var tr = sn.element("tr", {}, table);
-                                    ["Parameter", "Type", "Nullable", "Optional", "Description"].forEach(function (tit) { sn.element("th", {}, tr, tit); });
-                                    for (var k = 0; k < it.params.length; k++) {
-                                        var prm = it.params[k];
-                                        var tr = sn.element("tr", {}, table);
-                                        sn.element("td", { "class": "prmName" }, tr, prm.id);
-                                        var tyTD = sn.element("td", { "class": "prmType" }, tr);
-                                        var code = sn.element("code", {}, tyTD);
-                                        var codeHTML = datatype(prm.datatype);
-                                        if (prm.array) codeHTML += arrsq(prm);
-                                        if (prm.defaultValue) {
-                                            codeHTML += " = " + prm.defaultValue;
-                                        }
-                                        code.html(codeHTML);
-                                        if (prm.nullable) sn.element("td", { "class": "prmNullTrue" }, tr, $("<span role='img' aria-label='True'>\u2714</span>"));
-                                        else              sn.element("td", { "class": "prmNullFalse" }, tr, $("<span role='img' aria-label='False'>\u2718</span>"));
-                                        if (prm.optional) sn.element("td", { "class": "prmOptTrue" }, tr,  $("<span role='img' aria-label='True'>\u2714</span>"));
-                                        else              sn.element("td", { "class": "prmOptFalse" }, tr, $("<span role='img' aria-label='False'>\u2718</span>"));
-                                        var cnt = prm.description ? [prm.description] : "";
-                                        sn.element("td", { "class": "prmDesc" }, tr, cnt);
-                                    }
-                                }
-                                else {
-                                    sn.element("div", {}, desc, [sn.element("em", {}, null, "No parameters.")]);
-                                }
-                                if (this.conf.idlOldStyleExceptions && it.raises.length) {
-                                    var table = sn.element("table", { "class": "exceptions" }, desc);
-                                    var tr = sn.element("tr", {}, table);
-                                    ["Exception", "Description"].forEach(function (tit) { sn.element("th", {}, tr, tit); });
-                                    for (var k = 0; k < it.raises.length; k++) {
-                                        var exc = it.raises[k];
-                                        var tr = sn.element("tr", {}, table);
-                                        sn.element("td", { "class": "excName" }, tr, [sn.element("a", {}, null, exc.id)]);
-                                        var dtd = sn.element("td", { "class": "excDesc" }, tr);
-                                        if (exc.type == "simple") {
-                                            dtd.append(exc.description);
-                                        }
-                                        else {
-                                            var ctab = sn.element("table", { "class": "exceptionCodes" }, dtd );
-                                            for (var m = 0; m < exc.description.length; m++) {
-                                                var cd = exc.description[m];
-                                                var tr = sn.element("tr", {}, ctab);
-                                                sn.element("td", { "class": "excCodeName" }, tr, [sn.element("code", {}, null, cd.id)]);
-                                                sn.element("td", { "class": "excCodeDesc" }, tr, [cd.description]);
-                                            }
-                                        }
-                                    }
-                                }
-                                // else {
-                                //     sn.element("div", {}, desc, [sn.element("em", {}, null, "No exceptions.")]);
-                                // }
-                                 if (type !== "constructor") {
-                                    var reDiv = sn.element("div", {}, desc);
-                                    sn.element("em", {}, reDiv, "Return type: ");
-                                    var code = sn.element("code", {}, reDiv);
-                                    var codeHTML = datatype(it.datatype);
-                                    if (it.array) codeHTML += arrsq(it);
-                                    if (it.nullable) sn.text(", nullable", reDiv);
-                                    code.html(codeHTML);
-                                }
-                            }
-                            else if (type == "attribute") {
-                                sn.text(" of type ", dt);
-                                if (it.array) {
-                                    for (var m = 0, n = it.arrayCount; m < n; m++) sn.text("array of ", dt);
-                                }
-                                var span = sn.element("span", { "class": "idlAttrType" }, dt);
-                                var parameterized = this.parseParameterized(it.datatype);
-                                if (parameterized) {
-                                    sn.text(parameterized.type + "<", span);
-                                    sn.element("a", {}, span, parameterized.parameter);
-                                    sn.text(">", span);
-                                }
-                                else {
-                                    sn.element("a", {}, span, it.isUnionType ? "(" + it.datatype.join(" or ") + ")" : it.datatype);
-                                }
-                                if (it.declaration) sn.text(", " + it.declaration, dt);
-                                if (it.nullable) sn.text(", nullable", dt);
-
-                                if (this.conf.idlOldStyleExceptions && it.raises.length) {
-                                    var table = sn.element("table", { "class": "exceptions" }, desc);
-                                    var tr = sn.element("tr", {}, table);
-                                    ["Exception", "On Get", "On Set", "Description"].forEach(function (tit) { sn.element("th", {}, tr, tit); });
-                                    for (var k = 0; k < it.raises.length; k++) {
-                                        var exc = it.raises[k];
-                                        var tr = sn.element("tr", {}, table);
-                                        sn.element("td", { "class": "excName" }, tr, [sn.element("a", {}, null, exc.id)]);
-                                        ["onGet", "onSet"].forEach(function (gs) {
-                                            if (exc[gs]) sn.element("td", { "class": "excGetSetTrue" }, tr, $("<span role='img' aria-label='True'>\u2714</span>"));
-                                            else         sn.element("td", { "class": "excGetSetFalse" }, tr, $("<span role='img' aria-label='False'>\u2718</span>"));
-                                        });
-                                        var dtd = sn.element("td", { "class": "excDesc" }, tr);
-                                        if (exc.type == "simple") {
-                                            dtd.append(exc.description);
-                                        }
-                                        else {
-                                            var ctab = sn.element("table", { "class": "exceptionCodes" }, dtd );
-                                            for (var m = 0; m < exc.description.length; m++) {
-                                                var cd = exc.description[m];
-                                                var tr = sn.element("tr", {}, ctab);
-                                                sn.element("td", { "class": "excCodeName" }, tr, [sn.element("code", {}, null, cd.id)]);
-                                                sn.element("td", { "class": "excCodeDesc" }, tr, [cd.description]);
-                                            }
-                                        }
-                                    }
-                                }
-                                // else {
-                                //     sn.element("div", {}, desc, [sn.element("em", {}, null, "No exceptions.")]);
-                                // }
-                            }
-                            else if (type == "constant") {
-                                sn.text(" of type ", dt);
-                                sn.element("span", { "class": "idlConstType" }, dt, [sn.element("a", {}, null, it.datatype)]);
-                                if (it.nullable) sn.text(", nullable", dt);
-                            }
-                        }
-                    }
-                    // Serializer
-                    else {
-                        var div = sn.element("div", {}, sec);
-                        var it = things[0];
-                        if (it.serializertype != "prose") {
-                            var generatedDescription = "Instances of this interface are serialized as ";
-                            if (it.serializertype == "map") {
-                                var mapDescription = "a map ";
-                                if (it.getter) {
-                                    mapDescription += "with entries corresponding to the named properties";
-                                }
-                                else {
-                                    var and = "";
-                                    if (it.inherit) {
-                                        mapDescription += "with entries from the closest inherited interface ";
-                                        and = "and ";
-                                    }
-                                    if (it.all) {
-                                        mapDescription += and + "with entries for each of the serializable attributes";
-                                    }
-                                    else if (it.values && it.values.length) {
-                                        mapDescription += and + "with entries for the following attributes: " + it.values.join(", ");
-                                    }
-                                    else {
-                                        mapDescription = "an empty map";
-                                    }
-                                }
-                                generatedDescription += mapDescription;
-                            }
-                            else if (it.serializertype == "list") {
-                                var listDescription = "a list ";
-                                if (it.getter) {
-                                    listDescription += "with values corresponding to the indexed properties";
-                                }
-                                else {
-                                    if (it.values && it.values.length) {
-                                        listDescription += "with the values of the following attributes: " + it.values.join(", ");
-                                    }
-                                    else {
-                                        listDescription = "an empty list";
-                                    }
-                                }
-                                generatedDescription += listDescription;
-                            }
-                            else if (it.serializertype == "attribute") {
-                                generatedDescription += "the value of the attribute " + it.values[0];
-                            }
-                            generatedDescription += ".";
-                            sn.element("p", {}, div, generatedDescription);
-                        }
-                        sn.element("p", {}, div, [it.description]);
-                    }
+                    this.writeTypeFilteredThingsInInterfaceAsHTML(obj, curLnk, sn.element("section", {}, df), type, things);
                 }
                 return df;
             },


### PR DESCRIPTION
WebIDLProcessor.prototype.writeAsHTML is very long. This change split the function, to make it easy to read and modify.
This is a preliminary change for https://github.com/w3c/respec/issues/361.