### PR TITLE
Changed default diff tool URI to use https

### DIFF
--- a/js/ui/save-html.js
+++ b/js/ui/save-html.js
@@ -42,7 +42,7 @@ define(
         return {
             show:   function (ui, _conf, _doc) {
                 doc = _doc, conf = _conf;
-                if (!conf.diffTool) conf.diffTool = "http://www5.aptest.com/standards/htmldiff/htmldiff.pl";
+                if (!conf.diffTool) conf.diffTool = "https://www5.aptest.com/standards/htmldiff/htmldiff.pl";
                 var supportsDownload = Object
                     .getOwnPropertyNames(HTMLAnchorElement.prototype)
                     .indexOf("download") > -1


### PR DESCRIPTION
Changed the default URI for the diff tool to use https.

Addresses issue #808

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/respec/813)
<!-- Reviewable:end -->
