### PR TITLE
Teach ReSpec's references about publishers (closes #518)

### DIFF
--- a/js/core/biblio.js
+++ b/js/core/biblio.js
@@ -44,6 +44,14 @@ define(
                 if (ref.etAl) output += " et al";
                 output += ". ";
             }
+            if(ref.publisher){
+                output += ref.publisher;
+                if(/\.$/.test(ref.publisher)){
+                    output += " ";
+                }else{
+                    output += ". ";
+                }
+            }
             if (ref.href) output += '<a href="' + ref.href + '"><cite>' + ref.title + "</cite></a>. ";
             else output += '<cite>' + ref.title + '</cite>. ';
             if (ref.date) output += ref.date + ". ";

--- a/tests/SpecRunner.html
+++ b/tests/SpecRunner.html
@@ -13,6 +13,7 @@
 
     <!-- SPECS -->
     <script src="spec/SpecHelper.js"></script>
+    <script src="spec/core/biblio-spec.js"></script>
     <script src="spec/core/default-root-attr-spec.js"></script>
     <script src="spec/core/style-spec.js"></script>
     <script src="spec/core/override-configuration-spec.js"></script>
@@ -45,6 +46,7 @@
     <script src="spec/core/webidl-oldschool-spec.js"></script>
     <script src="spec/core/webidl-contiguous-spec.js"></script>
     <script src="spec/core/markdown-spec.js"></script>
+
 
     <!-- SOURCE -->
     <!-- none currently -->

--- a/tests/spec/core/biblio-spec.js
+++ b/tests/spec/core/biblio-spec.js
@@ -1,0 +1,65 @@
+/*jshint strict: true, jasmine:true, jquery:true*/
+/*global makeRSDoc, flushIframes*/
+"use strict";
+describe("W3C — Bibliographic References", function() {
+  var MAXOUT = 5000;
+  var basicConfig = {
+    editors: [
+        {name: "Robin Berjon"}
+    ], specStatus: "WD",
+    localBiblio: {
+      "TestRef1": {
+        title: "Test ref title",
+        href: "http://test.com",
+        authors: ["William Shakespeare"],
+        publisher: "Publishers Inc."
+      },
+      "TestRef2": {
+        title: "Second test",
+        href: "http://test.com",
+        authors: ["Another author"],
+        publisher: "Testing 123"
+      },
+      "TestRef3": {
+        title: "Third test",
+        href: "http://test.com",
+        publisher: "Publisher Here"
+      },
+    }
+  };
+
+  it("should display the publisher when present", function() {
+    var doc;
+    runs(function() {
+      makeRSDoc({
+          config: basicConfig,
+          body: $("<section id='sample'><p>foo [[!TestRef1]] [[TestRef2]] [[!TestRef3]]</p></section>")
+      }, function(rsdoc) {
+            doc = rsdoc;
+        });
+    });
+    waitsFor(function() {
+      return doc;
+    }, MAXOUT);
+    runs(function() {
+      // Make sure the reference is added.
+      var ref = doc.querySelector("#bib-TestRef1 + dd");
+      expect(ref).toBeTruthy();
+      expect(ref.textContent).toMatch(/Publishers Inc\.\s/);
+      ref = null;
+      // Make sure the ". " is automatically added to publisher.
+      ref = doc.querySelector("#bib-TestRef2 + dd");
+      expect(ref).toBeTruthy();
+      expect(ref.textContent).toMatch(/Testing 123\.\s/);
+      ref = null;
+
+      // Make sure publisher is shown even when there is no author
+      ref = doc.querySelector("#bib-TestRef3 + dd");
+      expect(ref).toBeTruthy();
+      expect(ref.textContent).toMatch(/^Publisher Here\.\s/);
+
+      //Done!
+      flushIframes();
+    });
+  });
+});

--- a/tests/specifications/publishers.html
+++ b/tests/specifications/publishers.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>Testing Respec References</title>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <script src='../../js/require.js' data-main='../../js/profile-w3c-common' async class='remove'></script>
+
+    <script type="text/javascript" class="remove">
+     var respecConfig = {
+       // specification status (e.g. WD, LCWD, NOTE, etc.). If in doubt use ED.
+       specStatus: "Member-SUBM",
+       specVersion: "v42.0",
+       shortName:  "my-test-spec",
+       publishDate: "2015-11-06",
+
+      // if the specification's copyright date is a range of years, specify
+      // the start date here:
+      copyrightStart: "2015",
+
+       // editors, add as many as you like
+       // only "name" is required
+       editors:  [
+         { name: "This Guy" }
+       , { name: "That Guy" }
+       , { name: "The Other Guy" }
+       ],
+       // authors, add as many as you like.
+       // This is optional, uncomment if you have authors as well as editors.
+       // only "name" is required. Same format as editors.
+
+     authors:  [
+      { name: "Author Guy" }
+     ]
+     };
+    </script>
+    <script type='text/javascript' class='remove'>
+    (function () {
+
+    respecConfig.localBiblio = {
+        "TestRef": {
+            title: "If this reference starts with a title followed by an author and a publisher, Respec works",
+            href: "http://www.w3.org/2001/06/manual/#ref-section",
+            authors: ["William Shakespeare"],
+            publisher: "Publishers Inc."
+        },
+        "TestRef2": {
+            title: "Second test",
+            href: "http://test.com",
+            authors: ["Another author"],
+            publisher: "Testing 123"
+        },
+        "TestRef3": {
+          title: "Third test",
+          href: "http://test.com",
+          publisher: "Publisher Here"
+        },
+    };
+
+    })();
+
+    </script>
+
+</head>
+
+<body>
+
+<section id='abstract'>
+  This spec shows publishers in the References sections: [[!TestRef]], [[TestRef2]], [[!TestRef3]].
+</section>
+<section id='sotd'>
+  Foo.
+</section>
+</body>


### PR DESCRIPTION
Publishers now show up when available in a bibliographical reference, after the author like so... 

<img width="527" alt="screenshot 2016-02-16 20 08 24" src="https://cloud.githubusercontent.com/assets/870154/13071671/19109d52-d4e9-11e5-9fec-a06cac7a4afb.png">
