### PR TITLE
Add IDL-index support (closes #159)

### DIFF
--- a/examples/webidl-contiguous.html
+++ b/examples/webidl-contiguous.html
@@ -3,9 +3,7 @@
   <head>
     <meta charset='utf-8'/>
     <title>WebIDL Tests</title>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" class=
-    "remove">
-    </script>
+    <script src='/js/deps/require.js' data-main='/js/profile-w3c-common' async class='remove'></script>
     <script class='remove'>
       var respecConfig = {
               specStatus:   "ED"
@@ -518,6 +516,9 @@ interface Foo {
       <pre id='impl-less-basic' class='idl'>
         [Something]Window implements Breakable;
       </pre>
+    </section>
+    <section id=idl-index>
+      <p>A summary of WebIDL...</p>
     </section>
   </body>
 </html>

--- a/js/core/css/webidl-oldschool.css
+++ b/js/core/css/webidl-oldschool.css
@@ -6,6 +6,14 @@ pre.idl {
     line-height:    120%;
 }
 
+.respec-idl-separator {
+    padding: 0 0 0.4cm 0;
+}
+
+.respec-idl-separator:last-child {
+    padding: 0;
+}
+
 @media print {
   pre.idl {
       white-space: pre-wrap;

--- a/js/core/webidl-contiguous.js
+++ b/js/core/webidl-contiguous.js
@@ -884,10 +884,17 @@ define(
         dfn.wrapInner("<code></code>");
       return dfn;
     }
-
+    var resolveDone;
+    const done = new Promise(function(resolve) {
+      resolveDone = resolve;
+    });
     return {
+      get done() {
+        return done;
+      },
       run: function(conf, doc, cb) {
         var finish = function() {
+          resolveDone();
           pubsubhub.pub("end", "core/webidl-contiguous");
           cb();
         };

--- a/js/core/webidl-index.js
+++ b/js/core/webidl-index.js
@@ -1,0 +1,76 @@
+/**
+ * Module: core/webidl-index
+ * constructs a summary of WebIDL in the document by
+ * cloning all the generated contiguous WebIDL nodes and
+ * appending them to pre element.
+ *
+ * Usage
+ * Add a <section id="idl-index"> to the document.
+ * It also supports title elements to generate a header.
+ * Or if a header element is an immediate child, then
+ * that is preferred.
+ */
+"use strict";
+define(["core/webidl-contiguous"], function(webIDL) {
+  var resolveDone;
+  const done = new Promise(function(resolve) {
+    resolveDone = resolve;
+  });
+  const idlIndexSec = document.querySelector("section#idl-index");
+  if (idlIndexSec) {
+    // Query for decedents headings, e.g., ":scope > h2, etc.."
+    const query = [2, 3, 4, 5, 6]
+      .map(function(level) {
+        return ":scope > h" + level;
+      })
+      .join(",");
+    if (!idlIndexSec.querySelector(query)) {
+      const header = document.createElement("h2");
+      if (idlIndexSec.title) {
+        header.innerHTML = idlIndexSec.title;
+        idlIndexSec.removeAttribute("title");
+      } else {
+        header.innerHTML = "IDL Index";
+      }
+      idlIndexSec.insertAdjacentElement("afterbegin", header);
+    }
+    if (!document.querySelector("pre.idl")) {
+      const text = "This specification doesn't declare any Web IDL.";
+      const noIDLFound = document.createTextNode(text);
+      idlIndexSec.appendChild(noIDLFound);
+      resolveDone();
+    } else {
+      webIDL.done.then(function() {
+        const virtualSummary = document.createDocumentFragment();
+        const pre = document.createElement("pre");
+        pre.classList.add("idl", "def");
+        Array
+          .from(document.querySelectorAll("pre.def.idl"))
+          .map(function(elem) {
+            return elem.cloneNode(true).firstElementChild;
+          })
+          .map(function(elem) {
+            const div = document.createElement("div");
+            div.appendChild(elem);
+            div.appendChild(document.createTextNode("\n"))
+            div.classList.add("respec-idl-separator");
+            return div;
+          })
+          .reduce(function(collector, elem) {
+            collector.appendChild(elem);
+            return collector;
+          }, pre);
+        virtualSummary.appendChild(pre);
+        idlIndexSec.appendChild(virtualSummary);
+        resolveDone();
+      });
+    }
+  } else {
+    resolveDone();
+  }
+  return {
+    get done() {
+      return done;
+    },
+  };
+});

--- a/js/profile-w3c-common.js
+++ b/js/profile-w3c-common.js
@@ -51,6 +51,7 @@ define([
     "core/figures",
     "core/biblio",
     "core/webidl-contiguous",
+    "core/webidl-index",
     "core/webidl-oldschool",
     "core/link-to-dfn",
     "core/highlight",

--- a/tests/spec/core/idl-index-spec.js
+++ b/tests/spec/core/idl-index-spec.js
@@ -1,0 +1,67 @@
+"use strict";
+describe("Core — IDL Index", () => {
+  afterAll( done => {
+    flushIframes();
+    done();
+  });
+  it("generates an idl summary", done => {
+    const body = `
+      ${makeDefaultBody()}
+      <section>
+        <pre class=idl>
+        interface Foo {
+          readonly attribute DOMString bar;
+        };
+        </pre>
+      </section>
+      <section>
+        <pre class=idl>
+        interface Bar {
+          readonly attribute DOMString foo;
+        };
+        </pre>
+      </section>
+      <section id="idl-index"></section>
+    `;
+    const expectedIDL = `interface Foo {
+    readonly attribute DOMString bar;
+};
+interface Bar {
+    readonly attribute DOMString foo;
+};\n`;
+    var ops = {
+      config: makeBasicConfig(),
+      body,
+    };
+    makeRSDoc(ops, function(doc) {
+      var idlIndex = doc.querySelector("#idl-index");
+      expect(idlIndex).not.toBe(null);
+      expect(idlIndex.querySelector("pre").textContent).toEqual(expectedIDL);
+      var header = doc.querySelector("#idl-index > h2");
+      expect(header).not.toBe(null);
+      expect(header.textContent).toEqual("1. IDL Index");
+    }).then(done);
+  });
+  it("allows custom content and header", done => {
+    const body = `
+      ${makeDefaultBody()}
+      <section id="idl-index">
+        <h2>PASS</h2>
+        <p>Custom paragraph.</p>
+      </section>
+    `;
+    var ops = {
+      config: makeBasicConfig(),
+      body,
+    };
+    makeRSDoc(ops, function(doc) {
+      var idlIndex = doc.querySelector("#idl-index");
+      expect(idlIndex).not.toBe(null);
+      expect(idlIndex.querySelector("pre")).toEqual(null);
+      var header = doc.querySelector("#idl-index > h2");
+      expect(header).not.toBe(null);
+      expect(header.textContent).toEqual("1. PASS");
+      expect(doc.querySelectorAll("#idl-index > h2").length).toEqual(1);
+    }).then(done);
+  });
+});

--- a/tests/testFiles.json
+++ b/tests/testFiles.json
@@ -9,6 +9,7 @@
   "spec/core/fix-headers-spec.js",
   "spec/core/highlight-spec.js",
   "spec/core/id-headers-spec.js",
+  "spec/core/idl-index-spec.js",
   "spec/core/include-config-spec.js",
   "spec/core/informative-spec.js",
   "spec/core/inlines-spec.js",


### PR DESCRIPTION
Gathers all the WebIDL into a single section. Keeps all the links.   