### PR TITLE
Added support for 'webspec' stylesheet.

### DIFF
--- a/js/w3c/style.js
+++ b/js/w3c/style.js
@@ -58,9 +58,23 @@ define(
           var styleBaseURL = "https://www.w3.org/StyleSheets/TR/{version}";
           var finalStyleURL = "";
           var styleFile = "W3C-";
+          var addFixup = true;
 
           // Figure out which style file to use.
           switch (conf.specStatus.toUpperCase()){
+            case "WEBSPEC":
+              addFixup = false;
+              styleBaseURL = "https://specs.webplatform.org/assets/css/";
+              styleFile = "kraken.css";
+              var icon = doc.createElement("link");
+              icon.rel = "icon";
+              icon.href = "https://specs.webplatform.org/assets/img/icon.png";
+              doc.head.appendChild(icon);
+              var script = doc.createElement("script");
+              script.async = true;
+              script.src = "https://specs.webplatform.org/assets/js/kraken.js";
+              doc.head.appendChild(script) ;
+              break;
             case "CG-DRAFT":
             case "CG-FINAL":
             case "BG-DRAFT":
@@ -98,7 +112,7 @@ define(
           }
 
           // Attach W3C fixup script after we are done.
-          if (version) {
+          if (version && addFixup) {
             var subscribeKey = window.respecEvents.sub("end-all", function (){
               attachFixupScript(doc, version);
               window.respecEvents.unsub("end-all", subscribeKey);

--- a/tests/spec/w3c/style-spec.js
+++ b/tests/spec/w3c/style-spec.js
@@ -33,6 +33,9 @@ var specStatus = [{
   status: "BG-FINAL",
   expectedURL: "https://www.w3.org/StyleSheets/TR/{version}bg-final",
 }, {
+  status: "webspec",
+  expectedURL: "https://specs.webplatform.org/assets/css/kraken.css",
+}, {
   status: "BG-DRAFT",
   expectedURL: "https://www.w3.org/StyleSheets/TR/{version}bg-draft",
 },];


### PR DESCRIPTION
Other support for webspec is already in w3c/headers.js. While the
webplatform.org project never really took off, there are certainly
documents out there that rely upon ReSpec and have this specStatus so we
need to leave support in for those.  We *could* issue a deprecation
warning, but it didn't feel that important to me.

This is related to issue #643 