### PR TITLE
[respecDocWriter] electron not closed properly if the document doesn't exist or is not a respec document

### DIFF
--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -96,6 +96,7 @@ const tasks = {
       if (response.code !== 200) {
         const warn = colors.warn(`📡 HTTP Error ${response.code}:`);
         const msg = `${warn} ${colors.debug(url)}`;
+        nightmare.proc.kill();
         throw new Error(msg);
       }
       const isRespecDoc = yield nightmare
@@ -113,6 +114,7 @@ const tasks = {
         });
       if(!isRespecDoc){
         const msg = `${colors.warn("💣 Not a ReSpec source document?")} ${colors.debug(url)}`;
+        nightmare.proc.kill();
         throw new Error(msg);
       }
       const html = yield nightmare


### PR DESCRIPTION
When using `respecDocWriter`, the `electron` process is not closed when the source provided doesn't return a HTTP 200 (eg. the document doesn't exist) or when the document is not a respec document.
That PR kills the process in the 2 use cases above.