### PR TITLE
Change to prefer data-lt for referring to link-titles

### DIFF
--- a/js/core/utils.js
+++ b/js/core/utils.js
@@ -32,7 +32,7 @@ define(
         // actual title of a <dfn> element (but can apply to other as well).
         // 
         // if args.isDefinition is true, then the element is a definition, not a 
-        // reference to a definition.  Any @title or @lt will be replaced with
+        // reference to a definition.  Any @title or @lt  or will be replaced with
         // @data-lt to be consistent with Bikeshed / Shepherd.
         //
         // This method now *prefers* the data-lt attribute for the list of 
@@ -45,17 +45,18 @@ define(
             var titles = [];
             var theAttr = "";
             var titleString = ""; 
-            if (( !args || (args && args.isDefinition != true) ) && this.attr("data-lt")) {
-                // only look for a data-lt when we are NOT being called to create a
-                // new definition
+            if (this.attr("data-lt")) {
+                // prefer @data-lt for the list of title aliases
                 titleString = this.attr("data-lt");
                 theAttr = "data-lt";
             }
             else if (this.attr("lt")) {
+                // allow @lt to be consistent with bikeshed
                 titleString = this.attr("lt");
                 theAttr = "lt";
             }
             else if (this.attr("title")) {
+                // allow @title for backward compatibility
                 titleString = this.attr("title");
                 theAttr = "title";
                 respecEvents.pub("warn", "Using deprecated attribute @title for '" + this.text() + "': see http://w3.org/respec/guide.html#definitions-and-linking");

--- a/js/core/utils.js
+++ b/js/core/utils.js
@@ -32,7 +32,7 @@ define(
         // actual title of a <dfn> element (but can apply to other as well).
         // 
         // if args.isDefinition is true, then the element is a definition, not a 
-        // reference to a definition.  Any @title or @lt  or will be replaced with
+        // reference to a definition.  Any @title or @lt will be replaced with
         // @data-lt to be consistent with Bikeshed / Shepherd.
         //
         // This method now *prefers* the data-lt attribute for the list of 

--- a/tests/spec/core/utils-spec.js
+++ b/tests/spec/core/utils-spec.js
@@ -98,12 +98,12 @@ describe("Core - Utils", function () {
             expect(utils.isoDate("2013-06-25")).toMatch(/2013-06-2[45]T/) ;
             var d = new Date();
             d.setFullYear(2013);
-            d.setMonth(5);
             d.setDate(25);
+            d.setMonth(8);
             d.setHours(0);
             d.setMinutes(0);
             d.setSeconds(0);
-            expect(utils.isoDate(d)).toMatch(/2013-06-2[45]T/);
+            expect(utils.isoDate(d)).toMatch(/2013-09-2[45]T/);
         });
     });
 


### PR DESCRIPTION
Addresses concerns from the user community about the use of the 'lt' attribute because it does 
not validate.