### PR TITLE
Fix (release.js): Protect against EPIPE bombs from npmjs (closes #645).

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "async": "^1.5.2",
     "chai": "^3.5.0",
     "colors": "^1.1.2",
+    "epipebomb": "^0.1.1",
     "express": "^4.13.4",
     "fs-extra": "^0.26.5",
     "fs-promise": "^0.5.0",


### PR DESCRIPTION
 * Adds epipebomb package, which swallows EPIPE errors.
 * Adds a default timeout to `toExecPromise`, and the ability to override it.
 * Increases timeout for npm publish.