### PR TITLE
Add UI to show a list of definitions.

### DIFF
--- a/js/profile-w3c-common.js
+++ b/js/profile-w3c-common.js
@@ -58,6 +58,7 @@ define([
             domReady(function () {
                 ui.addCommand("Save Snapshot", "ui/save-html", "Ctrl+Shift+Alt+S");
                 ui.addCommand("About ReSpec", "ui/about-respec", "Ctrl+Shift+Alt+A");
+                ui.addCommand("Definition List", "ui/dfn-list", "Ctrl+Shift+Alt+D");
                 ui.addCommand("Search Specref DB", "ui/search-specref", "Ctrl+Shift+Alt+space");
                 runner.runAll(args);
             });

--- a/js/ui/dfn-list.js
+++ b/js/ui/dfn-list.js
@@ -1,16 +1,21 @@
 
-// Module ui/about-respec
-// A simple about dialogue with pointer to the help
-
+// Module ui/dfn-list
+// Displays all definitions with links to the defining element.
 define(
     ["jquery"],
     function ($) {
         return {
             show:   function (ui, _conf) {
-                var $halp = $("<dl></dl>");
+                var $halp = $("<ul></ul>");
                 Object.keys(_conf.definitionMap).sort().forEach(function(title) {
                     _conf.definitionMap[title].forEach(function(dfn) {
-                      $("<li>" + title + "</li>").appendTo($halp);
+                      // Link to definition
+                      var $link = $("<a>" + title + "</a>")
+                        .attr("href", "#" + dfn.attr("id"))
+                        .click(function () {
+                          ui.closeModal();
+                      });
+                      ($("<li></li>").append($link)).appendTo($halp);
                     });
                 });
 

--- a/js/ui/dfn-list.js
+++ b/js/ui/dfn-list.js
@@ -1,0 +1,21 @@
+
+// Module ui/about-respec
+// A simple about dialogue with pointer to the help
+
+define(
+    ["jquery"],
+    function ($) {
+        return {
+            show:   function (ui, _conf) {
+                var $halp = $("<dl></dl>");
+                Object.keys(_conf.definitionMap).sort().forEach(function(title) {
+                    _conf.definitionMap[title].forEach(function(dfn) {
+                      $("<li>" + title + "</li>").appendTo($halp);
+                    });
+                });
+
+                ui.freshModal("List of Definitions", $halp);
+            }
+        };
+    }
+);


### PR DESCRIPTION
This is a simplistic implementation to add a UI component to show a list of definitions from the document.

I suspect that there will be scrolling issues in the modal, and it would be nice to link to the source of the definition, but this likely requires some magic I'm not familiar with to get out of the model and relocate to the definition.

I've often lost track of all of the definitions in a document, or need a way to find definitions in some other companion document for which I might not be an editor, so having a UI to provide a quick reference to definitions may be more generally useful. Of course, there could also be a "Table of Definitions" which could be added to the document, similar to a table of figures or the table of contents, but this would not be commonly used, as it's mostly useful for spec writers, not end users.