### PR TITLE
Added support for overriding the publication status

### DIFF
--- a/js/w3c/templates/sotd.html
+++ b/js/w3c/templates/sotd.html
@@ -40,6 +40,7 @@
           {{#unless sotdAfterWGinfo}}
           {{{sotdCustomParagraph}}}
           {{/unless}}
+          {{#unless overrideStatus}}
           <p>
             This document was published by {{{wgHTML}}} as {{anOrA}} {{longStatus}}.
             {{#if notYetRec}}
@@ -86,6 +87,7 @@
               {{/unless}}
             {{/if}}
           </p>
+          {{/unless}}
           {{#if implementationReportURI}}
             <p>
               Please see the Working Group's  <a href='{{implementationReportURI}}'>implementation

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -438,7 +438,14 @@ describe("W3C — Headers", function () {
     });
     // statusOverride
     it("should allow status paragraph to be overridden", function () {
-        loadWithConfig({ overrideStatus: true, wg: "WGNAME", wgURI: "WGURI", wgPatentURI: "WGPATENT", wgPublicList: "WGLIST" }, function ($ifr) {
+        var conf = { 
+           overrideStatus: true,
+           wg: "WGNAME",
+           wgURI: "WGURI",
+           wgPatentURI: "WGPATENT",
+           wgPublicList: "WGLIST",
+        };
+        loadWithConfig(conf, function ($ifr) {
             var $sotd = $("#sotd", $ifr[0].contentDocument);
             expect($sotd.find("p:contains('CUSTOM PARAGRAPH')").length).toEqual(1);
             expect($sotd.find("a:contains('WGNAME')").length).toEqual(0);

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -436,5 +436,16 @@ describe("W3C — Headers", function () {
             expect($sotd.find("a[href='http://www.w3.org/TeamSubmission/']").length).toEqual(1);
         });
     });
+    // statusOverride
+    it("should allow status paragraph to be overridden", function () {
+        loadWithConfig({ overrideStatus: true, wg: "WGNAME", wgURI: "WGURI", wgPatentURI: "WGPATENT", wgPublicList: "WGLIST" }, function ($ifr) {
+            var $sotd = $("#sotd", $ifr[0].contentDocument);
+            expect($sotd.find("p:contains('CUSTOM PARAGRAPH')").length).toEqual(1);
+            expect($sotd.find("a:contains('WGNAME')").length).toEqual(0);
+            expect($sotd.find("a:contains('WGLIST@w3.org')").length).toEqual(0);
+            expect($sotd.find("a:contains('subscribe')").length).toEqual(0);
+            expect($sotd.find("a:contains('disclosures')").attr("href")).toEqual("WGPATENT");
+        });
+    });
 });
 }());


### PR DESCRIPTION
At the request of @michael-n-cooper I added the
respec option overrideStatus.  If this option is true,
then the paragraph that starts "This document was published by..."
will be omitted from the generated output of the SotD.  Apparently
some working groups object to some of the wording and want to provide
their own.