### PR TITLE
Makes getDfnTitles work when called again

### DIFF
--- a/js/core/utils.js
+++ b/js/core/utils.js
@@ -34,11 +34,19 @@ define(
         // if args.isDefinition is true, then the element is a definition, not a 
         // reference to a definition.  Any @title or @lt will be replaced with
         // @data-lt to be consistent with Bikeshed / Shepherd.
+        //
+        // This method now *prefers* the data-lt attribute for the list of 
+        // titles.  That attribute is added by this method to dfn elements, so 
+        // subsequent calls to this method will return the data-lt based list.
         $.fn.getDfnTitles = function ( args ) {
             var titles = [];
             var theAttr = "";
             var titleString = ""; 
-            if (this.attr("title")) {
+            if (( !args || (args && args.isDefinition != true) ) && this.attr("data-lt")) {
+                titleString = this.attr("data-lt");
+                theAttr = "data-lt";
+            }
+            else if (this.attr("title")) {
                 titleString = this.attr("title");
                 theAttr = "title";
             }

--- a/js/core/utils.js
+++ b/js/core/utils.js
@@ -58,7 +58,7 @@ define(
             else if (this.attr("title")) {
                 titleString = this.attr("title");
                 theAttr = "title";
-                respecEvents.pub("warn", "Using deprecated attribute @title to specify link title for '" + this.text() + "': Change to @lt");
+                respecEvents.pub("warn", "Using deprecated attribute @title for '" + this.text() + "': see http://w3.org/respec/guide.html#definitions-and-linking");
             }
             else if (this.contents().length == 1 
                      && this.children("abbr, acronym").length == 1 

--- a/js/core/utils.js
+++ b/js/core/utils.js
@@ -38,21 +38,27 @@ define(
         // This method now *prefers* the data-lt attribute for the list of 
         // titles.  That attribute is added by this method to dfn elements, so 
         // subsequent calls to this method will return the data-lt based list.
+        //
+        // This method will publish a warning if a title is used on a definition
+        // instead of an @lt (as per specprod mailing list discussion).
         $.fn.getDfnTitles = function ( args ) {
             var titles = [];
             var theAttr = "";
             var titleString = ""; 
             if (( !args || (args && args.isDefinition != true) ) && this.attr("data-lt")) {
+                // only look for a data-lt when we are NOT being called to create a
+                // new definition
                 titleString = this.attr("data-lt");
                 theAttr = "data-lt";
-            }
-            else if (this.attr("title")) {
-                titleString = this.attr("title");
-                theAttr = "title";
             }
             else if (this.attr("lt")) {
                 titleString = this.attr("lt");
                 theAttr = "lt";
+            }
+            else if (this.attr("title")) {
+                titleString = this.attr("title");
+                theAttr = "title";
+                respecEvents.pub("warn", "Using deprecated attribute @title to specify link title for '" + this.text() + "': Change to @lt");
             }
             else if (this.contents().length == 1 
                      && this.children("abbr, acronym").length == 1 

--- a/tests/spec/core/utils-spec.js
+++ b/tests/spec/core/utils-spec.js
@@ -137,15 +137,29 @@ describe("Core - Utils", function () {
     // $.getDfnTitles()
     it("should find the definition title", function () {
         runs(function () {
-            var $dfn = $("<dfn title='DFN|DFN2|DFN3'><abbr title='ABBR'>TEXT</abbr></dfn>").appendTo($("body"));
-            var titles = $dfn.getDfnTitles();
+            var $dfn = $("<dfn lt='DFN|DFN2|DFN3'><abbr title='ABBR'>TEXT</abbr></dfn>").appendTo($("body"));
+            var titles = $dfn.getDfnTitles( { isDefinition: true } );
             expect(titles[0]).toEqual("dfn");
             expect(titles[1]).toEqual("dfn2");
             expect(titles[2]).toEqual("dfn3");
-            $dfn.removeAttr("title");
+            $dfn.removeAttr("data-lt");
             expect($dfn.getDfnTitles()[0]).toEqual("abbr");
             $dfn.find("abbr").removeAttr("title");
             expect($dfn.getDfnTitles()[0]).toEqual("text");
+            $dfn.remove();
+        });
+    });
+
+    // $.getDfnTitles()
+    it("should return list of terms when called a second time", function () {
+        runs(function () {
+            var $dfn = $("<dfn lt='DFN|DFN2|DFN3'>TEXT</dfn>").appendTo($("body"));
+            var titles = $dfn.getDfnTitles( { isDefinition: true } );
+            expect(titles[0]).toEqual("dfn");
+            expect(titles[1]).toEqual("dfn2");
+            expect(titles[2]).toEqual("dfn3");
+            expect($dfn.attr("data-lt")).toEqual('dfn|dfn2|dfn3');
+            expect($dfn.getDfnTitles()[0]).toEqual("dfn");
             $dfn.remove();
         });
     });


### PR DESCRIPTION
Some add-on code (used by PFWG and WPIG currently) call this utility
method on dfn elements again to get the title.  If there are aliases
for a dfn, these are moved into data-lt during the definition
processing phase, so a subsequent call will return the wrong list in
that case.  This fixes that (and improves the tests so we know it
works).