### PR TITLE
fix(webidl-contiguous): don't link special IDL things (closes #996)

### DIFF
--- a/js/core/webidl-contiguous.js
+++ b/js/core/webidl-contiguous.js
@@ -840,6 +840,8 @@ define(
     // marked as an IDL definition, and returned.  If no <dfn> is found,
     // the function returns 'undefined'.
     function findDfn(parent, name, definitionMap) {
+      var originalParent = parent;
+      var originalName = name;
       parent = parent.toLowerCase();
       name = name.toLowerCase();
       if (unlinkable.has(name)){
@@ -877,10 +879,10 @@ define(
         }
       }
       if (dfns.length > 1) {
-        pubsubhub.pub("error", "Multiple <dfn>s for " + name + (parent ? " in " + parent : ""));
+        pubsubhub.pub("error", "Multiple <dfn>s for " + originalName + (originalParent ? " in " + originalParent : ""));
       }
       if (dfns.length === 0) {
-        const msg = "No <dfn> for " + name + (parent ? " in " + parent : "") + ".";
+        const msg = "No <dfn> for " + originalName + (originalParent ? " in " + originalParent : "") + ".";
         pubsubhub.pub("warn", msg);
         return undefined;
       }

--- a/js/core/webidl-contiguous.js
+++ b/js/core/webidl-contiguous.js
@@ -36,6 +36,10 @@ define(
     var idlParamTmpl = tmpls["param.html"];
     var idlSerializerTmpl = tmpls["serializer.html"];
     var idlTypedefTmpl = tmpls["typedef.html"];
+    // TODO: make these linkable somehow.
+    // https://github.com/w3c/respec/issues/999
+    // https://github.com/w3c/respec/issues/982
+    var unlinkable = new Set(["maplike", "setlike", "stringifier"])
 
     function registerHelpers() {
       hb.registerHelper("extAttr", function(obj, indent) {
@@ -838,6 +842,9 @@ define(
     function findDfn(parent, name, definitionMap) {
       parent = parent.toLowerCase();
       name = name.toLowerCase();
+      if (unlinkable.has(name)){
+        return;
+      }
       var dfnForArray = definitionMap[name];
       var dfns = [];
       if (dfnForArray) {
@@ -872,8 +879,7 @@ define(
       if (dfns.length > 1) {
         pubsubhub.pub("error", "Multiple <dfn>s for " + name + (parent ? " in " + parent : ""));
       }
-
-      if (dfns.length === 0 && name !== "serializer" && name !== "stringifier") {
+      if (dfns.length === 0) {
         const msg = "No <dfn> for " + name + (parent ? " in " + parent : "") + ".";
         pubsubhub.pub("warn", msg);
         return undefined;


### PR DESCRIPTION
Currently, we don't support linking to "maplike", "setlike", "stringifier"