### PR TITLE
Let people write `<dfn>dotted.name</dfn>` to define IDL members.

### DIFF
--- a/js/core/webidl-contiguous.js
+++ b/js/core/webidl-contiguous.js
@@ -684,7 +684,7 @@ define(
         // When a matching <dfn> is found, it's given <code> formatting,
         // marked as an IDL definition, and returned.  If no <dfn> is found,
         // the function returns 'undefined'.
-        function findDfn(parent, name, definitionMap) {
+        function findDfn(parent, name, definitionMap, msg) {
             parent = parent.toLowerCase();
             name = name.toLowerCase();
             var dfnForArray = definitionMap[name];
@@ -719,7 +719,7 @@ define(
                 }
             }
             if (dfns.length > 1) {
-                msg.pub("error", "Multiple <dfn>s for " + name + " in " + parent);
+                msg.pub("error", "Multiple <dfn>s for " + name + (parent ? " in " + parent : ""));
             }
             if (dfns.length === 0) {
                 return undefined;

--- a/js/core/webidl-contiguous.js
+++ b/js/core/webidl-contiguous.js
@@ -688,18 +688,35 @@ define(
             parent = parent.toLowerCase();
             name = name.toLowerCase();
             var dfnForArray = definitionMap[name];
-            if (!dfnForArray) {
-                return undefined;
+            var dfns = [];
+            if (dfnForArray) {
+                // Definitions that have a title and [for] that exactly match the
+                // IDL entity:
+                dfns = dfnForArray.filter(function(dfn) {
+                    return dfn.attr('data-dfn-for') === parent;
+                });
+                // If this is a top-level entity, and we didn't find anything with
+                // an explicitly empty [for], try <dfn> that inherited a [for].
+                if (dfns.length === 0 && parent === "" && dfnForArray.length === 1) {
+                    dfns = dfnForArray;
+                }
             }
-            // Definitions that have a title and [for] that exactly match the
-            // IDL entity:
-            var dfns = dfnForArray.filter(function(dfn) {
-                return dfn.attr('data-dfn-for') === parent;
-            });
-            // If this is a top-level entity, and we didn't find anything with
-            // an explicitly empty [for], try <dfn> that inherited a [for].
-            if (dfns.length === 0 && parent === "" && dfnForArray.length === 1) {
-                var dfns = dfnForArray;
+            // If we haven't found any definitions with explicit [for]
+            // and [title], look for a dotted definition, "parent.name".
+            if (dfns.length === 0 && parent !== "") {
+                var dottedName = parent + '.' + name;
+                dfnForArray = definitionMap[dottedName];
+                if (dfnForArray !== undefined && dfnForArray.length === 1) {
+                    dfns = dfnForArray;
+                    // Found it: update the definition to specify its [for] and title.
+                    delete definitionMap[dottedName];
+                    dfns[0].attr('data-dfn-for', parent);
+                    dfns[0].attr('title', name);
+                    if (definitionMap[name] === undefined) {
+                        definitionMap[name] = [];
+                    }
+                    definitionMap[name].push(dfns[0]);
+                }
             }
             if (dfns.length > 1) {
                 msg.pub("error", "Multiple <dfn>s for " + name + " in " + parent);

--- a/tests/spec/core/webidl-contiguous-spec.js
+++ b/tests/spec/core/webidl-contiguous-spec.js
@@ -477,7 +477,10 @@ describe("Core - Contiguous WebIDL", function () {
         expect(notDefinedAttr.attr("id")).toEqual("idl-def-documented-notdefined");
         expect($section.find("p[link-for] a:contains('notDefined')").attr("href")).toEqual("#idl-def-documented-notdefined");
 
+        var definedElsewhere = $section.find("dfn:contains('definedElsewhere')");
         var linkFromElsewhere = $section.find("a:contains('Documented.docString')");
+        expect(definedElsewhere.prop('id')).toEqual('dom-documented-definedelsewhere');
+        expect($target.find(".idlAttrName:contains('definedElsewhere') a").attr("href")).toEqual("#dom-documented-definedelsewhere");
         expect(linkFromElsewhere.attr('href')).toEqual('#dom-documented-docstring');
 
         expect($section.find("#without-link-for a:contains('Documented')").attr("href")).toEqual("#idl-def-documented");

--- a/tests/spec/core/webidl-contiguous.html
+++ b/tests/spec/core/webidl-contiguous.html
@@ -459,6 +459,7 @@
         interface Documented {
           attribute DOMString docString;
           attribute DOMString notDefined;
+          attribute DOMString definedElsewhere;
         };
       </pre>
       <p class='note' dfn-for="Documented">
@@ -472,6 +473,7 @@
         <a>notDefined</a> is too, but isn't defined elsewhere.
       </p>
       <p>
+        <dfn>Documented.definedElsewhere</dfn> is defined by writing its fully-qualified name.
         <a>Documented.docString</a> is linked by writing its fully-qualified name.
       </p>
       <p id="without-link-for">


### PR DESCRIPTION
This replaces `<dfn for="dotted" title="name">dotted.name</dfn>`.