### PR TITLE
Ensure respec2html doesn't cache old respec versions in long-running processes

### DIFF
--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -83,6 +83,7 @@ const tasks = {
         webPreferences: {
           "images": false,
           "defaultEncoding": "utf-8",
+          partition: 'nopersist',
           userData,
         }
       });

--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -83,7 +83,7 @@ const tasks = {
         webPreferences: {
           "images": false,
           "defaultEncoding": "utf-8",
-          partition: 'nopersist',
+          partition: "nopersist",
           userData,
         }
       });


### PR DESCRIPTION
This has caused puzzling errors in the spec generator

credits to @deniak for identifying the bug and fix