### PR TITLE
don't generate a section ID if the heading has one

### DIFF
--- a/js/core/structure.js
+++ b/js/core/structure.js
@@ -36,7 +36,7 @@ define(
                     ;
                     $kidsHolder.find("a").renameElement("span").attr("class", "formerLink").removeAttr("href");
                     $kidsHolder.find("dfn").renameElement("span").removeAttr("id");
-                    var id = $sec.makeID(null, title);
+                    var id = h.id ? h.id : $sec.makeID(null, title);
 
                     if (!isIntro) current[current.length - 1]++;
                     var secnos = current.slice();


### PR DESCRIPTION
We're getting problems from ReSpec generating spurious IDs, notably on `section` when the `hN` already has one. This should eliminate that behaviour.