### PR TITLE
Fix figures so more than one link can be made to figures

### DIFF
--- a/js/core/figures.js
+++ b/js/core/figures.js
@@ -50,7 +50,7 @@ define(
                         .prepend($("<span class='figno'>" + num + "</span>"))
                         .prepend(doc.createTextNode(conf.l10n.fig))
                     ;
-                    figMap[id] = $cap.contents().clone();
+                    figMap[id] = $cap.contents();
                     var $tofCap = $cap.clone();
                     $tofCap.find("a").renameElement("span").removeAttr("href");
                     tof.push($("<li class='tofline'><a class='tocxref' href='#" + id + "'></a></li>")
@@ -67,7 +67,7 @@ define(
                     id = id.substring(1);
                     if (figMap[id]) {
                         $a.addClass("fig-ref");
-                        if ($a.html() === "") $a.append(figMap[id]);
+                        if ($a.html() === "") $a.append(figMap[id].clone());
                     }
                 });
 


### PR DESCRIPTION
Behaviour can be reproduced with multiple links created to a figure: without this change only the first one renders.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/respec/822)
<!-- Reviewable:end -->
