### PR TITLE
Fix config export with non-serializable content definitionMap

### DIFF
--- a/js/core/include-config.js
+++ b/js/core/include-config.js
@@ -9,8 +9,7 @@ define(
         msg.pub("start", "core/include-config");
         var script = doc.createElement("script");
         script.id = "respecFinalConfig";
-        seen = [];
-        script.innerText = JSON.stringify(conf, function(key, val) {
+        var confFilter = function(key, val) {
           // DefinitionMap contains array of DOM elements that aren't serializable
           // we replace them by their id
           if (key === "definitionMap") {
@@ -21,7 +20,8 @@ define(
             return ret;
           }
           return val;
-          }, 2);
+        }
+        script.innerText = JSON.stringify(conf, confFilter, 2);
         script.type = "application/json";
         doc.head.appendChild(script);
         msg.pub("end", "core/include-config");

--- a/js/core/include-config.js
+++ b/js/core/include-config.js
@@ -9,7 +9,19 @@ define(
         msg.pub("start", "core/include-config");
         var script = doc.createElement("script");
         script.id = "respecFinalConfig";
-        script.innerText = JSON.stringify(conf, null, 2);
+        seen = [];
+        script.innerText = JSON.stringify(conf, function(key, val) {
+          // DefinitionMap contains array of DOM elements that aren't serializable
+          // we replace them by their id
+          if (key === "definitionMap") {
+            var ret = {};
+            Object.keys(val).forEach(function(k) {
+              ret[k] = val[k].map(function(d) { return d[0].id});
+            });
+            return ret;
+          }
+          return val;
+          }, 2);
         script.type = "application/json";
         doc.head.appendChild(script);
         msg.pub("end", "core/include-config");


### PR DESCRIPTION
(at least) when used with phantomjs, respec now fails due to the respec config export which tries and fails to serialize respecConfig.definitionMap which itself contains a list of DOM elements (non JSON-serializable in phantomjs)

This patches replaces the DOM content with the id of the relevant definition.
