### PR TITLE
Improved Member-SUBM and Team-SUBM spec status support

### DIFF
--- a/js/w3c/headers.js
+++ b/js/w3c/headers.js
@@ -296,6 +296,9 @@ define(
                 conf.publishHumanDate = utils.humanDate(conf.publishDate);
                 conf.isNoTrack = $.inArray(conf.specStatus, this.noTrackStatus) >= 0;
                 conf.isRecTrack = conf.noRecTrack ? false : $.inArray(conf.specStatus, this.recTrackStatus) >= 0;
+                conf.isMemberSubmission = conf.specStatus === "Member-SUBM";
+                conf.isTeamSubmission = conf.specStatus === "Team-SUBM";
+                conf.isSubmission = conf.isMemberSubmission || conf.isTeamSubmission;
                 conf.anOrA = $.inArray(conf.specStatus, this.precededByAn) >= 0 ? "an" : "a";
                 conf.isTagFinding = conf.specStatus === "finding" || conf.specStatus === "draft-finding";
                 if (!conf.edDraftURI) {
@@ -338,7 +341,7 @@ define(
                     }
                 }
                 else {
-                    if (!/NOTE$/.test(conf.specStatus) && conf.specStatus !== "FPWD" && conf.specStatus !== "FPLC" && conf.specStatus !== "ED" && !conf.noRecTrack && !conf.isNoTrack)
+                    if (!/NOTE$/.test(conf.specStatus) && conf.specStatus !== "FPWD" && conf.specStatus !== "FPLC" && conf.specStatus !== "ED" && !conf.noRecTrack && !conf.isNoTrack && !conf.isSubmission)
                         msg.pub("error", "Document on track but no previous version.");
                     if (!conf.prevVersion) conf.prevVersion = "";
                 }
@@ -384,8 +387,7 @@ define(
                     conf.rdfStatus = this.status2rdf[conf.specStatus];
                 }
                 conf.showThisVersion =  (!conf.isNoTrack || conf.isTagFinding);
-                conf.showPreviousVersion = (conf.specStatus !== "FPWD" && conf.specStatus !== "FPLC" && conf.specStatus !== "ED" &&
-                                           !conf.isNoTrack);
+                conf.showPreviousVersion = (conf.specStatus !== "FPWD" && conf.specStatus !== "FPLC" && conf.specStatus !== "ED" && !conf.isNoTrack && !conf.isSubmission);
                 if (/NOTE$/.test(conf.specStatus) && !conf.prevVersion) conf.showPreviousVersion = false;
                 if (conf.isTagFinding) conf.showPreviousVersion = conf.previousPublishDate ? true : false;
                 conf.notYetRec = (conf.isRecTrack && conf.specStatus !== "REC");

--- a/js/w3c/templates/headers.html
+++ b/js/w3c/templates/headers.html
@@ -5,6 +5,12 @@
       {{else}}
         {{#if prependW3C}}
             <a href='http://www.w3.org/'><img width='72' height='48' src='https://www.w3.org/Icons/w3c_home' alt='W3C'></a>
+            {{#if isMemberSubmission}}
+            <a href="http://www.w3.org/Submission/"> <img height="48" width="211" alt="W3C Member Submission" src="http://www.w3.org/Icons/member_subm" /></a>
+            {{/if}}
+            {{#if isTeamSubmission}}
+            <a href="http://www.w3.org/TeamSubmission/"><img height="48" width="211" alt="W3C Team Submission" src="http://www.w3.org/Icons/team_subm"/></a>
+            {{/if}}
         {{/if}}
       {{/if}}
   </p>

--- a/js/w3c/templates/sotd.html
+++ b/js/w3c/templates/sotd.html
@@ -21,130 +21,147 @@
         <p>
           <em>{{{l10n.status_at_publication}}}</em>
         </p>
-        {{#unless sotdAfterWGinfo}}
-        {{{sotdCustomParagraph}}}
-        {{/unless}}
-        <p>
-          This document was published by the {{{wgHTML}}} as {{anOrA}} {{longStatus}}.
-          {{#if notYetRec}}
-            This document is intended to become a W3C Recommendation.
-          {{/if}}
-          {{#unless isPR}}
-            If you wish to make comments regarding this document, please send them to 
-            <a href='mailto:{{wgPublicList}}@w3.org{{#if subjectPrefix}}?subject={{subjectPrefixEnc}}{{/if}}'>{{wgPublicList}}@w3.org</a> 
-            (<a href='mailto:{{wgPublicList}}-request@w3.org?subject=subscribe'>subscribe</a>,
-            <a
-              href='http://lists.w3.org/Archives/Public/{{wgPublicList}}/'>archives</a>){{#if subjectPrefix}}
-              with <code>{{subjectPrefix}}</code> at the start of your email's subject{{/if}}.
-          {{/unless}}
-          {{#if isLC}}The Last Call period ends {{humanLCEnd}}.{{/if}}
-          {{#if isCR}}
-            W3C publishes a Candidate Recommendation to indicate that the document is believed to be
-            stable and to encourage implementation by the developer community. This Candidate
-            Recommendation is expected to advance to Proposed Recommendation no earlier than
-            {{humanCREnd}}.
-          {{/if}}
-          {{#if isPER}}
-              W3C Advisory Committee Members are invited to
-              send formal review comments on this Proposed
-              Edited Recommendation to the W3C Team until
-              {{humanPEREnd}}. 
-              Members of the Advisory Committee will find the
-              appropriate review form for this document by
-              consulting their list of current
-              <a href='https://www.w3.org/2002/09/wbs/myQuestionnaires'>WBS questionnaires</a>. 
-          {{/if}}
-          {{#if isPR}}
-              The W3C Membership and other interested parties are invited to review the document and
-              send comments to
-              <a rel='discussion' href='mailto:{{wgPublicList}}@w3.org'>{{wgPublicList}}@w3.org</a> 
-              (<a href='mailto:{{wgPublicList}}-request@w3.org?subject=subscribe'>subscribe</a>,
-              <a href='http://lists.w3.org/Archives/Public/{{wgPublicList}}/'>archives</a>)
-              through {{humanPREnd}}. Advisory Committee Representatives should consult their
-              <a href='https://www.w3.org/2002/09/wbs/myQuestionnaires'>WBS questionnaires</a>. 
-              Note that substantive technical comments were expected during the Last Call review
-              period that ended {{humanLCEnd}}.
+        {{#if isSubmission}}
+          {{{sotdCustomParagraph}}}
+          {{#if isMemberSubmission}}
+            <p>By publishing this document, W3C acknowledges that the <a href="http://www.w3.org/Submission/@@@submissiondoc@@@">Submitting Members</a> have made a formal Submission request to W3C for discussion. Publication of this document by W3C indicates no endorsement of its content by W3C, nor that W3C has, is, or will be allocating any resources to the issues addressed by it. This document is not the product of a chartered W3C group, but is published as potential input to the <a href="http://www.w3.org/Consortium/Process">W3C Process</a>. A <a href="http://www.w3.org/Submission/@@@teamcomment@@@">W3C Team Comment</a> has been published in conjunction with this Member Submission. Publication of acknowledged Member Submissions at the W3C site is one of the benefits of <a href="http://www.w3.org/Consortium/Prospectus/Joining">W3C Membership</a>. Please consult the requirements associated with Member Submissions of <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-submissions">section 3.3 of the W3C Patent Policy</a>. Please consult the complete <a href="http://www.w3.org/Submission">list of acknowledged W3C Member Submissions</a>.</p>
           {{else}}
-            {{#unless isPER}}
-            All comments are welcome.
-            {{/unless}}
-          {{/if}}
-        </p>
-        {{#if implementationReportURI}}
-          <p>
-            Please see the Working Group's  <a href='{{implementationReportURI}}'>implementation
-            report</a>.
-          </p>
-        {{/if}}
-        {{#if sotdAfterWGinfo}}
-        {{{sotdCustomParagraph}}
-        {{/if}}
-        {{#if notRec}}
-          <p>
-            Publication as {{anOrA}} {{textStatus}} does not imply endorsement by the W3C
-            Membership. This is a draft document and may be updated, replaced or obsoleted by other
-            documents at any time. It is inappropriate to cite this document as other than work in
-            progress.
-          </p>
-        {{/if}}
-        {{#if isRec}}
-          <p>
-            This document has been reviewed by W3C Members, by software developers, and by other W3C
-            groups and interested parties, and is endorsed by the Director as a W3C Recommendation.
-            It is a stable document and may be used as reference material or cited from another
-            document. W3C's role in making the Recommendation is to draw attention to the
-            specification and to promote its widespread deployment. This enhances the functionality
-            and interoperability of the Web.
-          </p>
-        {{/if}}
-        {{#if isLC}}
-          <p>
-            This is a Last Call Working Draft and thus the Working Group has determined that this
-            document has satisfied the relevant technical requirements and is sufficiently stable to
-            advance through the Technical Recommendation process.
-          </p>
-        {{/if}}
-        <p>
-          {{#unless isIGNote}}
-            This document was produced by a group operating under the 
-            <a{{#if doRDFa}} id="sotd_patent" property='w3p:patentRules'{{/if}}
-            href='http://www.w3.org/Consortium/Patent-Policy-20040205/'>5 February 2004 W3C Patent
-            Policy</a>.
-          {{/unless}}
-          {{#if recNotExpected}}
-            The group does not expect this document to become a W3C Recommendation.
-          {{/if}}
-          {{#unless isIGNote}}
-            {{#if multipleWGs}}
-              W3C maintains a public list of any patent disclosures ({{{wgPatentHTML}}})
-            {{else}}
-              W3C maintains a <a href='{{wgPatentURI}}' rel='disclosure'>public list of any patent
-              disclosures</a> 
+            {{#if isTeamSubmission}}
+              <p>If you wish to make comments regarding this document, please send them to
+              <a href='mailto:{{wgPublicList}}@w3.org{{#if subjectPrefix}}?subject={{subjectPrefixEnc}}{{/if}}'>{{wgPublicList}}@w3.org</a>
+              (<a href='mailto:{{wgPublicList}}-request@w3.org?subject=subscribe'>subscribe</a>,
+              <a
+                href='http://lists.w3.org/Archives/Public/{{wgPublicList}}/'>archives</a>){{#if subjectPrefix}}
+                with <code>{{subjectPrefix}}</code> at the start of your email's subject{{/if}}.</p>
+              <p>Please consult the complete <a href="http://www.w3.org/TeamSubmission/">list of Team Submissions</a>.</p>
             {{/if}}
-            made in connection with the deliverables of the group; that page also includes
-            instructions for disclosing a patent. An individual who has actual knowledge of a patent
-            which the individual believes contains
-            <a href='http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential'>Essential
-            Claim(s)</a> must disclose the information in accordance with
-            <a href='http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure'>section
-            6 of the W3C Patent Policy</a>.
-          {{/unless}}
-          {{#if isIGNote}}
-            The disclosure obligations of the Participants of this group are described in the 
-            <a href='{{charterDisclosureURI}}'>charter</a>. 
           {{/if}}
-        </p>
-        {{#if isNewProcess}}
-          <p>This document is governed by the <a id="w3c_process_revision"
-            href="http://www.w3.org/2014/Process-20140801/">1 August 2014 W3C Process Document</a>.
-          </p>
         {{else}}
+          {{#unless sotdAfterWGinfo}}
+          {{{sotdCustomParagraph}}}
+          {{/unless}}
           <p>
-            This document is governed by the  <a id="w3c_process_revision"
-            href="http://www.w3.org/2005/10/Process-20051014/">14 October 2005 W3C Process Document</a>.
+            This document was published by the {{{wgHTML}}} as {{anOrA}} {{longStatus}}.
+            {{#if notYetRec}}
+              This document is intended to become a W3C Recommendation.
+            {{/if}}
+            {{#unless isPR}}
+              If you wish to make comments regarding this document, please send them to 
+              <a href='mailto:{{wgPublicList}}@w3.org{{#if subjectPrefix}}?subject={{subjectPrefixEnc}}{{/if}}'>{{wgPublicList}}@w3.org</a> 
+              (<a href='mailto:{{wgPublicList}}-request@w3.org?subject=subscribe'>subscribe</a>,
+              <a
+                href='http://lists.w3.org/Archives/Public/{{wgPublicList}}/'>archives</a>){{#if subjectPrefix}}
+                with <code>{{subjectPrefix}}</code> at the start of your email's subject{{/if}}.
+            {{/unless}}
+            {{#if isLC}}The Last Call period ends {{humanLCEnd}}.{{/if}}
+            {{#if isCR}}
+              W3C publishes a Candidate Recommendation to indicate that the document is believed to be
+              stable and to encourage implementation by the developer community. This Candidate
+              Recommendation is expected to advance to Proposed Recommendation no earlier than
+              {{humanCREnd}}.
+            {{/if}}
+            {{#if isPER}}
+                W3C Advisory Committee Members are invited to
+                send formal review comments on this Proposed
+                Edited Recommendation to the W3C Team until
+                {{humanPEREnd}}. 
+                Members of the Advisory Committee will find the
+                appropriate review form for this document by
+                consulting their list of current
+                <a href='https://www.w3.org/2002/09/wbs/myQuestionnaires'>WBS questionnaires</a>. 
+            {{/if}}
+            {{#if isPR}}
+                The W3C Membership and other interested parties are invited to review the document and
+                send comments to
+                <a rel='discussion' href='mailto:{{wgPublicList}}@w3.org'>{{wgPublicList}}@w3.org</a> 
+                (<a href='mailto:{{wgPublicList}}-request@w3.org?subject=subscribe'>subscribe</a>,
+                <a href='http://lists.w3.org/Archives/Public/{{wgPublicList}}/'>archives</a>)
+                through {{humanPREnd}}. Advisory Committee Representatives should consult their
+                <a href='https://www.w3.org/2002/09/wbs/myQuestionnaires'>WBS questionnaires</a>. 
+                Note that substantive technical comments were expected during the Last Call review
+                period that ended {{humanLCEnd}}.
+            {{else}}
+              {{#unless isPER}}
+              All comments are welcome.
+              {{/unless}}
+            {{/if}}
           </p>
+          {{#if implementationReportURI}}
+            <p>
+              Please see the Working Group's  <a href='{{implementationReportURI}}'>implementation
+              report</a>.
+            </p>
+          {{/if}}
+          {{#if sotdAfterWGinfo}}
+          {{{sotdCustomParagraph}}
+          {{/if}}
+          {{#if notRec}}
+            <p>
+              Publication as {{anOrA}} {{textStatus}} does not imply endorsement by the W3C
+              Membership. This is a draft document and may be updated, replaced or obsoleted by other
+              documents at any time. It is inappropriate to cite this document as other than work in
+              progress.
+            </p>
+          {{/if}}
+          {{#if isRec}}
+            <p>
+              This document has been reviewed by W3C Members, by software developers, and by other W3C
+              groups and interested parties, and is endorsed by the Director as a W3C Recommendation.
+              It is a stable document and may be used as reference material or cited from another
+              document. W3C's role in making the Recommendation is to draw attention to the
+              specification and to promote its widespread deployment. This enhances the functionality
+              and interoperability of the Web.
+            </p>
+          {{/if}}
+          {{#if isLC}}
+            <p>
+              This is a Last Call Working Draft and thus the Working Group has determined that this
+              document has satisfied the relevant technical requirements and is sufficiently stable to
+              advance through the Technical Recommendation process.
+            </p>
+          {{/if}}
+          <p>
+            {{#unless isIGNote}}
+              This document was produced by a group operating under the 
+              <a{{#if doRDFa}} id="sotd_patent" property='w3p:patentRules'{{/if}}
+              href='http://www.w3.org/Consortium/Patent-Policy-20040205/'>5 February 2004 W3C Patent
+              Policy</a>.
+            {{/unless}}
+            {{#if recNotExpected}}
+              The group does not expect this document to become a W3C Recommendation.
+            {{/if}}
+            {{#unless isIGNote}}
+              {{#if multipleWGs}}
+                W3C maintains a public list of any patent disclosures ({{{wgPatentHTML}}})
+              {{else}}
+                W3C maintains a <a href='{{wgPatentURI}}' rel='disclosure'>public list of any patent
+                disclosures</a> 
+              {{/if}}
+              made in connection with the deliverables of the group; that page also includes
+              instructions for disclosing a patent. An individual who has actual knowledge of a patent
+              which the individual believes contains
+              <a href='http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential'>Essential
+              Claim(s)</a> must disclose the information in accordance with
+              <a href='http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure'>section
+              6 of the W3C Patent Policy</a>.
+            {{/unless}}
+            {{#if isIGNote}}
+              The disclosure obligations of the Participants of this group are described in the 
+              <a href='{{charterDisclosureURI}}'>charter</a>. 
+            {{/if}}
+          </p>
+          {{#if isNewProcess}}
+            <p>This document is governed by the <a id="w3c_process_revision"
+              href="http://www.w3.org/2014/Process-20140801/">1 August 2014 W3C Process Document</a>.
+            </p>
+          {{else}}
+            <p>
+              This document is governed by the  <a id="w3c_process_revision"
+              href="http://www.w3.org/2005/10/Process-20051014/">14 October 2005 W3C Process Document</a>.
+            </p>
+          {{/if}}
+          {{#if addPatentNote}}<p>{{{addPatentNote}}}</p>{{/if}}
         {{/if}}
-        {{#if addPatentNote}}<p>{{{addPatentNote}}}</p>{{/if}}
       {{/if}}
     {{/if}}
   {{/if}}

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -302,5 +302,39 @@ describe("W3C — Headers", function () {
         });
     });
 
+    // Member-SUBM
+    it("should not expose a Previous version link for Member submissions", function () {
+        loadWithConfig({ specStatus: "Member-SUBM" }, function ($ifr) {
+            expect($("dt:contains('Previous version:')", $ifr[0].contentDocument).length).toEqual(0);
+        });
+    });
+    it("should display the Member Submission logo for Member submissions", function () {
+        loadWithConfig({ specStatus: "Member-SUBM" }, function ($ifr) {
+            expect($(".head img[src='http://www.w3.org/Icons/member_subm']", $ifr[0].contentDocument).length).toEqual(1);
+        });
+    });
+    it("should use the right SoTD boilerplate for Member submissions", function () {
+        loadWithConfig({ specStatus: "Member-SUBM" }, function ($ifr) {
+            var $sotd = $("#sotd", $ifr[0].contentDocument);
+            expect($sotd.find("p:contains('W3C acknowledges that the Submitting Members have made a formal Submission request')").length).toEqual(1);
+        });
+    });
 
+    // Team-SUBM
+    it("should not expose a Previous version link for Team submissions", function () {
+        loadWithConfig({ specStatus: "Team-SUBM" }, function ($ifr) {
+            expect($("dt:contains('Previous version:')", $ifr[0].contentDocument).length).toEqual(0);
+        });
+    });
+    it("should display the Team Submission logo for Team submissions", function () {
+        loadWithConfig({ specStatus: "Team-SUBM" }, function ($ifr) {
+            expect($(".head img[src='http://www.w3.org/Icons/team_subm']", $ifr[0].contentDocument).length).toEqual(1);
+        });
+    });
+    it("should use the right SoTD boilerplate for Team submissions", function () {
+        loadWithConfig({ specStatus: "Team-SUBM" }, function ($ifr) {
+            var $sotd = $("#sotd", $ifr[0].contentDocument);
+            expect($sotd.find("a[href='http://www.w3.org/TeamSubmission/']").length).toEqual(1);
+        });
+    });
 });


### PR DESCRIPTION
This is a proposed fix for #458.

When the spec status is "Member-SUBM" or "Team-SUBM", ReSpec expected a
"Previous version" link that does not mean anything in this context, did not
set the proper companion logo next to the W3C logo and did not include the
right Status of This Document boilerplate.

Please note that the links in the SoTD boilerplate for Member submissions still
contain "@@@". That is normal since these links are set by W3C Team right before
the submissions is accepted, and cannot be computed a priori.

ReSpec still conserves the default copyright in that case, but users simply
have to use "overrideCopyright" to override that setting.

This commit contains a few regression tests.