### PR TITLE
Support required dictionary members in contiguous-idl mode.

### DIFF
--- a/js/core/templates/webidl-contiguous/dict-member.html
+++ b/js/core/templates/webidl-contiguous/dict-member.html
@@ -1,4 +1,4 @@
 <span class='idlMember' id="{{obj.idlId}}">{{extAttr obj indent
-}}{{idn indent}}<span class='idlMemberType'>{{idlType obj}}</span> {{pads pad
+}}{{idn indent}}{{qualifiers}}<span class='idlMemberType'>{{idlType obj}}</span> {{pads typePad
 }}<span class='idlMemberName'>{{#tryLink obj}}{{obj.name}}{{/tryLink}}</span>{{#if obj.default
 }} = <span class='idlMemberValue'>{{stringifyIdlConst obj.default}}</span>{{/if}};</span>

--- a/js/webidl2.js
+++ b/js/webidl2.js
@@ -758,15 +758,19 @@
                 }
                 var ea = extended_attrs(store ? mems : null);
                 all_ws(store ? mems : null, "pea");
+                var required = consume(ID, "required");
                 var typ = type() || error("No type for dictionary member");
                 all_ws();
                 var name = consume(ID) || error("No name for dictionary member");
+                var dflt = default_();
+                if (required && dflt) error("Required member must not have a default");
                 ret.members.push({
                     type:       "field"
                 ,   name:       name.value
+                ,   required:   !!required
                 ,   idlType:    typ
                 ,   extAttrs:   ea
-                ,   "default":  default_()
+                ,   "default":  dflt
                 });
                 all_ws();
                 consume(OTHER, ";") || error("Unterminated dictionary member");
@@ -937,5 +941,5 @@
     };
 
     if (inNode) module.exports = obj;
-    else        window.WebIDL2 = obj;
+    else        self.WebIDL2 = obj;
 }());

--- a/tests/spec/core/webidl-contiguous-spec.js
+++ b/tests/spec/core/webidl-contiguous-spec.js
@@ -313,6 +313,13 @@ describe("Core - Contiguous WebIDL", function () {
         expect($mem.find(".idlMemberName").text()).toEqual("value");
         expect($target.find(".idlMember").last().find(".idlMemberValue").text()).toEqual('"blah blah"');
 
+        $target = $("#dict-required-fields", doc);
+        text =  "dictionary SuperStar {\n" +
+                "    required DOMString value;\n" +
+                "             DOMString optValue;\n" +
+                "};";
+        expect($target.text()).toEqual(text);
+
         // Links and IDs.
         $target = $("#dict-doc", doc);
         expect($target.find(":contains('DictDocTest')").filter("a").attr("href")).toEqual("#dom-dictdoctest");

--- a/tests/spec/core/webidl-contiguous.html
+++ b/tests/spec/core/webidl-contiguous.html
@@ -332,6 +332,12 @@
           DOMString blah = "blah blah";
         };
       </pre>
+      <pre id='dict-required-fields' class='idl'>
+        dictionary SuperStar {
+          required DOMString value;
+          DOMString optValue;
+        };
+      </pre>
       <pre id='dict-doc' class='idl'>
         dictionary DictDocTest {
           DOMString dictDocField;


### PR DESCRIPTION
This imports webidl2.js from darobin/webidl2.js#25, which hasn't been merged yet. We should probably wait to merge this PR until the current PRs from that repo have been accepted, and then re-import webidl2.js from there.

Also note @dontcallmedom's https://github.com/dontcallmedom/respec/commit/3bbe54f9adac0d72b962c836908f64901c80e9b9, which fixes this in oldschool mode. Since oldschool mode isn't deprecated yet, we should probably take both.