### PR TITLE
Add maplike support.

### DIFF
--- a/js/core/css/webidl-oldschool.css
+++ b/js/core/css/webidl-oldschool.css
@@ -95,6 +95,11 @@ a.idlEnumItem {
     color: gray;
 }
 
+/*.idlMaplike*/
+.idlMaplikeKeyType, .idlMaplikeValueType {
+    color:  #005a9c;
+}
+
 /*.idlConst*/
 .idlConstType {
     color:  #005a9c;

--- a/js/core/templates/webidl/maplike.html
+++ b/js/core/templates/webidl/maplike.html
@@ -1,0 +1,2 @@
+<span class='idlMaplike'>{{extAttr obj indent true
+}}{{idn indent}}{{readonly}}maplike&lt;<span class='idlMaplikeKeyType'>{{datatype obj.key}}</span>, <span class='idlMaplikeValueType'>{{datatype obj.value}}</span>&gt;;</span>

--- a/tests/spec/core/webidl.html
+++ b/tests/spec/core/webidl.html
@@ -412,5 +412,19 @@
       </p>
       <div id='impl-less-basic' class='idl' title='[Something]Window implements Breakable'></div>
     </section>
+    <section>
+      <h2>maplike</h2>
+      <dl id="if-maplike" class="idl" title="interface SuperStar">
+        <dt>readonly maplike&lt;DOMString,SuperStar&gt;</dt>
+        <dd>This is a maplike interface whose key is hoge and value is fuga.</dd>
+      </dl>
+    </section>
+    <section>
+      <h2>readonly maplike</h2>
+      <dl id="if-maplike" class="idl" title="interface SuperStar">
+        <dt>readonly maplike&lt;DOMString,SuperStar&gt;</dt>
+        <dd>This is a readonly maplike interface whose value is a SuperStar instance and key is its ID.</dd>
+      </dl>
+    </section>
   </body>
 </html>


### PR DESCRIPTION
This change add support for "[readonly] maplike<K, V>;" in an interface as
the grammar is recently added to WebIDL. #361