### PR TITLE
Improve linking to and around WebIDL terms

### DIFF
--- a/js/core/link-to-dfn.js
+++ b/js/core/link-to-dfn.js
@@ -34,7 +34,12 @@ define(
                     var title = $ant.dfnTitle();
                     var link_for = ($ant.attr("for") || $ant.closest("[link-for]").attr("link-for") || "").toLowerCase();
                     if (titles[title] && titles[title][link_for]) {
+                        // Use an IDL, scoped definition if possible.
                         $ant.attr("href", "#" + titles[title][link_for].prop("id")).addClass("internalDFN");
+                    }
+                    else if (titles[title] && titles[title][""]) {
+                        // Use the global definition otherwise.
+                        $ant.attr("href", "#" + titles[title][""].prop("id")).addClass("internalDFN");
                     }
                     else {
                         // ignore WebIDL

--- a/js/core/link-to-dfn.js
+++ b/js/core/link-to-dfn.js
@@ -18,33 +18,49 @@ define(
                         }
                         var dfn_for = dfn.attr('data-dfn-for') || "";
                         if (dfn_for in titles[title]) {
-                            msg.pub("error", "Duplicate definition of '" + (dfn_for ? dfn_for + "/" : "") + title + "'");
+                            // We want <dfn> definitions to take precedence over
+                            // definitions from WebIDL. WebIDL definitions wind
+                            // up as <span>s instead of <dfn>.
+                            var oldIsDfn = titles[title][dfn_for].filter('dfn').length !== 0;
+                            var newIsDfn = dfn.filter('dfn').length !== 0;
+                            if (oldIsDfn && newIsDfn) {
+                                // Only complain if the user provides 2 <dfn>s
+                                // for the same term.
+                                msg.pub("error", "Duplicate definition of '" + (dfn_for ? dfn_for + "/" : "") + title + "'");
+                            }
+                            if (oldIsDfn) {
+                                // Don't overwrite <dfn> definitions.
+                                return;
+                            }
                         }
                         titles[title][dfn_for] = dfn;
-                        if (dfn.attr('data-idl')) {
-                            dfn.makeID("dom", (dfn_for ? dfn_for + "-" : "") + title);
-                        } else {
-                            dfn.makeID("dfn", title);
+                        if (dfn.attr('id') === undefined) {
+                            if (dfn.attr('data-idl')) {
+                                dfn.makeID("dom", (dfn_for ? dfn_for + "-" : "") + title);
+                            } else {
+                                dfn.makeID("dfn", title);
+                            }
                         }
                     });
                 });
                 $("a:not([href])").each(function () {
                     var $ant = $(this);
                     if ($ant.hasClass("externalDFN")) return;
-                    var title = $ant.dfnTitle();
-                    var link_for = ($ant.attr("for") || $ant.closest("[link-for]").attr("link-for") || "").toLowerCase();
-                    if (titles[title] && titles[title][link_for]) {
-                        // Use an IDL, scoped definition if possible.
-                        $ant.attr("href", "#" + titles[title][link_for].prop("id")).addClass("internalDFN");
-                    }
-                    else if (titles[title] && titles[title][""]) {
-                        // Use the global definition otherwise.
-                        $ant.attr("href", "#" + titles[title][""].prop("id")).addClass("internalDFN");
-                    }
-                    else {
+                    var linkTargets = $ant.linkTargets();
+                    var foundDfn = linkTargets.some(function(target) {
+                        if (titles[target.title] && titles[target.title][target.for_]) {
+                            var dfn = titles[target.title][target.for_];
+                            $ant.attr("href", "#" + dfn.prop("id")).addClass("internalDFN");
+                            return true;
+                        }
+                        return false;
+                    });
+                    if (!foundDfn) {
                         // ignore WebIDL
                         if (!$ant.parents(".idl, dl.methods, dl.attributes, dl.constants, dl.constructors, dl.fields, dl.dictionary-members, span.idlMemberType, span.idlTypedefType, div.idlImplementsDesc").length) {
-                            msg.pub("warn", "Found linkless <a> element with text '" + (link_for ? link_for + "/" : "") + title + "' but no matching <dfn>.");
+                            var link_for = linkTargets[0].for_;
+                            var title = linkTargets[0].title;
+                            msg.pub("warn", "Found linkless <a> element " + (link_for ? "for '" + link_for + "' " : "") + "with text '" + title + "' but no matching <dfn>.");
                         }
                         $ant.replaceWith($ant.contents());
                     }

--- a/js/core/link-to-dfn.js
+++ b/js/core/link-to-dfn.js
@@ -51,6 +51,16 @@ define(
                         if (titles[target.title] && titles[target.title][target.for_]) {
                             var dfn = titles[target.title][target.for_];
                             $ant.attr("href", "#" + dfn.prop("id")).addClass("internalDFN");
+                            // If a definition is <code>, links to it should
+                            // also be <code>.
+                            //
+                            // Note that contents().length===1 excludes
+                            // definitions that have either other text, or other
+                            // whitespace, inside the <dfn>.
+                            if (dfn.closest('code,pre').length ||
+                                (dfn.contents().length === 1 && dfn.children('code').length === 1)) {
+                                $ant.wrapInner('<code></code>');
+                            }
                             return true;
                         }
                         return false;

--- a/js/core/templates/webidl-contiguous/attribute.html
+++ b/js/core/templates/webidl-contiguous/attribute.html
@@ -1,3 +1,3 @@
-<span class='idlAttribute' id="{{obj.idlId}}">{{extAttr obj indent
+<span class='idlAttribute' id="{{obj.idlId}}" data-idl data-title='{{obj.name}}'>{{extAttr obj indent
 }}{{idn indent}}{{qualifiers}} attribute <span class='idlAttrType'>{{idlType obj}}</span> {{pads
 pad}}<span class='idlAttrName'>{{#tryLink obj}}{{escapeAttributeName obj.name}}{{/tryLink}}</span>;</span>

--- a/js/core/templates/webidl-contiguous/callback.html
+++ b/js/core/templates/webidl-contiguous/callback.html
@@ -1,3 +1,3 @@
-<span class='idlCallback' id='{{obj.idlId}}'>{{extAttr obj indent
+<span class='idlCallback' id='{{obj.idlId}}' data-idl data-title='{{obj.name}}'>{{extAttr obj indent
 }}{{idn indent}}callback <span class='idlCallbackID'>{{#tryLink obj}}{{obj.name
 }}{{/tryLink}}</span> = <span class='idlCallbackType'>{{idlType obj}}</span> ({{{children}}});</span>

--- a/js/core/templates/webidl-contiguous/const.html
+++ b/js/core/templates/webidl-contiguous/const.html
@@ -1,4 +1,4 @@
-<span class='idlConst' id="{{obj.idlId}}">{{extAttr obj indent
+<span class='idlConst' id="{{obj.idlId}}" data-idl data-title='{{obj.name}}'>{{extAttr obj indent
 }}{{idn indent}}const <span class='idlConstType'>{{idlType obj}}</span>{{nullable}} {{pads pad
 }}<span class='idlConstName'>{{#tryLink obj}}{{obj.name
 }}{{/tryLink}}</span> = <span class='idlConstValue'>{{stringifyIdlConst obj.value}}</span>;</span>

--- a/js/core/templates/webidl-contiguous/dict-member.html
+++ b/js/core/templates/webidl-contiguous/dict-member.html
@@ -1,4 +1,4 @@
-<span class='idlMember' id="{{obj.idlId}}">{{extAttr obj indent
+<span class='idlMember' id="{{obj.idlId}}" data-idl data-title='{{obj.name}}'>{{extAttr obj indent
 }}{{idn indent}}{{qualifiers}}<span class='idlMemberType'>{{idlType obj}}</span> {{pads typePad
 }}<span class='idlMemberName'>{{#tryLink obj}}{{obj.name}}{{/tryLink}}</span>{{#if obj.default
 }} = <span class='idlMemberValue'>{{stringifyIdlConst obj.default}}</span>{{/if}};</span>

--- a/js/core/templates/webidl-contiguous/dictionary.html
+++ b/js/core/templates/webidl-contiguous/dictionary.html
@@ -1,4 +1,4 @@
-<span class='idlDictionary' id='{{obj.idlId}}'>{{extAttr obj indent
+<span class='idlDictionary' id='{{obj.idlId}}' data-idl data-title='{{obj.name}}'>{{extAttr obj indent
 }}{{idn indent}}{{partial}}dictionary <span class='idlDictionaryID'>{{#tryLink obj}}{{obj.name}}{{/tryLink
 }}</span>{{#if obj.inheritance}} : <span class='idlSuperclass'><a>{{obj.inheritance}}</a></span>{{/if}} {
 {{{children}}}};</span>

--- a/js/core/templates/webidl-contiguous/enum.html
+++ b/js/core/templates/webidl-contiguous/enum.html
@@ -1,3 +1,3 @@
-<span class='idlEnum' id='{{obj.idlId}}'>{{extAttr obj indent
+<span class='idlEnum' id='{{obj.idlId}}' data-idl data-title='{{obj.name}}'>{{extAttr obj indent
 }}{{idn indent}}enum <span class='idlEnumID'>{{#tryLink obj}}{{obj.name}}{{/tryLink}}</span> {
 {{{children}}}{{idn indent}}}};

--- a/js/core/templates/webidl-contiguous/enum.html
+++ b/js/core/templates/webidl-contiguous/enum.html
@@ -1,3 +1,3 @@
 <span class='idlEnum' id='{{obj.idlId}}' data-idl data-title='{{obj.name}}'>{{extAttr obj indent
 }}{{idn indent}}enum <span class='idlEnumID'>{{#tryLink obj}}{{obj.name}}{{/tryLink}}</span> {
-{{{children}}}{{idn indent}}}};
+{{{children}}}{{idn indent}}}};</span>

--- a/js/core/templates/webidl-contiguous/exception.html
+++ b/js/core/templates/webidl-contiguous/exception.html
@@ -1,4 +1,4 @@
-<span class='idlException' id='{{obj.idlId}}'>{{extAttr obj indent
+<span class='idlException' id='{{obj.idlId}}' data-idl data-title='{{obj.name}}'>{{extAttr obj indent
 }}{{idn indent}}exception <span class='idlExceptionID'>{{#tryLink obj}}{{obj.name}}{{/tryLink
 }}</span>{{#if obj.inheritance}} : <span class='idlSuperclass'><a>{{obj.inheritance}}</a></span>{{/if}} {
 {{{children}}}{{idn indent}}}};</span>

--- a/js/core/templates/webidl-contiguous/field.html
+++ b/js/core/templates/webidl-contiguous/field.html
@@ -1,3 +1,3 @@
-<span class='idlField' id="{{obj.idlId}}">{{extAttr obj indent
+<span class='idlField' id="{{obj.idlId}}" data-idl data-title='{{obj.name}}'>{{extAttr obj indent
 }}{{idn indent}}<span class='idlFieldType'>{{idlType obj}}</span> {{pads
 pad}}<span class='idlFieldName'>{{#tryLink obj}}{{obj.name}}{{/tryLink}}</span>;</span>

--- a/js/core/templates/webidl-contiguous/interface.html
+++ b/js/core/templates/webidl-contiguous/interface.html
@@ -1,4 +1,4 @@
-<span class='idlInterface' id='{{obj.idlId}}'>{{extAttr obj indent
+<span class='idlInterface' id='{{obj.idlId}}' data-idl data-title='{{obj.name}}'>{{extAttr obj indent
 }}{{idn indent}}{{partial}}{{callback}}interface <span class='idlInterfaceID'>{{#tryLink obj}}{{obj.name}}{{/tryLink
 }}</span>{{#if obj.inheritance}} : <span class='idlSuperclass'><a>{{obj.inheritance}}</a></span>{{/if}} {
 {{{children}}}{{idn indent}}}};</span>

--- a/js/core/templates/webidl-contiguous/method.html
+++ b/js/core/templates/webidl-contiguous/method.html
@@ -1,3 +1,3 @@
-<span class='idlMethod' id="{{obj.idlId}}">{{extAttr obj indent
+<span class='idlMethod' id="{{obj.idlId}}" data-idl data-title='{{obj.name}}'>{{extAttr obj indent
 }}{{idn indent}}{{static}}{{special}}<span class='idlMethType'>{{idlType obj}}</span> {{pads pad
 }}<span class='idlMethName'>{{#tryLink obj}}{{obj.name}}{{/tryLink}}</span>({{{children}}});</span>

--- a/js/core/templates/webidl-contiguous/serializer.html
+++ b/js/core/templates/webidl-contiguous/serializer.html
@@ -1,3 +1,3 @@
-<span class='idlSerializer' id="{{obj.idlId}}">{{extAttr obj indent
+<span class='idlSerializer' id="{{obj.idlId}}" data-idl data-title='serializer'>{{extAttr obj indent
 }}{{idn indent}}{{#tryLink obj}}serializer{{/tryLink
 }}{{#if values}} = <span class='idlSerializerValues'>{{values}}</span>{{/if}};</span>

--- a/js/core/templates/webidl-contiguous/typedef.html
+++ b/js/core/templates/webidl-contiguous/typedef.html
@@ -1,3 +1,3 @@
-<span class='idlTypedef' id='{{obj.idlId}}'>typedef {{typeExtAttrs obj
+<span class='idlTypedef' id='{{obj.idlId}}' data-idl data-title='{{obj.name}}'>typedef {{typeExtAttrs obj
 }}<span class='idlTypedefType'>{{idlType obj
 }}</span> <span class='idlTypedefID'>{{#tryLink obj}}{{obj.name}}{{/tryLink}}</span>;</span>

--- a/js/core/utils.js
+++ b/js/core/utils.js
@@ -38,6 +38,31 @@ define(
             return title.toLowerCase().replace(/^\s+/, "").replace(/\s+$/, "").split(/\s+/).join(" ");
         };
 
+        // For any element (usually <a>), returns an array of targets that
+        // element might refer to, of the form
+        // {for_: 'interfacename', title: 'membername'}.
+        //
+        // For an element like:
+        //  <p link-for="Int1"><a for="Int2">Int3.member</a></p>
+        // we'll return:
+        //  * {for_: "int2", title: "int3.member"}
+        //  * {for_: "int3", title: "member"}
+        //  * {for_: "", title: "int3.member"}
+        $.fn.linkTargets = function () {
+            var elem = this;
+            var link_for = (elem.attr("for") || elem.closest("[link-for]").attr("link-for") || "").toLowerCase();
+            var title = elem.dfnTitle();
+            var result = [{for_: link_for, title: title}];
+            var split = title.split('.');
+            if (split.length === 2) {
+                // If there are multiple '.'s, this won't match an
+                // Interface/member pair anyway.
+                result.push({for_: split[0], title: split[1]});
+            }
+            result.push({for_:"", title: title});
+            return result;
+        };
+
 
         // Applied to an element, sets an ID for it (and returns it), using a specific prefix
         // if provided, and a specific text if given.

--- a/js/core/webidl-contiguous.js
+++ b/js/core/webidl-contiguous.js
@@ -748,7 +748,8 @@ define(
                         .each(function() {
                             var elem = $(this);
                             var title = elem.attr('data-title').toLowerCase();
-                            var parent = elem.closest('.idlDictionary,.idlEnum,.idlException,.idlInterface');
+                            // Select the nearest ancestor element that can contain members.
+                            var parent = elem.parent().closest('.idlDictionary,.idlEnum,.idlException,.idlInterface');
                             if (parent.length) {
                                 elem.attr('data-dfn-for', parent.attr('data-title').toLowerCase());
                             }

--- a/js/core/webidl-contiguous.js
+++ b/js/core/webidl-contiguous.js
@@ -731,7 +731,7 @@ define(
                     $(doc).find("head link").first().before($("<style/>").text(css));
                 }
 
-                var infNames = [];
+                var idlNames = [];
                 $idl.each(function () {
                     var parse;
                     try {
@@ -744,22 +744,22 @@ define(
                     linkDefinitions(parse, conf.definitionMap, "", msg);
                     var $df = makeMarkup(parse, msg);
                     $df.attr({id: this.id});
-                    $.merge(infNames,
-                            $df.find('.idlInterface,.idlException,.idlDictionary,.idlTypedef,.idlCallback,.idlEnum')
-                               .map(function() { return this.id; }).get());
+                    $df.find('.idlAttribute,.idlCallback,.idlConst,.idlDictionary,.idlEnum,.idlException,.idlField,.idlInterface,.idlMember,.idlMethod,.idlSerializer,.idlTypedef')
+                        .each(function() {
+                            var elem = $(this);
+                            var title = elem.attr('data-title').toLowerCase();
+                            var parent = elem.closest('.idlDictionary,.idlEnum,.idlException,.idlInterface');
+                            if (parent.length) {
+                                elem.attr('data-dfn-for', parent.attr('data-title').toLowerCase());
+                            }
+                            if (!conf.definitionMap[title]) {
+                                conf.definitionMap[title] = [];
+                            }
+                            conf.definitionMap[title].push(elem);
+                        });
                     $(this).replaceWith($df);
                 });
                 doc.normalize();
-                $("a:not([href])").each(function () {
-                    var $ant = $(this);
-                    if ($ant.hasClass("externalDFN")) return;
-                    var name = $ant.dfnTitle();
-                    if (!conf.definitionMap[name] && $.inArray('idl-def-' + name, infNames) !== -1) {
-                        $ant.attr("href", "#idl-def-" + name)
-                            .addClass("idlType")
-                            .wrapInner("<code></code>");
-                    }
-                });
                 finish();
             }
         };

--- a/tests/spec/core/dfn-spec.js
+++ b/tests/spec/core/dfn-spec.js
@@ -18,4 +18,30 @@ describe("Core — Definitions", function () {
             flushIframes();
         });
     });
+    it("should make links <code> when their definitions are <code>", function () {
+        var doc;
+        runs(function () {
+            makeRSDoc({ config: basicConfig, body:
+                        $("<section id='dfn'>" +
+                            "<code><dfn>outerCode</dfn></code>" +
+                            "<pre><dfn>outerPre</dfn></pre>" +
+                            "<dfn><code>innerCode</code></dfn>" +
+                            "<dfn><code>partial</code> inner code</dfn>" +
+                            "<a>outerCode</a>" +
+                            "<a>outerPre</a>" +
+                            "<a>innerCode</a>" +
+                            "<a>partial inner code</a>" +
+                            "</section>") },
+                      function (rsdoc) { doc = rsdoc; });
+        });
+        waitsFor(function () { return doc; }, MAXOUT);
+        runs(function () {
+            var $sec = $("#dfn", doc);
+            expect($sec.find("a:contains('outerCode')").contents()[0].nodeName).toEqual("CODE");
+            expect($sec.find("a:contains('outerPre')").contents()[0].nodeName).toEqual("CODE");
+            expect($sec.find("a:contains('innerCode')").contents()[0].nodeName).toEqual("CODE");
+            expect($sec.find("a:contains('partial')").contents()[0].nodeName).toEqual("#text");
+            flushIframes();
+        });
+    });
 });

--- a/tests/spec/core/webidl-contiguous-spec.js
+++ b/tests/spec/core/webidl-contiguous-spec.js
@@ -479,5 +479,7 @@ describe("Core - Contiguous WebIDL", function () {
 
         var linkFromElsewhere = $section.find("a:contains('Documented.docString')");
         expect(linkFromElsewhere.attr('href')).toEqual('#dom-documented-docstring');
+
+        expect($section.find("#without-link-for a:contains('Documented')").attr("href")).toEqual("#idl-def-documented");
     });
 });

--- a/tests/spec/core/webidl-contiguous-spec.js
+++ b/tests/spec/core/webidl-contiguous-spec.js
@@ -474,5 +474,10 @@ describe("Core - Contiguous WebIDL", function () {
         var notDefinedAttr = $target.find(".idlAttribute:contains('notDefined')");
         expect(notDefinedAttr.find(".idlAttrName").length).toEqual(1);
         expect(notDefinedAttr.find(".idlAttrName").find('a').length).toEqual(0);
+        expect(notDefinedAttr.attr("id")).toEqual("idl-def-documented-notdefined");
+        expect($section.find("p[link-for] a:contains('notDefined')").attr("href")).toEqual("#idl-def-documented-notdefined");
+
+        var linkFromElsewhere = $section.find("a:contains('Documented.docString')");
+        expect(linkFromElsewhere.attr('href')).toEqual('#dom-documented-docstring');
     });
 });

--- a/tests/spec/core/webidl-contiguous-spec.js
+++ b/tests/spec/core/webidl-contiguous-spec.js
@@ -467,5 +467,12 @@ describe("Core - Contiguous WebIDL", function () {
         $target = $("#doc-iface", doc);
         expect($target.find(".idlAttrName:contains('docString') a").attr("href")).toEqual("#dom-documented-docstring");
         expect($section.find("dfn:contains('docString')").attr("id")).toEqual("dom-documented-docstring");
+
+        expect($section.find("dfn:contains('Some generic term')").attr("id")).toEqual("dfn-some-generic-term");
+        expect($section.find("a:contains('Some generic term')").attr("href")).toEqual("#dfn-some-generic-term");
+        expect($section.find("p[link-for] a:contains('docString')").attr("href")).toEqual("#dom-documented-docstring");
+        var notDefinedAttr = $target.find(".idlAttribute:contains('notDefined')");
+        expect(notDefinedAttr.find(".idlAttrName").length).toEqual(1);
+        expect(notDefinedAttr.find(".idlAttrName").find('a').length).toEqual(0);
     });
 });

--- a/tests/spec/core/webidl-contiguous.html
+++ b/tests/spec/core/webidl-contiguous.html
@@ -474,6 +474,10 @@
       <p>
         <a>Documented.docString</a> is linked by writing its fully-qualified name.
       </p>
+      <p id="without-link-for">
+        We had a bug where <a>Documented</a> got a [dfn-for] attribute,
+        which broke links to it without [link-for].
+      </p>
     </section>
   </body>
 </html>

--- a/tests/spec/core/webidl-contiguous.html
+++ b/tests/spec/core/webidl-contiguous.html
@@ -471,6 +471,9 @@
         <a>docString</a> is.
         <a>notDefined</a> is too, but isn't defined elsewhere.
       </p>
+      <p>
+        <a>Documented.docString</a> is linked by writing its fully-qualified name.
+      </p>
     </section>
   </body>
 </html>

--- a/tests/spec/core/webidl-contiguous.html
+++ b/tests/spec/core/webidl-contiguous.html
@@ -458,10 +458,18 @@
       <pre id='doc-iface' class='idl'>
         interface Documented {
           attribute DOMString docString;
+          attribute DOMString notDefined;
         };
       </pre>
       <p class='note' dfn-for="Documented">
         <dfn>docString</dfn> is defined in a note.
+      </p>
+      <p link-for="Documented">
+        Testing <code>[link-for]</code>:
+        <dfn>Some generic term</dfn> isn't IDL.
+        <a>Some generic term</a> also isn't part of <a>Documented</a>.
+        <a>docString</a> is.
+        <a>notDefined</a> is too, but isn't defined elsewhere.
       </p>
     </section>
   </body>


### PR DESCRIPTION
* `[link-for]` used to break non-IDL links in its scope.
* It was difficult to link to members when their interface wasn't immediately obvious. Now `<a>Interface.member</a>` works.
* Now links point to declarations if no definition is available.
* Any `<code>` definition now causes its links to also be `<code>`.

This builds on #432.