### PR TITLE
Fix logic in <script src="fixup.js">

### DIFF
--- a/js/w3c/fixup.js
+++ b/js/w3c/fixup.js
@@ -18,7 +18,7 @@ define(
                     statStyle === "LC-NOTE") statStyle = "WD";
                 if (statStyle === "FPWD-NOTE") statStyle = "WG-NOTE";
                 if (statStyle === "finding" || statStyle === "draft-finding") statStyle = "base";
-                var fixup = "null";
+                var fixup;
                 if (statStyle === "unofficial" || statStyle === "base" ||
                     statStyle === "CG-DRAFT" || statStyle === "CG-FINAL" ||
                     statStyle === "BG-DRAFT" || statStyle === "BG-FINAL") {
@@ -29,7 +29,7 @@ define(
                 } else if (conf.useExperimentalStyles) {
                     fixup = "https://www.w3.org/scripts/TR/2016/fixup.js";
                 }
-                if (fixup !== null) {
+                if (fixup) {
                   $("html>body").append($('<script src="' + fixup + '"></script>'));
                 }
                 msg.pub("end", "w3c/fixup");


### PR DESCRIPTION
See:
* [The error in the list](https://lists.w3.org/Archives/Public/public-tr-notifications/2016Feb/0034.html)
* [The message dumped in the spec produced (&ldquo;SyntaxError: Parse error&rdquo;)](https://labs.w3.org/spec-generator/?type=respec&url=https://w3c.github.io/preload/?specStatus=WD;shortName=preload;useExperimentalStyles=false)
* [This condition, which is always `true`](https://github.com/w3c/respec/blob/develop/js/w3c/fixup.js#L32)