### PR TITLE
Always use a nav

### DIFF
--- a/js/core/structure.js
+++ b/js/core/structure.js
@@ -97,8 +97,7 @@ define(
                 if (!conf.noTOC) {
                     var $ul = makeTOCAtLevel($("body", doc), doc, [0], 1, conf);
                     if (!$ul) return;
-                    var w = conf.useExperimentalStyles ? "nav" : "section";
-                    var $sec = $("<" + w + " id='toc'/>")
+                    var $sec = $("<nav id='toc'/>")
                         .append("<h2 class='introductory'>" + conf.l10n.toc + "</h2>")
                         .append($ul)
                     ,   $ref = $("#toc", doc), replace = false;


### PR DESCRIPTION
We should always use nav#toc independently of the experimental style or not.
