### PR TITLE
Avoid cloning nodes in issues and notes.

### DIFF
--- a/js/core/issues-notes.js
+++ b/js/core/issues-notes.js
@@ -72,8 +72,8 @@ define(
                                 $inno.removeAttr("title");
                             }
                             $div.append($tit);
-                            $div.append($inno.clone().removeClass(report.type).removeAttr('data-number'));
                             $inno.replaceWith($div);
+                            $div.append($inno.removeClass(report.type).removeAttr('data-number'));
                         }
                         msg.pub(report.type, report);
                     });

--- a/tests/spec/core/webidl-contiguous-spec.js
+++ b/tests/spec/core/webidl-contiguous-spec.js
@@ -3,6 +3,7 @@ describe("Core - Contiguous WebIDL", function () {
     ,   $widl = $("<iframe width='800' height='200' style='display: none' src='spec/core/webidl-contiguous.html'></iframe>")
     ,   loaded = false
     ,   $target
+    ,   $section
     ,   text
     ,   doc
     ;
@@ -451,5 +452,12 @@ describe("Core - Contiguous WebIDL", function () {
         $target = $("#impl-less-basic", doc);
         text = "[Something]\n" + text;
         expect($target.text()).toEqual(text);
+    });
+
+    it("should link documentation", function() {
+        $section = $("#documentation", doc);
+        $target = $("#doc-iface", doc);
+        expect($target.find(".idlAttrName:contains('docString') a").attr("href")).toEqual("#dom-documented-docstring");
+        expect($section.find("dfn:contains('docString')").attr("id")).toEqual("dom-documented-docstring");
     });
 });

--- a/tests/spec/core/webidl-contiguous.html
+++ b/tests/spec/core/webidl-contiguous.html
@@ -454,5 +454,16 @@
         [Something]Window implements Breakable;
       </pre>
     </section>
+    <section id="documentation">
+      <h2>Documentation</h2>
+      <pre id='doc-iface' class='idl'>
+        interface Documented {
+          attribute DOMString docString;
+        };
+      </pre>
+      <p class='note' dfn-for="Documented">
+        <dfn>docString</dfn> is defined in a note.
+      </p>
+    </section>
   </body>
 </html>


### PR DESCRIPTION
Cloning the nodes breaks references in conf.definitionMap, so the <dfn>s that
link-to-dfn.js assigns IDs weren't the ones that actually wind up in the result
document.