### PR TITLE
Remove class 'toc-sidebar' from <body> when generating a snapshot

### DIFF
--- a/js/ui/save-html.js
+++ b/js/ui/save-html.js
@@ -9,6 +9,7 @@ define(
         var cleanup = function (rootEl) {
             $(".removeOnSave", rootEl).remove();
             $("#toc-nav", rootEl).remove() ;
+            $("body", rootEl).removeClass('toc-sidebar');
             utils.removeReSpec(rootEl);
         };
         return {


### PR DESCRIPTION
As mentioned in https://github.com/w3c/tr-design/pull/91#issuecomment-208467559, the generated snapshot shouldn't add the class 'toc-sidebar' to the `<body>`. It's added by JS only.
Shoud fix #644 