### PR TITLE
Add firstElementChild polyfill

### DIFF
--- a/js/core/ui.js
+++ b/js/core/ui.js
@@ -9,6 +9,21 @@
 //  - make a release candidate that people can test
 //  - once we have something decent, merge, ship as 3.2.0
 "use strict";
+
+// Quick polyfill for browser broken by lack of ElementTraversal APIs on the document object.
+if (!document.firstElementChild) {
+    Object.defineProperty(Document.prototype, "firstElementChild", { 
+        enumerable: true, configurable: true, get: function () { 
+            var child = this.firstChild;
+            while (child && child.nodeType != 1/*element node*/)
+                child = child.nextSibling;
+            return child;
+        }
+    });
+}
+// lastElementChild does not seem to be used in this codebase. Same for nextElementSibling, 
+// previousElementSibling, childElementCount, and document.children. So, skipping the polyfill for those.
+
 define(
     [
         "shortcut",


### PR DESCRIPTION
Edge browser is broken when loading (live) respect documents for the past few days. Found (one of?) the root causes--lack of ElementTraversal support on the document node. After a quick scan of the respect code, it looks like only `firstElementChild` is used on the document, so this is a minimal polyfill to fix it.

Alternatively, in the place this is used (line 135), you could replace `doc.firstElementChild.addEventListener` with `doc.documentElement.addEventListener` which would be semantically equivalent and better supported (and not need to add this polyfill). We've had this bug in Edge for awhile, but have not yet prioritized fixing it--sorry!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/respec/796)
<!-- Reviewable:end -->
