### PR TITLE
increase contrast for .parameters th and .exceptions th text

### DIFF
--- a/js/core/css/webidl-oldschool.css
+++ b/js/core/css/webidl-oldschool.css
@@ -210,13 +210,12 @@ table.parameters { border-bottom:  1px solid #90b8de; }
 table.exceptions { border-bottom:  1px solid #deb890; }
 
 .parameters th, .exceptions th {
-    color:  #fff;
+    color:  inherit;
     padding:    3px 5px;
     text-align: left;
     font-weight:    normal;
-    text-shadow:    #666 1px 1px 0;
 }
-.parameters th { background: #90b8de; }
+.parameters th { color: #fff; background: #005a9c; }
 .exceptions th { background: #deb890; }
 
 .parameters td, .exceptions td {


### PR DESCRIPTION
drops the text shadow, darkens the .parameters background, explicitly
sets .parameters th color to white and .exceptions th to inherit/black

closes https://github.com/w3c/respec/issues/882