### PR TITLE
using .innerHTML makes JSON reappear (closes #478)

### DIFF
--- a/js/core/base-runner.js
+++ b/js/core/base-runner.js
@@ -23,6 +23,16 @@
     ,   embedded = (top !== self)
     ;
     if (!("respecConfig" in window)) window.respecConfig = {};
+    // clone the initial user configuration.
+    try{
+        if(Object.assign){
+            respecConfig.initialUserConfig = Object.assign({}, respecConfig);
+        } else {
+            respecConfig.initialUserConfig = JSON.parse(JSON.stringify(respecConfig));
+        }
+    }catch(err){
+        respecConfig.initialUserConfig = {};
+    }
     GLOBAL.respecEvents = {
         pub:    function (topic) {
             var args = Array.prototype.slice.call(arguments);

--- a/js/core/include-config.js
+++ b/js/core/include-config.js
@@ -8,7 +8,7 @@ define(
       run: function(conf, doc, cb, msg) {
         msg.pub("start", "core/include-config");
         var script = doc.createElement("script");
-        script.id = "respecFinalConfig";
+        script.id = "initialUserConfig";
         var confFilter = function(key, val) {
           // DefinitionMap contains array of DOM elements that aren't serializable
           // we replace them by their id
@@ -21,7 +21,7 @@ define(
           }
           return val;
         }
-        script.innerText = JSON.stringify(conf, confFilter, 2);
+        script.innerHTML = JSON.stringify(conf.initialUserConfig, confFilter, 2);
         script.type = "application/json";
         doc.head.appendChild(script);
         msg.pub("end", "core/include-config");

--- a/tests/spec/core/include-config-spec.js
+++ b/tests/spec/core/include-config-spec.js
@@ -1,11 +1,11 @@
 describe("Core — Include config as JSON", function() {
-  var MAXOUT = 5000,
-    basicConfig = {
-      editors: [{
-        name: "Robin Berjon"
-      }],
-      specStatus: "WD"
-    };
+  var MAXOUT = 5000;
+  var basicConfig = {
+    editors: [{
+      name: "Robin Berjon"
+    }],
+    specStatus: "WD"
+  };
   it("should have a script tag with the correct attributes", function() {
     var doc;
     runs(function() {
@@ -21,9 +21,9 @@ describe("Core — Include config as JSON", function() {
       return doc;
     }, MAXOUT);
     runs(function() {
-      var $script = $("#respecConfig", doc);
+      var $script = $("#initialUserConfig", doc);
       expect($script[0].tagName).toEqual("SCRIPT");
-      expect($script.attr("id")).toEqual("respecFinalConfig");
+      expect($script.attr("id")).toEqual("initialUserConfig");
       expect($script.attr("type")).toEqual("application/json");
       flushIframes();
     });
@@ -43,9 +43,9 @@ describe("Core — Include config as JSON", function() {
       return doc;
     }, MAXOUT);
     runs(function() {
-      var $script = $("#respecConfig", doc);
-      var jsonConfig = JSON.stringify(doc.defaultView.respecConfig, null, 2);
-      expect($script.text()).toEqual(jsonConfig);
+      var $script = $("#initialUserConfig", doc);
+      var jsonConfig = JSON.stringify(doc.defaultView.respecConfig.initialUserConfig, null, 2);
+      expect($script[0].innerHTML).toEqual(jsonConfig);
       flushIframes();
     });
   });


### PR DESCRIPTION
For whatever reason, .innerText means that when .toString() is called within the output function, the inner text doesn't show up. However, using .innerHTML means that it does show up. 