### PR TITLE
Fetch specref.jit.su over HTTPS

### DIFF
--- a/js/core/biblio.js
+++ b/js/core/biblio.js
@@ -150,7 +150,7 @@ define(
                                 .concat(refs.informativeReferences)
                                 .concat(localAliases);
                 if (refs.length) {
-                    var url = "http://specref.jit.su/bibrefs?refs=" + refs.join(",");
+                    var url = "https://specref.jit.su/bibrefs?refs=" + refs.join(",");
                     $.ajax({
                         dataType:   "json"
                     ,   url:        url


### PR DESCRIPTION
See https://webbluetoothcg.github.io/web-bluetooth/ for a spec broken by this issue, with the error message:

> Mixed Content: The page at 'https://webbluetoothcg.github.io/web-bluetooth/' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://specref.jit.su/bibrefs?refs=RFC4122,BLUETOOTH41,BLUETOOTH-ASSIGNED-B…BLUETOOTH-ASSIGNED,BLUETOOTH-SUPPLEMENT4,dom,HTML,powerful-features,WebIDL'. This request has been blocked; the content must be served over HTTPS.