### PR TITLE
Update npm dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     },
     "author": "Robin Berjon",
     "devDependencies": {
-        "express":      "*"
-    ,   "requirejs":    "2.1.8"
-    ,   "prompt":       "0.2.12"
-    ,   "async":        "0.2.9"
+        "async": "^1.5.0",
+        "express": "*",
+        "prompt": "^0.2.14",
+        "requirejs": "^2.1.22"
     }
 }


### PR DESCRIPTION
&hellip;running [updtr](https://github.com/peerigon/updtr). (And sort the lines alphabetically.)

(`npm` complains that there is no licence information in `package.json`; I would have added it myself, but I don't know which licence this projects uses; it isn't said on the repo nor on [`w3.org/respec`](http://www.w3.org/respec/)&hellip;)