### PR TITLE
feat(data-cite): add support for data-cite attribute

### DIFF
--- a/js/core/data-cite.js
+++ b/js/core/data-cite.js
@@ -1,0 +1,69 @@
+/**
+ * Module core/data-cite
+ *
+ * Allows citing other specifications using
+ * anchor elements. Simply add "data-cite"
+ * and key of specification.
+ *
+ * This module simply adds the found key
+ * to either conf.normativeReferences
+ * or to conf.informativeReferences depending on
+ * if it starts with a ! or not.
+ *
+ * Usage:
+ * https://github.com/w3c/respec/wiki
+ */
+"use strict";
+define(["core/pubsubhub", "core/biblio"], function(pubsubhub, biblio) {
+  function toLookupRequest(elem) {
+    var originalKey = elem.dataset.cite;
+    var key = elem.dataset.cite.trim();
+    if (key.startsWith("!")) {
+      key = key.substr(1);
+    }
+    return biblio.resolveRef(key).then(function(entry) {
+      elem.removeAttribute("data-cite");
+      if (!entry) {
+        var msg = "Couldn't find a match for `data-cite=" + originalKey + "`.";
+        console.warn(msg, elem);
+        msg += " Please check developer console for offending element.";
+        pubsubhub.pub("warn", msg);
+        return;
+      }
+      elem.href = entry.href;
+    });
+  }
+  return {
+    run: function(conf, doc, cb) {
+      Array
+        .from(doc.querySelectorAll(["a[data-cite]"]))
+        .filter(function(el) {
+          return el.dataset.cite;
+        })
+        .map(function(el) {
+          var ref = el.dataset.cite.trim();
+          const isNormative = ref.startsWith("!");
+          return {
+            isNormative: isNormative,
+            key: (isNormative) ? ref.substr(1) : ref
+          };
+        })
+        .reduce(function(conf, refDetails) {
+          if (refDetails.isNormative) {
+            conf.normativeReferences.add(refDetails.key);
+          } else {
+            conf.informativeReferences.add(refDetails.key);
+          }
+          return conf;
+        }, conf);
+      cb();
+    },
+    linkInlineCitations: function(doc) {
+      const citedSpecs = doc.querySelectorAll("a[data-cite]");
+      const lookupRequests = Array
+        .from(citedSpecs)
+        .map(toLookupRequest);
+      return Promise.all(lookupRequests);
+    }
+  };
+});

--- a/js/core/link-to-dfn.js
+++ b/js/core/link-to-dfn.js
@@ -2,8 +2,8 @@
 // Module core/link-to-dfn
 // Gives definitions in conf.definitionMap IDs and links <a> tags to the matching definitions.
 define(
-    ["core/pubsubhub"],
-    function (pubsubhub) {
+    ["core/pubsubhub", "core/data-cite"],
+    function (pubsubhub, dataCite) {
         return {
             run:    function (conf, doc, cb) {
                 doc.normalize();
@@ -42,7 +42,8 @@ define(
                         }
                     });
                 });
-                $("a:not([href])").each(function () {
+                dataCite.linkInlineCitations(doc);
+                $("a:not([href]):not([data-cite])").each(function () {
                     var $ant = $(this);
                     if ($ant.hasClass("externalDFN")) return;
                     var linkTargets = $ant.linkTargets();

--- a/js/profile-w3c-common.js
+++ b/js/profile-w3c-common.js
@@ -42,6 +42,7 @@ define([
     "w3c/conformance",
     "core/data-transform",
     "core/inlines",
+    "core/data-cite",
     "core/dfn",
     "w3c/rfc2119",
     "core/examples",

--- a/tests/spec/core/data-cite-spec.js
+++ b/tests/spec/core/data-cite-spec.js
@@ -1,0 +1,71 @@
+"use strict";
+describe("Core — data-cite attribute", () => {
+  afterAll(done => {
+    flushIframes();
+    done();
+  });
+  it("links data-cite attributes as normative reference", done => {
+    async.task(function*() {
+      const ops = {
+        config: makeBasicConfig(),
+        body: makeDefaultBody() + `
+          <section>
+            <p id="t1"><a data-cite="!WHATWG-HTML">inline link</a></p>
+          </section>
+        `,
+      };
+      const doc = yield makeRSDoc(ops);
+      const a = doc.querySelector("#t1 > a");
+      expect(a.textContent).toEqual("inline link");
+      expect(a.href).toEqual("https://html.spec.whatwg.org/multipage/");
+      expect(a.hasAttribute("data-cite")).toEqual(false);
+      expect(doc.querySelector("#bib-WHATWG-HTML").closest("section").id)
+        .toEqual("normative-references");
+    }).then(done);
+  });
+  it("links data-cite attributes as informative reference", done => {
+    async.task(function*() {
+      const ops = {
+        config: makeBasicConfig(),
+        body: makeDefaultBody() + `
+          <section>
+            <p id="t1"><a data-cite="WHATWG-DOM">inline link</a></p>
+          </section>
+        `,
+      };
+      const doc = yield makeRSDoc(ops);
+      const a = doc.querySelector("#t1 > a");
+      expect(a.textContent).toEqual("inline link");
+      expect(a.href).toEqual("https://dom.spec.whatwg.org/");
+      expect(a.hasAttribute("data-cite")).toEqual(false);
+      expect(doc.querySelector("#bib-WHATWG-DOM").closest("section").id)
+        .toEqual("informative-references");
+    }).then(done);
+  });
+  it("handles bogus data-cite values", done => {
+    async.task(function*() {
+      const ops = {
+        config: makeBasicConfig(),
+        body: makeDefaultBody() + `
+          <section>
+            <p id="t1"><a data-cite="no-exist-inf">link 1</a></p>
+            <p id="t2"><a data-cite="!no-exist-norm">link 2</a></p>
+          </section>
+        `,
+      };
+      const doc = yield makeRSDoc(ops);
+      const a1 = doc.querySelector("#t1 > a");
+      const a2 = doc.querySelector("#t2 > a");
+      expect(a1.textContent).toEqual("link 1");
+      expect(a2.textContent).toEqual("link 2");
+      expect(a1.href).toEqual("");
+      expect(a2.href).toEqual("");
+      expect(a1.hasAttribute("data-cite")).toEqual(false);
+      expect(a2.hasAttribute("data-cite")).toEqual(false);
+      expect(doc.querySelector("#bib-no-exist-inf").closest("section").id)
+        .toEqual("informative-references");
+      expect(doc.querySelector("#bib-no-exist-norm").closest("section").id)
+        .toEqual("normative-references");
+    }).then(done);
+  });
+});

--- a/tests/testFiles.json
+++ b/tests/testFiles.json
@@ -1,6 +1,7 @@
 [
   "spec/core/best-practices-spec.js",
   "spec/core/biblio-spec.js",
+  "spec/core/data-cite-spec.js",
   "spec/core/data-include-spec.js",
   "spec/core/default-root-attr-spec.js",
   "spec/core/dfn-spec.js",


### PR DESCRIPTION
This adds a new foundation feature to ReSpec, allowing authors to directly cite another SpecRef spec in inline text. This is currently very simple, on purpose... so we can build: 

```HTML
<!-- normative -->
It's in the <a data-cite="!DOM">DOM spec</a>.

<!-- informative -->
It's in the <a data-cite="HTML">HTML spec</a>.
```  

That automatically adds `href` attribute pointing to the DOM spec.  It also adds the reference to the References section in the right place. 