### PR TITLE
[Urgent] Avoid assigning property to a string object (non-strict compatible)

### DIFF
--- a/js/core/webidl-contiguous.js
+++ b/js/core/webidl-contiguous.js
@@ -640,11 +640,12 @@ define(
 
                     case "enum":
                         name = defn.name;
-                        defn.values = defn.values.filter(function (v) { return v.type === undefined;})
-                        .map(function(v) {
-                            return { toString: function() {return v;},
-                                     dfn: findDfn(name, v, definitionMap, msg)
-                                   };
+                        defn.values.forEach(function(v,i) {
+                            if (v.type === undefined) {
+                                defn.values[i] = { toString: function() {return v;},
+                                                   dfn: findDfn(name, v, definitionMap, msg)
+                                                 };
+                            }
                         });
                         defn.idlId = "idl-def-" + name.toLowerCase();
                         break;

--- a/js/core/webidl-contiguous.js
+++ b/js/core/webidl-contiguous.js
@@ -641,8 +641,10 @@ define(
                     case "enum":
                         name = defn.name;
                         defn.values.filter(function (v) { return v.type === undefined;})
-                                   .forEach(function(v) {
-                            v.dfn = findDfn(name, v, definitionMap, msg);
+                        .map(function(v) {
+                            return { toString: function() {return v;},
+                                     dfn: findDfn(name, v, definitionMap, msg)
+                                   };
                         });
                         defn.idlId = "idl-def-" + name.toLowerCase();
                         break;

--- a/js/core/webidl-contiguous.js
+++ b/js/core/webidl-contiguous.js
@@ -640,7 +640,7 @@ define(
 
                     case "enum":
                         name = defn.name;
-                        defn.values.filter(function (v) { return v.type === undefined;})
+                        defn.values = defn.values.filter(function (v) { return v.type === undefined;})
                         .map(function(v) {
                             return { toString: function() {return v;},
                                      dfn: findDfn(name, v, definitionMap, msg)


### PR DESCRIPTION
Breaks WebIDL Contiguous mode in Chrome/Edge
cf https://github.com/w3c/presentation-api/issues/232#issuecomment-168742148