### PR TITLE
stop headless.js testing basic.built.html

### DIFF
--- a/tests/headless.js
+++ b/tests/headless.js
@@ -48,6 +48,7 @@ const excludedFiles = new Set([
   "embedder.html",
   "starter.html",
   "PresentationAPI.html",
+  "basic.built.html",
 ]);
 
 const runRespec2html = async(function*(server) {


### PR DESCRIPTION
This is causing headless.js to fail unnecessarily.  