### PR TITLE
Prevent whitespaces in methodObject.idlId

### DIFF
--- a/js/core/webidl-contiguous.js
+++ b/js/core/webidl-contiguous.js
@@ -654,7 +654,7 @@ define(
                                           var optional = arg.optional ? "optional-" : "";
                                           var variadic = arg.variadic ? "..." : "";
                                           return optional + idlType2Text(arg.idlType).toLowerCase() + variadic;
-                                      }).join(',') + ')');
+                                      }).join(',').replace(/\s/g, '_') + ')');
                         break;
                     case "iterator":
                         name = "iterator";


### PR DESCRIPTION
This prevents respec from generating whitespaces in HTML id for methods.

e.g
 https://w3c.github.io/requestidlecallback/#idl-def-window-requestidlecallback(idlerequestcallback,optional-unsigned%20long)

