### PR TITLE
Implemented aliases for definitions

### DIFF
--- a/js/core/dfn.js
+++ b/js/core/dfn.js
@@ -21,12 +21,12 @@ define(
                     } else {
                         dfn.attr("data-dfn-for", (dfn.closest("[data-dfn-for]").attr("data-dfn-for") || "").toLowerCase());
                     }
-                    var titles = dfn.dfnTitle( true );
-                    $.each(titles, function() {
-                        if (!conf.definitionMap[this]) {
-                            conf.definitionMap[this] = [];
+                    var titles = dfn.getDfnTitles( { isDefinition: true } );
+                    titles.forEach( function( item, i ) {
+                        if (!conf.definitionMap[item]) {
+                            conf.definitionMap[item] = [];
                         }
-                        conf.definitionMap[this].push($(dfn[0]));
+                        conf.definitionMap[item].push($(dfn[0]));
                         });
                 });
                 msg.pub("end", "core/dfn");

--- a/js/core/dfn.js
+++ b/js/core/dfn.js
@@ -22,7 +22,7 @@ define(
                         dfn.attr("data-dfn-for", (dfn.closest("[data-dfn-for]").attr("data-dfn-for") || "").toLowerCase());
                     }
                     var titles = dfn.getDfnTitles( { isDefinition: true } );
-                    titles.forEach( function( item, i ) {
+                    titles.forEach( function( item ) {
                         if (!conf.definitionMap[item]) {
                             conf.definitionMap[item] = [];
                         }

--- a/js/core/dfn.js
+++ b/js/core/dfn.js
@@ -21,11 +21,13 @@ define(
                     } else {
                         dfn.attr("data-dfn-for", (dfn.closest("[data-dfn-for]").attr("data-dfn-for") || "").toLowerCase());
                     }
-                    var title = dfn.dfnTitle();
-                    if (!conf.definitionMap[title]) {
-                        conf.definitionMap[title] = [];
-                    }
-                    conf.definitionMap[title].push(dfn);
+                    var titles = dfn.dfnTitle( true );
+                    $.each(titles, function() {
+                        if (!conf.definitionMap[this]) {
+                            conf.definitionMap[this] = [];
+                        }
+                        conf.definitionMap[this].push($(dfn[0]));
+                        });
                 });
                 msg.pub("end", "core/dfn");
                 cb();

--- a/js/core/link-to-dfn.js
+++ b/js/core/link-to-dfn.js
@@ -51,6 +51,10 @@ define(
                         if (titles[target.title] && titles[target.title][target.for_]) {
                             var dfn = titles[target.title][target.for_];
                             $ant.attr("href", "#" + dfn.prop("id")).addClass("internalDFN");
+                            // add a bikeshed style indication of the type of link
+                            if (! $ant.attr("data-link-type") ) {
+                                $ant.attr("data-link-type", "dfn") ;
+                            }
                             // If a definition is <code>, links to it should
                             // also be <code>.
                             //

--- a/js/core/utils.js
+++ b/js/core/utils.js
@@ -31,10 +31,10 @@ define(
         // the algorithm used for determining the
         // actual title of a <dfn> element (but can apply to other as well).
         // 
-        // if isDefinition is true, then the element is a definition, not a 
+        // if args.isDefinition is true, then the element is a definition, not a 
         // reference to a definition.  Any @title or @lt will be replaced with
         // @data-lt to be consistent with Bikeshed / Shepherd.
-        $.fn.dfnTitle = function ( isDefinition ) {
+        $.fn.getDfnTitles = function ( args ) {
             var titles = [];
             var theAttr = "";
             var titleString = ""; 
@@ -46,28 +46,40 @@ define(
                 titleString = this.attr("lt");
                 theAttr = "lt";
             }
-            else if (this.contents().length == 1 && this.children("abbr, acronym").length == 1 &&
-                     this.find(":first-child").attr("title")) titleString = this.find(":first-child").attr("title");
-            else titleString = this.text();
+            else if (this.contents().length == 1 
+                     && this.children("abbr, acronym").length == 1 
+                     && this.find(":first-child").attr("title")) {
+                titleString = this.find(":first-child").attr("title");
+            }
+            else {
+                titleString = this.text();
+            }
             // now we have a string of one or more titles
-            // ensure there is no extra whitespace
-            titleString = titleString.toLowerCase().replace(/^\s+/, "").replace(/\s+$/, "").split(/\s+/).join(" ");
-            if (isDefinition) {
+            titleString = titleString.toLowerCase() // mask to lower case
+                .replace(/^\s+/, "") // strip out any leading whitespace
+                .replace(/\s+$/, "") // and any trailing whitespace
+                .split(/\s+/) // split on any whitepace
+                .join(" ");  // and replace with a single space
+            if (args && args.isDefinition === true) {
                 // if it came from an attribute, replace that with data-lt as per contract with Shepherd
                 if (theAttr) {
                     this.attr("data-lt", titleString);
                     this.removeAttr(theAttr) ;
                 }
                 // if there is no pre-defined type, assume it is a 'dfn'
-                if (!this.attr("dfn-type")) this.attr("data-dfn-type", "dfn")
+                if (!this.attr("dfn-type")) {
+                    this.attr("data-dfn-type", "dfn");
+                }
                 else {
                     this.attr("data-dfn-type", this.attr("dfn-type"));
                     this.removeAttr("dfn-type");
                 }
             }
-            $.each(titleString.split('|'), function() {
-                    if (this != "") titles.push(this);
-                    });
+            titleString.split('|').forEach( function( item, i ) {
+                    if (item != "") {
+                        titles.push(item);
+                    }
+                });
             return titles;
         };
 
@@ -84,7 +96,7 @@ define(
         $.fn.linkTargets = function () {
             var elem = this;
             var link_for = (elem.attr("for") || elem.closest("[link-for]").attr("link-for") || "").toLowerCase();
-            var titles = elem.dfnTitle();
+            var titles = elem.getDfnTitles();
             var result = [];
             $.each(titles, function() {
                     result.push({for_: link_for, title: this});

--- a/js/core/utils.js
+++ b/js/core/utils.js
@@ -75,7 +75,7 @@ define(
                     this.removeAttr("dfn-type");
                 }
             }
-            titleString.split('|').forEach( function( item, i ) {
+            titleString.split('|').forEach( function( item ) {
                     if (item != "") {
                         titles.push(item);
                     }

--- a/tests/spec/core/dfn-spec.js
+++ b/tests/spec/core/dfn-spec.js
@@ -44,4 +44,31 @@ describe("Core — Definitions", function () {
             flushIframes();
         });
     });
+    it("should process aliases", function () {
+        var doc;
+        runs(function () {
+            makeRSDoc({ config: basicConfig, body: $("<section id='dfn'><dfn title='text|text 1|text  2|text 3 '>text</dfn><a>text</a></section>") },
+                      function (rsdoc) { doc = rsdoc; });
+        });
+        waitsFor(function () { return doc; }, MAXOUT);
+        runs(function () {
+            var $sec = $("#dfn", doc);
+            expect($sec.find("dfn").attr("data-lt")).toEqual("text|text 1|text 2|text 3");
+            expect($sec.find("dfn").attr("data-dfn-type")).toEqual("dfn");
+            flushIframes();
+        });
+    });
+    it("should allow defined dfn-type ", function () {
+        var doc;
+        runs(function () {
+            makeRSDoc({ config: basicConfig, body: $("<section id='dfn'><dfn dfn-type='myType'>text</dfn><a>text</a></section>") },
+                      function (rsdoc) { doc = rsdoc; });
+        });
+        waitsFor(function () { return doc; }, MAXOUT);
+        runs(function () {
+            var $sec = $("#dfn", doc);
+            expect($sec.find("dfn").attr("data-dfn-type")).toEqual("myType");
+            flushIframes();
+        });
+    });
 });

--- a/tests/spec/core/dfn-spec.js
+++ b/tests/spec/core/dfn-spec.js
@@ -7,7 +7,8 @@ describe("Core — Definitions", function () {
     it("should process definitions", function () {
         var doc;
         runs(function () {
-            makeRSDoc({ config: basicConfig, body: $("<section id='dfn'><dfn>text</dfn><a>text</a></section>") },
+            makeRSDoc({ config: basicConfig, 
+                        body: $("<section id='dfn'><dfn>text</dfn><a>text</a></section>") },
                       function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);
@@ -47,7 +48,11 @@ describe("Core — Definitions", function () {
     it("should process aliases", function () {
         var doc;
         runs(function () {
-            makeRSDoc({ config: basicConfig, body: $("<section id='dfn'><dfn title='text|text 1|text  2|text 3 '>text</dfn><a>text</a></section>") },
+            makeRSDoc({ config: basicConfig, 
+                        body: $("<section id='dfn'>" +
+                                "<dfn title='text|text 1|text  2|text 3 '>text</dfn>" +
+                                "<a>text</a>" +
+                                "</section>") },
                       function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);
@@ -61,7 +66,11 @@ describe("Core — Definitions", function () {
     it("should allow defined dfn-type ", function () {
         var doc;
         runs(function () {
-            makeRSDoc({ config: basicConfig, body: $("<section id='dfn'><dfn dfn-type='myType'>text</dfn><a>text</a></section>") },
+            makeRSDoc({ config: basicConfig, 
+                        body: $("<section id='dfn'>" +
+                                "<dfn dfn-type='myType'>text</dfn>" +
+                                "<a>text</a>" +
+                                "</section>") },
                       function (rsdoc) { doc = rsdoc; });
         });
         waitsFor(function () { return doc; }, MAXOUT);

--- a/tests/spec/core/utils-spec.js
+++ b/tests/spec/core/utils-spec.js
@@ -137,12 +137,15 @@ describe("Core - Utils", function () {
     // $.dfnTitle()
     it("should find the definition title", function () {
         runs(function () {
-            var $dfn = $("<dfn title='DFN'><abbr title='ABBR'>TEXT</abbr></dfn>").appendTo($("body"));
-            expect($dfn.dfnTitle()).toEqual("dfn");
+            var $dfn = $("<dfn title='DFN|DFN2|DFN3'><abbr title='ABBR'>TEXT</abbr></dfn>").appendTo($("body"));
+            var titles = $dfn.dfnTitle();
+            expect(titles[0]).toEqual("dfn");
+            expect(titles[1]).toEqual("dfn2");
+            expect(titles[2]).toEqual("dfn3");
             $dfn.removeAttr("title");
-            expect($dfn.dfnTitle()).toEqual("abbr");
+            expect($dfn.dfnTitle()[0]).toEqual("abbr");
             $dfn.find("abbr").removeAttr("title");
-            expect($dfn.dfnTitle()).toEqual("text");
+            expect($dfn.dfnTitle()[0]).toEqual("text");
             $dfn.remove();
         });
     });

--- a/tests/spec/core/utils-spec.js
+++ b/tests/spec/core/utils-spec.js
@@ -134,18 +134,18 @@ describe("Core - Utils", function () {
         });
     });
 
-    // $.dfnTitle()
+    // $.getDfnTitles()
     it("should find the definition title", function () {
         runs(function () {
             var $dfn = $("<dfn title='DFN|DFN2|DFN3'><abbr title='ABBR'>TEXT</abbr></dfn>").appendTo($("body"));
-            var titles = $dfn.dfnTitle();
+            var titles = $dfn.getDfnTitles();
             expect(titles[0]).toEqual("dfn");
             expect(titles[1]).toEqual("dfn2");
             expect(titles[2]).toEqual("dfn3");
             $dfn.removeAttr("title");
-            expect($dfn.dfnTitle()[0]).toEqual("abbr");
+            expect($dfn.getDfnTitles()[0]).toEqual("abbr");
             $dfn.find("abbr").removeAttr("title");
-            expect($dfn.dfnTitle()[0]).toEqual("text");
+            expect($dfn.getDfnTitles()[0]).toEqual("text");
             $dfn.remove();
         });
     });


### PR DESCRIPTION
Added handling for aliases as per Bikeshed.  Specifically,
`<dfn title="foo|bar">my term</dfn>` is able to be referenced with
things like `<a>foo</a>` or `<a title="bar">my term</a>` or
`<a>bar</a>`.

This also ensures that the generated output is compatible with the
Bikeshed contract for external processors.  There is more work to do to
get that complete, but this is a good first step.

This is in general in reference to issue #344