### PR TITLE
Fix enumeration values references in WebIDL contiguous mode

### DIFF
--- a/js/core/templates/webidl-contiguous/enum-item.html
+++ b/js/core/templates/webidl-contiguous/enum-item.html
@@ -1,1 +1,1 @@
-{{idn indent}}"<a href="#idl-def-{{parentID}}.{{obj}}" class="idlEnumItem">{{obj}}</a>"{{#if needsComma}},{{/if}}
+{{idn indent}}"<a href="#dom-{{parentID}}-{{lname}}" class="idlEnumItem">{{name}}</a>"{{#if needsComma}},{{/if}}

--- a/js/core/webidl-contiguous.js
+++ b/js/core/webidl-contiguous.js
@@ -423,8 +423,9 @@ define(
                                     }
                                 }
                                 children += idlEnumItemTmpl({
-                                    obj: item,
-                                    parentID: obj.name,
+                                    lname: item.toString().toLowerCase(),
+                                    name: item.toString(),
+                                    parentID: obj.name.toLowerCase(),
                                     indent: indent + 1,
                                     needsComma: needsComma
                                 });

--- a/tests/spec/core/webidl-contiguous-spec.js
+++ b/tests/spec/core/webidl-contiguous-spec.js
@@ -418,6 +418,13 @@ describe("Core - Contiguous WebIDL", function () {
         expect($target.find(".idlEnum:contains('EnumBasic')").attr("id")).toEqual("idl-def-enumbasic");
     });
 
+    it("should handle enumeration value definitions", function () {
+        $section = $("#enumerations", doc);
+        expect($section.find("dfn:contains('one')").attr("id")).toEqual("dom-enumbasic-one");
+        expect($section.find("p[data-link-for] a:contains('one')").attr("href")).toEqual("#dom-enumbasic-one");
+        expect($section.find("#enum-ref-without-link-for a:contains('one')").attr("href")).toEqual("#dom-enumbasic-one");
+    });
+
     it("should handle callbacks", function () {
         $target = $("#cb-basic", doc);
         text = "callback SuperStar = void ();";

--- a/tests/spec/core/webidl-contiguous.html
+++ b/tests/spec/core/webidl-contiguous.html
@@ -386,7 +386,7 @@
       </pre>
       <p id="ex-fields-doc" dfn-for="ExFields"><dfn>ExFields</dfn> contains <dfn>value</dfn> and <dfn>floats</dfn></p>
     </section>
-    <section>
+    <section id="enumerations">
       <h2>Enumerations</h2>
       <p>
         Basic enumeration.
@@ -405,9 +405,9 @@
         };
       </pre>
       <p id="enum-basic-doc"><dfn>EnumBasic</dfn></p>
-      <!--
-        XXX extattr?
-       -->
+      <p dfn-for="EnumBasic"><dfn>one</dfn> is first.</p>
+      <p link-for="EnumBasic"><a>one</a> is referenced with a <code>[link-for]</code> attribute.</p>
+      <p id="enum-ref-without-link-for"><a>EnumBasic.one</a> may also be referenced with fully-qualified name.</p>
     </section>
     <section>
       <h2>Callbacks</h2>


### PR DESCRIPTION
@dontcallmedom's recent commits were not enough to fix the definition of enumeration items. In practice, the template generated references using an "idl-def-" prefix, preserving the case and using a dotted notation, while definitions were made with a "dom-" prefix, lower case characters, and dash-separated parts.

This commit ensures that the references produced in the WebIDL definition correctly use the "dom-" prefix. It includes a regression test.