### PR TITLE
Feat(markdown): teach markdown how to highlight code

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -77,6 +77,16 @@ module.exports = function(config) {
         included: false,
         served: true,
       },
+      {
+        pattern: "./node_modules/highlightjs/*.js",
+        included: false,
+        served: true,
+      },
+      {
+        pattern: "./node_modules/js-beautify/js/lib/*.js",
+        included: false,
+        served: true,
+      },
       "tests/spec/SpecHelper.js",
       "tests/test-main.js",
     ],


### PR DESCRIPTION
Here we actually start teaching the markdown parser how to highlight markdown. This means we can do cool things like triple back tick  + language detection, just like in Github. 
