### PR TITLE
refactor(utils): ownerSwapper only takes Nodes (close #801)

### DIFF
--- a/js/core/highlight.js
+++ b/js/core/highlight.js
@@ -14,7 +14,7 @@ define(
     var codeStyle = document.createElement("style");
     codeStyle.textContent = ghCss;
     var swapStyleOwner = utils.makeOwnerSwapper(codeStyle);
-    swapStyleOwner(document, document.head);
+    swapStyleOwner(document.head);
     return {
       run: function(conf, doc, cb) {
         // Nothing to do
@@ -23,7 +23,7 @@ define(
         }
 
         if (codeStyle.ownerDocument !== doc) {
-          swapStyleOwner(doc, doc.head);
+          swapStyleOwner(doc.head);
         }
 
         if (doc.querySelector("highlight")) {

--- a/js/core/style.js
+++ b/js/core/style.js
@@ -20,13 +20,13 @@ define(
     styleElement.id = "respec-mainstyle";
     styleElement.textContent = css;
     var swapStyleOwner = utils.makeOwnerSwapper(styleElement);
-    swapStyleOwner(document, document.head);
+    swapStyleOwner(document.head);
     return {
       run: function(conf, doc, cb) {
         if (conf.noReSpecCSS) {
           styleElement.remove();
         } else if (styleElement.ownerDocument !== doc) {
-          swapStyleOwner(doc, doc.head);
+          swapStyleOwner(doc.head);
         }
         cb();
       },

--- a/js/core/utils.js
+++ b/js/core/utils.js
@@ -39,47 +39,24 @@ define(
        * reside.
        *
        * @param  {Node} node The node to be swapped.
-       * @return {Function} A function that takes a document and a new
-       *                    insertion point (element). When called,
+       * @return {Function} A function that takes a new
+       *                    insertion point (Node). When called,
        *                    node gets inserted into doc at before a given
-       *                    insertion point (node) - or just appended, if
+       *                    insertion point (Node) - or just appended, if
        *                    the element has no children.
        */
       makeOwnerSwapper: function(node) {
         if (!(node instanceof Node)) {
-          throw TypeError();
+          throw new TypeError("Expected instance of Node.");
         }
-        return function(doc, insertionPoint) {
+        return function(insertionPoint) {
           node.remove();
-          doc.adoptNode(node);
-          var firstElementChild = this.findFirstElementChild(insertionPoint);
-          if (firstElementChild) {
-            insertionPoint.insertBefore(node, firstElementChild);
-            return;
+          insertionPoint.ownerDocument.adoptNode(node);
+          if (insertionPoint.firstElementChild) {
+            return insertionPoint.insertBefore(node, insertionPoint.firstElementChild);
           }
           insertionPoint.appendChild(node);
-        }.bind(this);
-      },
-      /**
-       * Finds the first Element child, given a node. Provides support for
-       * Microsoft Edge's missing support of .firstElementChild.
-       *
-       * @param  {Node} node The node to be traversed.
-       * @return {Element}   The first Element in the child list.
-       */
-      findFirstElementChild: function(node) {
-        if (!node.hasChildNodes()) {
-          return null;
-        }
-        // We have native support
-        if (node.firstElementChild) {
-          return node.firstElementChild;
-        }
-        return Array
-          .from(node.childNodes)
-          .find(function(node) {
-            return node.nodeType === Node.ELEMENT_NODE;
-          });
+        };
       },
       calculateLeftPad: function(text) {
         if (typeof text !== "string") {

--- a/tests/spec/core/utils-spec.js
+++ b/tests/spec/core/utils-spec.js
@@ -225,7 +225,7 @@ describe("Core - Utils", function() {
       var newDoc = document.implementation.createHTMLDocument("test");
       document.body.appendChild(testNode);
       expect(document.body.contains(testNode)).toBe(true);
-      swapTestNode(newDoc, newDoc.body);
+      swapTestNode(newDoc.body);
       expect(document.body.contains(testNode)).toBe(false);
       expect(testNode.ownerDocument).toEqual(newDoc);
     });
@@ -235,7 +235,7 @@ describe("Core - Utils", function() {
       var swapTestNode = utils.makeOwnerSwapper(testNode);
       var newDoc = document.implementation.createHTMLDocument("test");
       expect(document.head.contains(testNode)).toBe(false);
-      swapTestNode(newDoc, newDoc.head);
+      swapTestNode(newDoc.head);
       expect(newDoc.head.contains(testNode)).toBe(true);
       expect(testNode.ownerDocument).toEqual(newDoc);
     });
@@ -246,24 +246,9 @@ describe("Core - Utils", function() {
       var newDoc = document.implementation.createHTMLDocument("test");
       var metaElem = newDoc.createElement("meta");
       newDoc.head.appendChild(metaElem);
-      swapTestNode(newDoc, newDoc.head);
+      swapTestNode(newDoc.head);
       expect(newDoc.head.firstChild).toEqual(testNode);
       expect(newDoc.head.lastChild).toEqual(metaElem);
-    });
-  });
-
-  describe("findFirstElementChild() method", function(){
-    it("doesn't find elements when there are none to find", function(done){
-      var textNode = document.createTextNode("text");
-      expect(utils.findFirstElementChild(textNode)).toBe(null);
-      done();
-    });
-    it("finds the first Element child amongst a list of nodes", function(done){
-      var div = document.createElement("div");
-      div.innerHTML = "text <span>pass</span> text <span>fail</span> text";
-      expect(utils.findFirstElementChild(div)).toBeTruthy();
-      expect(utils.findFirstElementChild(div).textContent).toEqual("pass");
-      done();
     });
   });
 


### PR DESCRIPTION
* Removes code that Travis said was redundant
* Simplifies the swapper, but getting the owner document directly from insertion point