### PR TITLE
Move charset declaration at the top when saving

### DIFF
--- a/js/ui/save-html.js
+++ b/js/ui/save-html.js
@@ -31,6 +31,7 @@ define(
                 metaCharset = doc.createElement("meta");
                 metaCharset.setAttribute("charset", "utf-8");
             }
+            head.insertBefore(metaCharset, head.firstChild);
             // Add meta generator
             var metaGenerator = doc.createElement("meta");
             metaGenerator.name = "generator";


### PR DESCRIPTION
close #791 (again)

the line it adds was mistaken removed in https://github.com/w3c/respec/commit/e5724439d4bcaba0aed60477facc5cd0d06eabd0

(this blocks echidna publications, so hopefully we can release this fix ASAP)