### PR TITLE
Default to new doc+software license (closes #505)

### DIFF
--- a/js/w3c/headers.js
+++ b/js/w3c/headers.js
@@ -91,6 +91,9 @@
 //          pushed to the WHATWG
 //      - "w3c-software", a permissive and attributions license (but GPL-compatible). This is only
 //          available with webspecs and is the recommended value. It is the default for webspecs.
+//      - "w3c-software-doc", the W3C Software and Document License
+//            http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+
 
 define(
     [
@@ -247,30 +250,35 @@ define(
         ,   cgbg:           ["CG-DRAFT", "CG-FINAL", "BG-DRAFT", "BG-FINAL"]
         ,   precededByAn:   ["ED", "IG-NOTE"]
         ,   licenses: {
-                cc0:    {
-                    name:   "Creative Commons 0 Public Domain Dedication"
-                ,   short:  "CC0"
-                ,   url:    "http://creativecommons.org/publicdomain/zero/1.0/"
-                }
-            ,   "w3c-software": {
-                    name:   "W3C Software Notice and License"
-                ,   short:  "W3C"
-                ,   url:    "http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231"
-                }
-            ,   "cc-by": {
-                    name:   "Creative Commons Attribution 4.0 International Public License"
-                ,   short:  "CC-BY"
-                ,   url:    "http://creativecommons.org/licenses/by/4.0/legalcode"
+                cc0: {
+                  name: "Creative Commons 0 Public Domain Dedication",
+                  short: "CC0",
+                  url: "http://creativecommons.org/publicdomain/zero/1.0/",
+                },
+                "w3c-software": {
+                  name: "W3C Software Notice and License",
+                  short: "W3C Software",
+                  url: "http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231",
+                },
+                "w3c-software-doc": {
+                  name: "W3C Software and Document Notice and License",
+                  short: "W3C Software and Document",
+                  url: "http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document",
+                },
+                "cc-by": {
+                  name: "Creative Commons Attribution 4.0 International Public License",
+                  short: "CC-BY",
+                  url: "http://creativecommons.org/licenses/by/4.0/legalcode",
                 }
             }
         ,   run:    function (conf, doc, cb, msg) {
                 msg.pub("start", "w3c/headers");
-
                 // Default include RDFa document metadata
                 if (conf.doRDFa === undefined) conf.doRDFa = true;
                 // validate configuration and derive new configuration values
                 if (!conf.license) conf.license = (conf.specStatus === "webspec") ? "w3c-software" : "w3c";
                 conf.isCCBY = conf.license === "cc-by";
+                conf.isW3CSoftAndDocLicense = conf.license === "w3c-software-doc";
                 if (conf.specStatus === "webspec" && !$.inArray(conf.license, ["cc0", "w3c-software"]))
                     msg.pub("error", "You cannot use that license with WebSpecs.");
                 if (conf.specStatus !== "webspec" && !$.inArray(conf.license, ["cc-by", "w3c"]))

--- a/js/w3c/templates/headers.html
+++ b/js/w3c/templates/headers.html
@@ -154,15 +154,19 @@
         <a href='http://www.keio.ac.jp/'>Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). 
         {{#if isCCBY}}
           Some Rights Reserved: this document is dual-licensed,
-          <a href="https://creativecommons.org/licenses/by/3.0/">CC-BY</a> and 
-          <a href="http://www.w3.org/Consortium/Legal/copyright-documents">W3C Document License</a>.
+          <a rel="license" href="https://creativecommons.org/licenses/by/3.0/">CC-BY</a> and
+          <a rel="license" href="http://www.w3.org/Consortium/Legal/copyright-documents">W3C Document License</a>.
         {{/if}}
         W3C <a href='http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer'>liability</a>,
         <a href='http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks'>trademark</a> and
         {{#if isCCBY}}
-          <a href='http://www.w3.org/Consortium/Legal/2013/copyright-documents-dual.html'>document use</a>
+          <a rel="license" href='http://www.w3.org/Consortium/Legal/2013/copyright-documents-dual.html'>document use</a>
         {{else}}
-          <a href='http://www.w3.org/Consortium/Legal/copyright-documents'>document use</a>
+          {{#if isW3CSoftAndDocLicense}}
+            <a rel="license" href='http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document'>document + software use</a>
+          {{else}}
+            <a rel="license" href='http://www.w3.org/Consortium/Legal/copyright-documents'>document use</a>
+          {{/if}}
         {{/if}}
         rules apply.
       </p>

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -130,6 +130,17 @@ describe("W3C — Headers", function () {
         });
     });
 
+    // license "w3c-software-doc"
+    it("it should allow the inclusion of the W3C Software and Document Notice and License (w3c-software-doc)", function () {
+        loadWithConfig({ specStatus: "FPWD", license: "w3c-software-doc" }, function ($ifr) {
+            var document = $ifr[0].contentDocument;
+            var licenses = document.querySelectorAll("#respecHeader a[rel=license]");
+            expect(licenses.length).toEqual(1);
+            expect(licenses.item(0).tagName).toEqual("A");
+            expect(licenses.item().href).toEqual("http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document");
+        });
+    });
+
     // alternateFormats
     it("should take alternateFormats into account", function () {
         loadWithConfig({ specStatus: "FPWD", "alternateFormats[]": [{ uri: "URI", label: "LABEL" }] }, function ($ifr) {


### PR DESCRIPTION
This allow an editor to select the W3C's software and document license. 