### PR TITLE
WebIDL: setID removes digits from the id

### DIFF
--- a/js/core/webidl-oldschool.js
+++ b/js/core/webidl-oldschool.js
@@ -118,7 +118,7 @@ define(
         WebIDLProcessor.prototype = {
             setID:  function (obj, match) {
                 obj.id = match;
-                obj.refId = obj.id.replace(/[^a-zA-Z_\-]/g, "");
+                obj.refId = obj.id.replace(/[^a-zA-Z0-9_\-]/g, "");
                 obj.unescapedId = (obj.id[0] == "_" ? obj.id.slice(1) : obj.id);
             }
         ,   nullable:   function (obj, type) {

--- a/js/core/webidl-oldschool.js
+++ b/js/core/webidl-oldschool.js
@@ -118,7 +118,7 @@ define(
         WebIDLProcessor.prototype = {
             setID:  function (obj, match) {
                 obj.id = match;
-                obj.refId = obj.id.replace(/[^a-zA-Z_\-]/g, "").replace(/^[0-9\-]*/, "");
+                obj.refId = obj.id.replace(/[^a-zA-Z0-9_\-]/g, "").replace(/^[0-9\-]*/, "");
                 obj.unescapedId = (obj.id[0] == "_" ? obj.id.slice(1) : obj.id);
             }
         ,   nullable:   function (obj, type) {

--- a/js/core/webidl-oldschool.js
+++ b/js/core/webidl-oldschool.js
@@ -118,7 +118,7 @@ define(
         WebIDLProcessor.prototype = {
             setID:  function (obj, match) {
                 obj.id = match;
-                obj.refId = obj.id.replace(/[^a-zA-Z0-9_\-]/g, "");
+                obj.refId = obj.id.replace(/[^a-zA-Z_\-]/g, "").replace(/^[0-9\-]*/, "");
                 obj.unescapedId = (obj.id[0] == "_" ? obj.id.slice(1) : obj.id);
             }
         ,   nullable:   function (obj, type) {


### PR DESCRIPTION
The WebIDL support creates `id` from the name of the attributes. If these attributes contain digits in their names, [`setID`](https://github.com/w3c/respec/blob/develop/js/core/webidl-oldschool.js#L121) removes them.
This is a problem for specs like [Vehicule Data](https://w3c.github.io/automotive/vehicle_data/data_spec.html). For instance:
```
    readonly        attribute float?          batteryTempT0;
    readonly        attribute float?          batteryVoltageT120;
    readonly        attribute float?          batteryTempT120;
    readonly        attribute float?          batteryVoltageESD30;
    readonly        attribute float?          batteryTempESD30;
    readonly        attribute float?          batteryVoltageESD450;
    readonly        attribute float?          batteryTempESD450;
    readonly        attribute float?          batteryVoltageESD870;
    readonly        attribute float?          batteryTempESD870;
    readonly        attribute float?          batteryVoltageESD1290;
    readonly        attribute float?          batteryTempESD1290;
    readonly        attribute float?          batteryVoltageESD1710;
    readonly        attribute float?          batteryTempESD1710;
```
resulting in duplicate `id`.

That PR aims at keeping the digits.