### PR TITLE
Added code to remove toc-nav node (closes #644)

### DIFF
--- a/js/ui/save-html.js
+++ b/js/ui/save-html.js
@@ -8,6 +8,7 @@ define(
         var msg, doc, conf;
         var cleanup = function (rootEl) {
             $(".removeOnSave", rootEl).remove();
+            $("#toc-nav", rootEl).remove() ;
             utils.removeReSpec(rootEl);
         };
         return {


### PR DESCRIPTION
If there is a toc-nav node when saving a snapshot, remove it.  It is not
part of the document. It was added by fixup.js.

Should address #644