### PR TITLE
Javascript errors shouldn't appear in the output

### DIFF
--- a/tools/respec2html.js
+++ b/tools/respec2html.js
@@ -80,6 +80,10 @@ page.onConsoleMessage = function(msg) {
   }
 };
 
+page.onError = function(msg) {
+  errors.push(msg);
+};
+
 page.open(source, function(status) {
   if (status !== "success") {
     console.error("Unable to access ReSpec source file.");


### PR DESCRIPTION
Otherwise spec-generator can't generate properly the clipboard-apis spec.
