### PR TITLE
Code to switch CG and BG reports to new styles

### DIFF
--- a/js/w3c/style.js
+++ b/js/w3c/style.js
@@ -65,7 +65,6 @@ define(
             case "CG-FINAL":
             case "BG-DRAFT":
             case "BG-FINAL":
-              styleBaseURL = "https://www.w3.org/community/src/css/spec/";
               styleFile = conf.specStatus.toLowerCase();
               break;
             case "FPWD":

--- a/tests/spec/w3c/style-spec.js
+++ b/tests/spec/w3c/style-spec.js
@@ -25,16 +25,16 @@ var specStatus = [{
   expectedURL: "https://www.w3.org/StyleSheets/TR/{version}W3C-FAKE-TEST-TYPE",
 }, {
   status: "CG-FINAL",
-  expectedURL: "https://www.w3.org/community/src/css/spec/cg-final",
+  expectedURL: "https://www.w3.org/StyleSheets/TR/{version}cg-final",
 }, {
   status: "CG-DRAFT",
-  expectedURL: "https://www.w3.org/community/src/css/spec/cg-draft",
+  expectedURL: "https://www.w3.org/StyleSheets/TR/{version}cg-draft",
 }, {
   status: "BG-FINAL",
-  expectedURL: "https://www.w3.org/community/src/css/spec/bg-final",
+  expectedURL: "https://www.w3.org/StyleSheets/TR/{version}bg-final",
 }, {
   status: "BG-DRAFT",
-  expectedURL: "https://www.w3.org/community/src/css/spec/bg-draft",
+  expectedURL: "https://www.w3.org/StyleSheets/TR/{version}bg-draft",
 },];
 
 function loadWithStatus(status, expectedURL, mode) {


### PR DESCRIPTION
The requisite styles and logos are already in the
new location - this just enables their use.  

This supercedes PR #579 