### PR TITLE
Hljs update

### DIFF
--- a/js/core/base-runner.js
+++ b/js/core/base-runner.js
@@ -42,7 +42,7 @@ define(
                         try {
                             respecConfig.preProcess[i].apply(this); }
                         catch (e) {
-                            window.console.error(e);
+                            window.console.error(e.stack || JSON.stringify(e));
                         }
                     }
                 }

--- a/js/core/biblio.js
+++ b/js/core/biblio.js
@@ -183,7 +183,7 @@ define(
                     cb();
                     return;
                 }
-                var url = "https://labs.w3.org/specrefs/bibrefs?refs=" + externalRefs.join(",");
+                var url = "https://specref.herokuapp.com/bibrefs?refs=" + externalRefs.join(",");
                 fetch(url)
                     .then(function(response) {
                         return response.json();

--- a/js/core/css/github.css
+++ b/js/core/css/github.css
@@ -1,1 +1,1 @@
-../../../node_modules/highlightjs/styles/github.css
+../../../node_modules/highlight.js/src/styles/github.css

--- a/js/core/highlight.js
+++ b/js/core/highlight.js
@@ -6,8 +6,8 @@ define(
   [
     "core/pubsubhub",
     "core/utils",
-    "highlight",
-    "text!highlightStyles/github.css",
+    "deps/highlight",
+    "text!core/css/github.css",
   ],
   function(pubsubhub, utils, hljs, ghCss) {
     // Opportunistically insert the style into the head to reduce FOUC.

--- a/js/core/markdown.js
+++ b/js/core/markdown.js
@@ -53,9 +53,12 @@ define([
   var defaultLanguages = Object.freeze([
     "css",
     "html",
+    "http",
     "js",
     "json",
+    "markdown",
     "xml",
+    "xquery",
   ]);
 
   hljs.configure({

--- a/js/core/markdown.js
+++ b/js/core/markdown.js
@@ -46,7 +46,7 @@
 define([
   "marked",
   "core/utils",
-  "highlight",
+  "deps/highlight",
   "beautify-html",
   "core/beautify-options",
 ], function(marked, utils, hljs, beautify, beautifyOps) {

--- a/js/deps/highlight.js
+++ b/js/deps/highlight.js
@@ -1,0 +1,1 @@
+../../node_modules/highlight.js/build/highlight.pack.js

--- a/js/profile-w3c-common.js
+++ b/js/profile-w3c-common.js
@@ -21,8 +21,6 @@ require.config({
     "beautify-html": "/node_modules/js-beautify/js/lib/beautify-html",
     "fetch": "/node_modules/whatwg-fetch/fetch",
     "handlebars": "/node_modules/handlebars/dist/handlebars",
-    "highlight": "/node_modules/highlightjs/highlight.pack.min",
-    "highlightStyles": "/node_modules/highlightjs/styles/",
     "jquery": "/node_modules/jquery/dist/jquery",
     "marked": "/node_modules/marked/lib/marked",
     "Promise": "/node_modules/promise-polyfill/promise",

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -78,16 +78,6 @@ module.exports = function(config) {
         served: true,
       },
       {
-        pattern: "./node_modules/highlightjs/*.js",
-        included: false,
-        served: true,
-      },
-      {
-        pattern: "./node_modules/highlightjs/styles/*.css",
-        included: false,
-        served: true,
-      },
-      {
         pattern: "./node_modules/js-beautify/js/lib/*.js",
         included: false,
         served: true,

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "fs-extra": "^0.30.0",
     "fs-promise": "^0.5.0",
     "handlebars": "^4.0.5",
+    "highlight.js": "github:isagalaev/highlight.js",
     "jasmine-core": "^2.4.1",
     "jasmine-reporters": "^2.1.1",
     "jquery": "^3.0.0",
@@ -57,6 +58,8 @@
     "whatwg-fetch": "^1.0.0"
   },
   "scripts": {
+    "postinstall": "npm run build:highlight",
+    "build:highlight": "cd node_modules/highlight.js/; npm install; npm update; node ./tools/build.js -n xml javascript css http markdown; cd ../../",
     "karma": "karma start --single-run",
     "test:karma": "npm run karma",
     "test:headless": "node ./tests/headless.js",
@@ -67,14 +70,15 @@
     "jscs:fix": "jscs --esnext --fix tests",
     "pretest": "npm run jshint && npm run jscs",
     "test:travis": "npm run pretest; npm run test:build; karma start --single-run --reporters progress karma.conf.js; npm run test:headless",
-    "test:appveyor": "npm run pretest"
+    "test:appveyor": "npm run pretest",
+    "build": "npm run build:highlight; npm run build:respec-w3c-common",
+    "build:respec-w3c-common": "./tools/build-w3c-common.js"
   },
   "dependencies": {
     "colors": "^1.1.2",
     "command-line-args": "^3.0.0",
     "command-line-usage": "^3.0.1",
     "fs-promise": "^0.5.0",
-    "highlightjs": "^8.7.0",
     "marcosc-async": "^1.1.3",
     "marked": "^0.3.5",
     "nightmare": "^2.3.3"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "scripts": {
     "postinstall": "npm run build:highlight",
-    "build:highlight": "cd node_modules/highlight.js/; npm install; npm update; node ./tools/build.js -n xml javascript css http markdown; cd ../../",
+    "build:highlight": "cd node_modules/highlight.js/; npm install; npm update; node ./tools/build.js -n xml javascript css http markdown xquery; cd ../../",
     "karma": "karma start --single-run",
     "test:karma": "npm run karma",
     "test:headless": "node ./tests/headless.js",

--- a/tests/spec/core/biblio-spec.js
+++ b/tests/spec/core/biblio-spec.js
@@ -12,7 +12,7 @@ describe("W3C — Bibliographic References", function() {
     var fetchOps = {
       method: "HEAD"
     };
-    fetch("https://labs.w3.org/specrefs/bibrefs", fetchOps)
+    fetch("https://specref.herokuapp.com/bibrefs", fetchOps)
       .then(function(res) {
         isSpecRefAvailable = res.ok;
         expect(res.ok).toBeTruthy();

--- a/tools/builder.js
+++ b/tools/builder.js
@@ -98,8 +98,6 @@ var Builder = {
           "beautify-html": "../node_modules/js-beautify/js/lib/beautify-html",
           "fetch": "../node_modules/whatwg-fetch/fetch",
           "handlebars": "../node_modules/handlebars/dist/handlebars",
-          "highlight": "../node_modules/highlightjs/highlight.pack.min",
-          "highlightStyles": "../node_modules/highlightjs/styles/",
           "jquery": "../node_modules/jquery/dist/jquery",
           "marked": "../node_modules/marked/lib/marked",
           "Promise": "../node_modules/promise-polyfill/promise",


### PR DESCRIPTION
hightlight.js is intended to be built and bundled. Previously, we were
using a pre-built version of hightlightjs. However, the bundle included
all the language options, which bloated ReSpec significantly.

This new version now downloads the hightlighter repo and builds a
custom highlighter specifically for ReSpec using HTML/XML, JS, CSS, HTTP and
markdown as options.

It also now includes highlight.js via a symlink to the generated file.

Additionally, I added an `npm run build` script, which builds both ReSpec
and the highlighter.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/w3c/respec/830)
<!-- Reviewable:end -->
