### PR TITLE
Changed header numbering logic

### DIFF
--- a/js/core/fix-headers.js
+++ b/js/core/fix-headers.js
@@ -10,13 +10,16 @@ define(
         return {
             run:    function (conf, doc, cb, msg) {
                 msg.pub("start", "core/fix-headers");
-                var $secs = $("section:not(.introductory)", doc)
-                                .find("h1:first, h2:first, h3:first, h4:first, h5:first, h6:first");
-                $secs.each(function () {
-                    var depth = $(this).parents("section").length + 1;
-                    if (depth > 6) depth = 6;
-                    var h = "h" + depth;
-                    if (this.localName.toLowerCase() !== h) $(this).renameElement(h);
+                var $secs = $(doc).find("section");
+                $secs.each(function(i, item) {
+                    var $items = $(item).find("h1:first, h2:first, h3:first, h4:first, h5:first, h6:first");
+                    if ($items.length) {
+                        var $item = $($items[0]) ;
+                        var depth = $item.parents("section").length + 1;
+                        if (depth > 6) depth = 6;
+                        var h = "h" + depth;
+                        if (! $item.is(h)) $item.renameElement(h);
+                    }
                 });
                 msg.pub("end", "core/fix-headers");
                 cb();

--- a/js/core/structure.js
+++ b/js/core/structure.js
@@ -91,12 +91,6 @@ define(
                     }
                 ;
                 if (!$secs.length) return finish();
-                $secs.each(function () {
-                    var depth = $(this).parents("section").length + 1;
-                    if (depth > 6) depth = 6;
-                    var h = "h" + depth;
-                    if (this.localName.toLowerCase() != h) $(this).renameElement(h);
-                });
 
                 // makeTOC
                 if (!conf.noTOC) {

--- a/tests/spec/core/fix-headers-spec.js
+++ b/tests/spec/core/fix-headers-spec.js
@@ -9,14 +9,14 @@ describe("Core - Fix headers", function () {
         runs(function () {
             makeRSDoc({ config: basicConfig,
                         body: "<section id='turtles'><h1>ONE</h1><section><h1>TWO</h1><section><h1>THREE</h1><section><h1>FOUR</h1>" +
-                              "<section><h1>FIVE</h1><section><h1>SIX</h1></section></section></section></section></section></section>"
+                              "<section><h1>FIVE</h1><section><h1>SIX</h1><h2>SUBHEADING</h2></section></section></section></section></section></section>"
                     }, function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);
         runs(function () {
             var $s = $("#turtles", doc);
             expect($s.find("h1").length).toEqual(0);
-            expect($s.find("h2").length).toEqual(1);
+            expect($s.find("h2").length).toEqual(2);    // there is an explicit h2 later
             expect($s.find("h2").text()).toMatch(/ONE/);
             expect($s.find("h2 > span").attr('resource')).toEqual('xhv:heading');
             expect($s.find("h2 > span").attr('property')).toEqual('xhv:role');
@@ -29,6 +29,7 @@ describe("Core - Fix headers", function () {
             expect($s.find("h6").length).toEqual(2);
             expect($s.find("h6").first().text()).toMatch(/FIVE/);
             expect($s.find("h6").last().text()).toMatch(/SIX/);
+            expect($s.find("h2").last().text()).toMatch(/SUBHEADING/);
             flushIframes();
         });
     });


### PR DESCRIPTION
Only the first heading within a section should be
renumbered to match depth.

Also, fix-headers.js and structure.js were doing the same
thing to the H elements.  I removed the duplicate code from
structure.js since it was redundant.

This fixes Issue #419.