### PR TITLE
Changed CGBG style references to new repo

### DIFF
--- a/js/w3c/style.js
+++ b/js/w3c/style.js
@@ -63,7 +63,6 @@ define(
             case "CG-FINAL":
             case "BG-DRAFT":
             case "BG-FINAL":
-              styleBaseURL = "https://www.w3.org/community/src/css/spec/";
               styleFile = conf.specStatus.toLowerCase();
               break;
             case "FPWD":


### PR DESCRIPTION
This change assumes that the CG and BG stylesheets and logos are integrated with StyleSheets/TR/2016 as per my pull request w3c/tr-design#70

