### PR TITLE
Fixed header pollution from permalinks

### DIFF
--- a/js/w3c/permalinks.js
+++ b/js/w3c/permalinks.js
@@ -45,16 +45,18 @@ define(
                             // if we still have resourceID
                             if (resourceID != null) {
                                 // we have an id.  add a permalink
+                                $item.addClass("permalink");
+                                $item.wrap("<div></div>") ;
                                 // right after the h* element
-                                var theNode = $("<span></span>");
+                                var theNode = $("<p></p>");
                                 theNode.attr('class', 'permalink');
                                 if (conf.doRDFa) theNode.attr('typeof', 'bookmark');
                                 var ctext = $item.text();
                                 var el = $("<a></a>");
                                 el.attr({
                                     href:         '#' + resourceID,
-                                    'aria-label': 'Permalink for ' + ctext,
-                                    title:        'Permalink for ' + ctext });
+                                    'aria-label': ctext + " permalink",
+                                    title:        ctext + " permalink" });
                                 if (conf.doRDFa) el.attr('property', 'url');
                                 var sym = $("<span></span>");
                                 if (conf.doRDFa) {
@@ -66,14 +68,7 @@ define(
                                 el.append(sym);
                                 theNode.append(el);
 
-                                // if this is not being put at
-                                // page edge, then separate it
-                                // from the heading with a
-                                // non-breaking space
-                                if (!conf.permalinkEdge) {
-                                   $item.append("&nbsp;");
-                                }
-                                $item.append(theNode);
+                                $item.parent().append(theNode);
                             }
                         }
                     });

--- a/js/w3c/templates/permalinks.css
+++ b/js/w3c/templates/permalinks.css
@@ -1,9 +1,13 @@
 /* --- PERMALINKS --- */
 {{#if permalinkHide}}
-section > *:hover > span.permalink { visibility: visible; }
+section > *:hover > p.permalink { visibility: visible; } 
 {{/if}}
 
-.permalink {
+h2.permalink, h3.permalink, h4.permalink, h5.permalink, h6.permalink {
+    display:inline;
+}
+
+p.permalink {
     width: 1px;
     height: 1px;
     overflow: visible;
@@ -11,6 +15,7 @@ section > *:hover > span.permalink { visibility: visible; }
     font-style: normal;
     vertical-align: middle;
     margin-left: 4px;
+    display: inline;
     {{#if permalinkEdge}}
 	float: right;
     {{/if}}

--- a/tests/spec/w3c/permalinks-spec.js
+++ b/tests/spec/w3c/permalinks-spec.js
@@ -70,7 +70,7 @@ describe("W3C — Permalinks", function () {
             expect(list.length).toEqual(0);
             $c = $("#testing", doc);
             list = $(".permalink", $c) ;
-            expect(list.length).toEqual(1);
+            expect(list.length).toEqual(2);
             flushIframes();
         });
     });
@@ -87,7 +87,7 @@ describe("W3C — Permalinks", function () {
             expect(list.length).toEqual(0);
             $c = $("#testing", doc);
             list = $(".permalink", $c) ;
-            expect(list.length).toEqual(1);
+            expect(list.length).toEqual(2);
             flushIframes();
         });
     });
@@ -146,25 +146,10 @@ describe("W3C — Permalinks", function () {
         waitsFor(function () { return doc; }, MAXOUT);
         runs(function () {
             var $c = $("#testing", doc);
-            var list = $("span.permalink a span", $c) ;
+            var list = $("p.permalink a span", $c) ;
             expect(list.length).toEqual(1);
             expect($(list[0]).attr("content")).toMatch(/'/);
             expect($(list[0]).attr("content")).toMatch(/"/);
-            flushIframes();
-        });
-    });
-    it("permalinks not on edge will have non-breaking space after heading", function () {
-        var doc;
-        runs(function () {
-            makeRSDoc({ config: basicConfig, body: $("<section class='introductory' id='sotd'>Some unique SOTD content</section><div id='testing'><h2>a heading with "+'"'+" and '</h2><p>some content</p></div>") },
-                      function (rsdoc) { doc = rsdoc; });
-        });
-        waitsFor(function () { return doc; }, MAXOUT);
-        runs(function () {
-            var $c = $("#testing", doc);
-            var list = $("h2", $c) ;
-            expect(list.length).toEqual(1);
-            expect(list[0].innerHTML).toMatch(/&nbsp;/);
             flushIframes();
         });
     });


### PR DESCRIPTION
hN elements were having permalink data included within them.  This made
them less accessible for people with screen readers.

In addition, the permalink label / title was such that it was difficult
to use assistive technology and keyboard shortcuts to navigate the links
to find a specific section.

The changes in this branch address the issues raised in #425