### PR TITLE
Optimize space used for attributes in WebIDL contiguous

### DIFF
--- a/js/core/templates/webidl-contiguous/attribute.html
+++ b/js/core/templates/webidl-contiguous/attribute.html
@@ -1,3 +1,3 @@
 <span class='idlAttribute' id="{{obj.idlId}}" data-idl data-title='{{obj.name}}'>{{extAttr obj indent
-}}{{idn indent}}{{qualifiers}} attribute <span class='idlAttrType'>{{idlType obj}}</span> {{pads
+}}{{idn indent}}{{qualifiers}}attribute <span class='idlAttrType'>{{idlType obj}}</span> {{pads
 pad}}<span class='idlAttrName'>{{#tryLink obj}}{{escapeAttributeName obj.name}}{{/tryLink}}</span>;</span>

--- a/js/core/webidl-contiguous.js
+++ b/js/core/webidl-contiguous.js
@@ -447,20 +447,23 @@ define(
 
         function writeInterfaceDefinition(opt, callback) {
             var obj = opt.obj, indent = opt.indent;
-            var maxAttr = 0, maxMeth = 0, maxConst = 0;
+            var maxAttr = 0, maxAttrQualifiers = 0, maxMeth = 0, maxConst = 0;
             obj.members.forEach(function (it) {
                 if (typeIsWhitespace(it.type) || it.type === "serializer" || it.type === "maplike") {
                     return;
                 }
                 var len = idlType2Text(it.idlType).length;
-                if (it.type === "attribute") maxAttr = (len > maxAttr) ? len : maxAttr;
-                else if (it.type === "operation") maxMeth = (len > maxMeth) ? len : maxMeth;
+                if (it.type === "attribute") {
+                    var qualifiersLen = writeAttributeQualifiers(it).length;
+                    maxAttr = (len > maxAttr) ? len : maxAttr;
+                    maxAttrQualifiers = (qualifiersLen > maxAttrQualifiers) ? qualifiersLen : maxAttrQualifiers;
+                } else if (it.type === "operation") maxMeth = (len > maxMeth) ? len : maxMeth;
                 else if (it.type === "const") maxConst = (len > maxConst) ? len : maxConst;
             });
             var children = obj.members
                               .map(function (ch) {
                                   switch (ch.type) {
-                                      case "attribute": return writeAttribute(ch, maxAttr, indent + 1);
+                                      case "attribute": return writeAttribute(ch, maxAttr, indent + 1, maxAttrQualifiers);
                                       case "operation": return writeMethod(ch, maxMeth, indent + 1);
                                       case "const": return writeConst(ch, maxConst, indent + 1);
                                       case "serializer": return writeSerializer(ch, indent + 1);
@@ -491,16 +494,21 @@ define(
             });
         }
 
-        function writeAttribute (attr, max, indent) {
-            var len = idlType2Text(attr.idlType).length;
-            var pad = max - len;
+        function writeAttributeQualifiers(attr) {
             var qualifiers = "";
             if (attr.static) qualifiers += "static ";
             if (attr.stringifier) qualifiers += "stringifier ";
             if (attr.inherit) qualifiers += "inherit ";
             if (attr.readonly) qualifiers += "readonly ";
-            qualifiers += "           ";
-            qualifiers = qualifiers.slice(0, 11);
+            return qualifiers;
+        }
+
+        function writeAttribute (attr, max, indent, maxQualifiers) {
+            var len = idlType2Text(attr.idlType).length;
+            var pad = max - len;
+            var qualifiers = writeAttributeQualifiers(attr);
+            qualifiers += pads(maxQualifiers);
+            qualifiers = qualifiers.slice(0, maxQualifiers);
             return idlAttributeTmpl({
                 obj:            attr
             ,   indent:         indent

--- a/js/core/webidl-contiguous.js
+++ b/js/core/webidl-contiguous.js
@@ -453,7 +453,6 @@ define(
                     return;
                 }
                 var len = idlType2Text(it.idlType).length;
-                if (it.static) len += 7;
                 if (it.type === "attribute") maxAttr = (len > maxAttr) ? len : maxAttr;
                 else if (it.type === "operation") maxMeth = (len > maxMeth) ? len : maxMeth;
                 else if (it.type === "const") maxConst = (len > maxConst) ? len : maxConst;

--- a/tests/spec/core/webidl-contiguous-spec.js
+++ b/tests/spec/core/webidl-contiguous-spec.js
@@ -256,8 +256,8 @@ describe("Core - Contiguous WebIDL", function () {
     it("should handle serializer", function () {
         $target = $("#serializer-map", doc);
         text =  "interface SerializerMap {\n" +
-                "                attribute DOMString foo;\n" +
-                "                attribute DOMString bar;\n" +
+                "    attribute DOMString foo;\n" +
+                "    attribute DOMString bar;\n" +
                 "    serializer = {foo, bar};\n" +
                 "};";
         expect($target.text()).toEqual(text);


### PR DESCRIPTION
It's already counted in qualifiers