### PR TITLE
Fix(respec2.css): Override code highlighter background

### DIFF
--- a/js/core/css/respec2.css
+++ b/js/core/css/respec2.css
@@ -3,8 +3,13 @@
  * Robin Berjon - http://berjon.com/
  *****************************************************************/
 
+/* Override code highlighter background */
+.hljs {
+    background: transparent !important;
+}
+
 /* --- INLINES --- */
-em.rfc2119 { 
+em.rfc2119 {
     text-transform:     lowercase;
     font-variant:       small-caps;
     font-style:         normal;


### PR DESCRIPTION
Context: the syntax highlighter uses ".hljs" as its CSS class - but the syntax highlighting themes all have their own custom backgrounds. This makes specs look ugly, so I'm forcing ReSpec to set the background to transparent. 