### PR TITLE
Small improvement to error reporting

### DIFF
--- a/js/core/base-runner.js
+++ b/js/core/base-runner.js
@@ -55,10 +55,10 @@
 // these need to be improved, or complemented with proper UI indications
 if (window.console) {
     respecEvents.sub("warn", function (details) {
-        console.log("WARN: " + details);
+        console.warn("WARN: ", details);
     });
     respecEvents.sub("error", function (details) {
-        console.log("ERROR: " + details);
+        console.error("ERROR: ", details);
     });
     respecEvents.sub("start", function (details) {
         if (respecConfig && respecConfig.trace) console.log(">>> began: " + details);


### PR DESCRIPTION
ReSpec should not swallow the error stacks. Now we can see where errors happen, so long as an error is thrown.