### PR TITLE
Wrap content in main element (closes #479)

### DIFF
--- a/js/core/structure.js
+++ b/js/core/structure.js
@@ -95,8 +95,9 @@ define(
 
                 // makeTOC
                 if (!conf.noTOC) {
-                    var $ul = makeTOCAtLevel($("body", doc), doc, [0], 1, conf);
-                    if (!$ul) return;
+                    var main = doc.querySelector("main, *[role=main]");
+                    var $ul = makeTOCAtLevel($(main || doc.body), doc, [0], 1, conf);
+                    if (!$ul) return finish();
                     var $sec = $("<section id='toc'/>").append("<h2 class='introductory'>" + conf.l10n.toc + "</h2>")
                                                        .append($ul)
                     ,   $ref = $("#toc", doc), replace = false;
@@ -117,6 +118,10 @@ define(
                     }
                 });
 
+                //Wrap sections with <main>
+                if(doc.querySelector("main, *[role=main]") === null){
+                    $("body > section").wrapAll("<main></main>");
+                }
                 finish();
             }
         };

--- a/js/core/structure.js
+++ b/js/core/structure.js
@@ -120,7 +120,7 @@ define(
 
                 //Wrap sections with <main>
                 if(doc.querySelector("main, *[role=main]") === null){
-                    $("body > section").wrapAll("<main></main>");
+                    $("body > section").wrapAll("<main role='main'></main>");
                 }
                 finish();
             }

--- a/tests/spec/core/markdown-spec.js
+++ b/tests/spec/core/markdown-spec.js
@@ -181,8 +181,8 @@ describe("Core - Markdown", function () {
         runs(function () {
             var $bar = $('#bar', doc);
             expect($bar.text()).toMatch(/2. Bar/);
-            var $body = $(doc.body, doc);
-            expect($body.find('> #bar').length).toEqual(1);
+            var $main = $("main", doc);
+            expect($main.find('> #bar').length).toEqual(1);
         });
     });
 
@@ -196,8 +196,8 @@ describe("Core - Markdown", function () {
         waitsFor(function () { return doc; }, MAXOUT);
 
         runs(function () {
-          var $body = $(doc.body, doc);
-          expect($body.find('> #bar').length).toEqual(1);
+          var $main = $("main", doc);
+          expect($main.find('> #bar').length).toEqual(1);
         });
     });
 });

--- a/tests/spec/core/structure-spec.js
+++ b/tests/spec/core/structure-spec.js
@@ -3,6 +3,8 @@ describe("Core - Structure", function () {
     ,   basicConfig = {
             editors:    [{ name: "Robin Berjon" }]
         ,   specStatus: "WD"
+        ,   shortName: "foo"
+        ,   trace: true
 //        ,   doRDFa:  false
         }
     ,   body = "<section class='introductory'><h2>INTRO</h2></section>" +
@@ -13,6 +15,79 @@ describe("Core - Structure", function () {
               "<h2>FOUR</h2><section><h2>FIVE</h2><section><h2>SIX</h2><p>[[DAHUT]]</p><p>[[!HTML5]]</p></section></section></section>" +
               "</section></section></section>"
     ;
+
+    it("should wrap sections in a main element", function () {
+        var doc;
+        runs(function () {
+            makeRSDoc({ config: basicConfig, body: body }, function (rsdoc) { doc = rsdoc; });
+        });
+        waitsFor(function () { return doc; }, MAXOUT);
+        runs(function () {
+            var $main = $("main", doc);
+            expect($main.length).toEqual(1);
+            expect($main.find('> section').length).toBeGreaterThan(7);
+            flushIframes();
+        });
+    });
+
+    it("should not override existing main elements irrespective of where they are declared", function () {
+        var doc;
+        var body = "<section id=abstract><h2>fooo</h2></section><main id='customMain'><section><h2>custom main</h2></section></main>";
+        runs(function () {
+            makeRSDoc({ config: basicConfig, body: body }, function (rsdoc) { doc = rsdoc; });
+        });
+        waitsFor(function () { return doc; }, MAXOUT);
+        runs(function () {
+            var $main = $("main", doc);
+            expect($main.length).toEqual(1);
+            expect($main.attr('id')).toEqual("customMain");
+            expect($main.find('> section').length).toBe(1);
+            expect($main.find("> section > h2").text()).toEqual("1. custom main");
+            flushIframes();
+        });
+    });
+
+    it("should not override existing main elements", function () {
+        var doc;
+        var body = "<main id='customMain'><section><h2>custom main</h2></section></main>";
+        runs(function () {
+            makeRSDoc({ config: basicConfig, body: body }, function (rsdoc) {
+                doc = rsdoc;
+            });
+        });
+        waitsFor(function () { return doc; }, MAXOUT);
+        runs(function () {
+            var $main = $("main", doc);
+            expect($main.length).toEqual(1);
+            expect($main.attr('id')).toEqual("customMain");
+            expect($main.find('> section').length).toBe(1);
+            expect($main.find("> section > h2").text()).toEqual("1. custom main");
+            flushIframes();
+        });
+    });
+
+    it("should not add a main when there is a role=main already in doc", function () {
+        var doc;
+        var body = "<div id='customMain' role=main>";
+        body += "<section><h2>main 1</h2></section>";
+        body += "<section><h2>main 2</h2></section>";
+        body += "<section><h2>main 3</h2></section>";
+        body += "</div>";
+        runs(function () {
+            makeRSDoc({ config: basicConfig, body: body }, function (rsdoc) { doc = rsdoc; });
+        });
+        waitsFor(function () { return doc; }, MAXOUT);
+        runs(function () {
+            expect(doc.querySelector("main")).toEqual(null);
+            var $main = $("*[role=main]", doc);
+            expect($main.length).toEqual(1);
+            expect($main.attr('id')).toEqual("customMain");
+            expect($main.find('> section').length).toBeGreaterThan(2);
+            expect(doc.querySelector("*[role=main] > section > h2").textContent).toEqual("1. main 1");
+            flushIframes();
+        });
+    });
+
     it("should build a ToC with default values", function () {
         var doc;
         runs(function () {


### PR DESCRIPTION
* if there is no main, wraps everything in a main. 
* if a main or [role=main] exists, it won't wrap. 
   - it will use main the main content to generate the ToC