### PR TITLE
feat(biblio-db): use IndexedDB to store refs

### DIFF
--- a/src/core/biblio-db.js
+++ b/src/core/biblio-db.js
@@ -1,0 +1,263 @@
+/**
+ * Module core/biblio-db
+ *
+ * Stores a IndexedDB copy of the references and aliases.
+ */
+/*globals IDBKeyRange, DOMException, console */
+const ALLOWED_TYPES = new Set(["alias", "reference"]);
+// Database initialization, tracked by "readyPromise"
+const readyPromise = new Promise((resolve, reject) => {
+  const request = window.indexedDB.open("respec-biblio", 6);
+  request.onerror = () => {
+    reject(new DOMException(request.error.message, request.error.name));
+  };
+  request.onsuccess = () => {
+    resolve(request.result);
+  };
+  request.onupgradeneeded = function() {
+    const db = request.result;
+    Array
+      .from(db.objectStoreNames)
+      .map(
+        storeName => db.deleteObjectStore(storeName)
+      );
+    const promisesToCreateSchema = [
+      new Promise((resolve, reject) => {
+        try {
+          const store = db.createObjectStore("alias", { keyPath: "id" });
+          store.createIndex("aliasOf", "aliasOf", { unique: false });
+          store.transaction.oncomplete = resolve;
+        } catch (err) {
+          reject(err);
+        }
+      }),
+      new Promise((resolve, reject) => {
+        try {
+          db
+            .createObjectStore("reference", { keyPath: "id" })
+            .transaction
+            .oncomplete = resolve;
+        } catch (err) {
+          reject(err);
+        }
+      }),
+    ];
+    Promise
+      .all(promisesToCreateSchema)
+      .then(() => resolve(db))
+      .catch(reject);
+  };
+});
+
+export const biblioDB = {
+  get ready() {
+    return readyPromise;
+  },
+  /**
+   * Finds either a reference or an alias.
+   * If it's an alias, it resolves it.
+   *
+   * @param {String} id The reference or alias to look for.
+   * @return {Object?} The reference or null.
+   */
+  async find(id) {
+    if (await this.isAlias(id)) {
+      id = await this.resolveAlias(id);
+    }
+    return this.get("reference", id);
+  },
+  /**
+   * Checks if the database has an id for a given type.
+   *
+   * @param {String} type One of the ALLOWED_TYPES.
+   * @param {String} id The reference to find.
+   * @return {Boolean} True if it has it, false otherwise.
+   */
+  async has(type, id) {
+    if (!ALLOWED_TYPES.has(type)) {
+      throw new TypeError("Invalid type: " + type);
+    }
+    if (!id) {
+      throw new TypeError("id is required");
+    }
+    const db = await this.ready;
+    return new Promise((resolve, reject) => {
+      var objectStore = db
+        .transaction([type], "readonly")
+        .objectStore(type);
+      var range = IDBKeyRange.only(id);
+      var request = objectStore.openCursor(range);
+      request.onsuccess = () => {
+        resolve(!!request.result);
+      };
+      request.onerror = () => {
+        reject(new DOMException(request.error.message, request.error.name));
+      };
+    });
+  },
+  /**
+   * Checks if a given id is an alias.
+   *
+   * @param {String} id The reference to check.
+   * @return {Promise<Boolean>} Resolves with true if found.
+   */
+  async isAlias(id) {
+    if (!id) {
+      throw new TypeError("id is required");
+    }
+    const db = await this.ready;
+    return new Promise((resolve, reject) => {
+      var objectStore = db
+        .transaction(["alias"], "readonly")
+        .objectStore("alias");
+      var range = IDBKeyRange.only(id);
+      var request = objectStore.openCursor(range);
+      request.onsuccess = () => {
+        resolve(!!request.result);
+      };
+      request.onerror = () => {
+        reject(new DOMException(request.error.message, request.error.name));
+      };
+    });
+  },
+  /**
+   * Resolves an alias to its corresponding reference id.
+   *
+   * @param {String} id The id of the alias to look up.
+   * @return {Promise<String>} The id of the resolved reference.
+   */
+  async resolveAlias(id) {
+    if (!id) {
+      throw new TypeError("id is required");
+    }
+    const db = await this.ready;
+    return new Promise((resolve, reject) => {
+      var objectStore = db
+        .transaction("alias", "readonly")
+        .objectStore("alias");
+      var range = IDBKeyRange.only(id);
+      var request = objectStore.openCursor(range);
+      request.onsuccess = () => {
+        if (request.result === null) {
+          return resolve(null);
+        }
+        resolve(request.result.value.aliasOf);
+      };
+      request.onerror = () => {
+        reject(new DOMException(request.error.message, request.error.name));
+      };
+    });
+  },
+  /**
+   * Get a reference or alias out of the data.
+   *
+   * @param {[type]} type [description]
+   * @param {[type]} id [description]
+   * @return {[type]} [description]
+   */
+  async get(type, id) {
+    if (!ALLOWED_TYPES.has(type)) {
+      throw new TypeError("Invalid type: " + type);
+    }
+    if (!id) {
+      throw new TypeError("id is required");
+    }
+    const db = await this.ready;
+    return new Promise((resolve, reject) => {
+      var objectStore = db
+        .transaction([type], "readonly")
+        .objectStore(type);
+      var range = IDBKeyRange.only(id);
+      var request = objectStore.openCursor(range);
+      request.onsuccess = () => {
+        if (request.result === null) {
+          return resolve(null);
+        }
+        resolve(request.result.value);
+      };
+      request.onerror = () => {
+        reject(new DOMException(request.error.message, request.error.name));
+      };
+    });
+  },
+  /**
+   * Adds references and aliases to database. This is usually the data from
+   * Specref's output (parsed JSON).
+   *
+   * @param {Object} data An object that contains references and aliases.
+   */
+  async addAll(data) {
+    if (!data) {
+      return;
+    }
+    const aliasesAndRefs = {
+      alias: new Set(),
+      reference: new Set(),
+    };
+    Object
+      .keys(data)
+      .map(
+        id => Object.assign({ id }, data[id])
+      )
+      .reduce((collector, obj) => {
+        if (obj.aliasOf) {
+          collector.alias.add(obj);
+        } else {
+          collector.reference.add(obj);
+        }
+        return collector;
+      }, aliasesAndRefs);
+    const promisesToAdd = Object
+      .keys(aliasesAndRefs)
+      .map(type => {
+        return Array
+          .from(aliasesAndRefs[type])
+          .map(
+            details => this.add(type, details)
+          );
+      })
+      .reduce(
+        (collector, promises) => collector.concat(promises), []
+      );
+    await Promise.all(promisesToAdd);
+  },
+  /**
+   * Adds a reference or alias to the database.
+   *
+   * @param {String} type The type.
+   * @param {String} details The object to store.
+   */
+  async add(type, details) {
+    if (!ALLOWED_TYPES.has(type)) {
+      throw new TypeError("Invalid type: " + type);
+    }
+    if (typeof details !== "object") {
+      throw new TypeError("details should be an object");
+    }
+    if (type === "alias" && !details.hasOwnProperty("aliasOf")) {
+      throw new TypeError("Invalid alias object.");
+    }
+    const db = await this.ready;
+    const isInDB = await this.has(type, details.id);
+    return new Promise((resolve, reject) => {
+      const store = db
+        .transaction([type], "readwrite")
+        .objectStore(type);
+      // update or add, depending of already having it in db
+      var request = isInDB ? store.put(details) : store.add(details);
+      request.onsuccess = resolve;
+      request.onerror = () => {
+        reject(new DOMException(request.error.message, request.error.name));
+      };
+    });
+  },
+  /**
+   * Closes the underlying database.
+   *
+   * @return {Promise} Resolves after database closes.
+   */
+  async close() {
+    const db = await this.ready;
+    db.close();
+  },
+};

--- a/tests/spec/core/biblio-db-spec.js
+++ b/tests/spec/core/biblio-db-spec.js
@@ -1,0 +1,269 @@
+"use strict";
+describe("Core - biblioDB", () => {
+  const data = {
+    "whatwg-dom": {
+      "aliasOf": "WHATWG-DOM"
+    },
+    "WHATWG-DOM": {
+      "authors": [
+        "Anne van Kesteren"
+      ],
+      "href": "https://dom.spec.whatwg.org/",
+      "title": "DOM Standard",
+      "status": "Living Standard",
+      "publisher": "WHATWG",
+      "id": "WHATWG-DOM"
+    },
+    "addAllTest": {
+      "id": "ADD-ALL-TEST",
+      "title": "ADD ALL TEST",
+    },
+  };
+  var biblioDB;
+  beforeAll((done) => {
+    require(["core/biblio-db"], ({ biblioDB: db }) => {
+      biblioDB = db;
+      done();
+    });
+  });
+  describe("ready getter", () => {
+    it("resolves with a IDB database", (done) => {
+      biblioDB.ready.then((db) => {
+        expect(db instanceof window.IDBDatabase).toBe(true);
+      }).then(done);
+    });
+  });
+  describe("add() method", () => {
+    it("rejects when adding bad types", (done) => {
+      biblioDB.add("invalid", "bar").catch(
+        err => expect(err instanceof TypeError).toBe(true)
+      ).then(done);
+    });
+    it("rejects when adding empty type", (done) => {
+      biblioDB.add("", "ref").catch(
+        err => expect(err instanceof TypeError).toBe(true)
+      ).then(done);
+    });
+    it("adds single reference", (done) => {
+      biblioDB.add("reference", {
+          "authors": [
+            "Test Author"
+          ],
+          "href": "https://test/",
+          "title": "test spec",
+          "status": "Living Standard",
+          "publisher": "W3C",
+          "id": "test123"
+        }).then(
+          () => biblioDB.has("reference", "test123")
+        )
+        .then(
+          result => expect(result).toBe(true)
+        )
+        .then(done);
+    });
+  });
+  describe("addAll() method", () => {
+    it("adds both aliases and references", (done) => {
+      biblioDB
+        .addAll(data)
+        .then(
+          () => Promise.all([
+            biblioDB.has("alias", "whatwg-dom"),
+            biblioDB.has("reference", "ADD-ALL-TEST"),
+            biblioDB.has("reference", "WHATWG-DOM"),
+          ])
+        ).then(
+          results => expect(results.every(v => v === true)).toBe(true)
+        ).then(
+          done
+        );
+    });
+  });
+  describe("get() method", () => {
+    it("rejects when getting invalid type", (done) => {
+      biblioDB.get("invalid", "bar").catch(
+        err => expect(err instanceof TypeError).toBe(true)
+      ).then(done);
+    });
+    it("rejects when id is missing", (done) => {
+      biblioDB.get("invalid").catch(
+        err => expect(err instanceof TypeError).toBe(true)
+      ).then(done);
+    });
+    it("retrieves a reference", (done) => {
+      biblioDB.add("reference", {
+          "href": "https://test/",
+          "title": "PASS",
+          "publisher": "W3C",
+          "id": "get-ref-test"
+        }).then(
+          () => biblioDB.get("reference", "get-ref-test")
+        )
+        .then(
+          entry => expect(entry.title).toEqual("PASS")
+        )
+        .then(done);
+    });
+    it("retrieves an alias", (done) => {
+      biblioDB.add("alias", {
+          "id": "ALIAS-GET-TEST",
+          "aliasOf": "PASS",
+        }).then(
+          () => biblioDB.get("alias", "ALIAS-GET-TEST")
+        )
+        .then(
+          entry => expect(entry.aliasOf).toEqual("PASS")
+        )
+        .then(done);
+    });
+    it("returns null when it can't find an entry", (done) => {
+      Promise.all([
+          biblioDB.get("reference", "does not exist"),
+          biblioDB.get("alias", "does not exist"),
+        ])
+        .then(
+          results => expect(results.every(v => v === null)).toBe(true)
+        )
+        .then(done);
+    });
+  });
+  describe("has() method", () => {
+    it("rejects on invalid type", (done) => {
+      biblioDB.has("invalid", "bar").catch(
+        err => expect(err instanceof TypeError).toBe(true)
+      ).then(done);
+    });
+    it("rejects when id is missing", (done) => {
+      biblioDB.has("invalid").catch(
+        err => expect(err instanceof TypeError).toBe(true)
+      ).then(done);
+    });
+    it("returns true when entries exist", (done) => {
+      Promise.all(
+          [
+            biblioDB.add("reference", {
+              id: "has-ref-test",
+              "title": "pass",
+            }),
+            biblioDB.add("alias", {
+              id: "has-alias-test",
+              "aliasOf": "pass",
+            })
+          ]).then(
+          () => Promise.all([
+            biblioDB.has("reference", "has-ref-test"),
+            biblioDB.has("alias", "has-alias-test"),
+          ])
+        )
+        .then(
+          result => expect(result.every(v => v === true)).toBe(true)
+        )
+        .then(done);
+    });
+    it("returns false when entries don't exist", (done) => {
+      Promise.all([
+          biblioDB.has("reference", "does not exist"),
+          biblioDB.has("alias", "does not exist"),
+        ])
+        .then(
+          result => expect(result.every(v => v === false)).toBe(true)
+        )
+        .then(done);
+    });
+  });
+  describe("isAlias() method", () => {
+    it("rejects if passed a bad id", (done) => {
+      var p1 = biblioDB.isAlias();
+      var p2 = biblioDB.isAlias(null);
+      var p3 = biblioDB.isAlias("");
+      Promise.all([
+        p1.catch(err => expect(err instanceof TypeError).toBe(true)),
+        p2.catch(err => expect(err instanceof TypeError).toBe(true)),
+        p3.catch(err => expect(err instanceof TypeError).toBe(true)),
+      ]).then(done);
+    });
+    it("returns true when it is an alias", (done) => {
+      biblioDB
+        .add("alias", { aliasOf: "isAlias", id: "test-isAlias-pass" })
+        .then(
+          () => biblioDB.isAlias("test-isAlias-pass")
+        ).then(
+          result => expect(result).toBe(true)
+        ).then(
+          done
+        );
+    });
+    it("returns false when it is not an alias", (done) => {
+      biblioDB
+        .isAlias("not an alias")
+        .then(result => expect(result).toBe(false))
+        .then(done);
+    });
+  });
+  describe("find() method", () => {
+    it("rejects if passed a bad id", (done) => {
+      var p1 = biblioDB.find();
+      var p2 = biblioDB.find(null);
+      var p3 = biblioDB.find("");
+      Promise.all([
+        p1.catch(err => expect(err instanceof TypeError).toBe(true)),
+        p2.catch(err => expect(err instanceof TypeError).toBe(true)),
+        p3.catch(err => expect(err instanceof TypeError).toBe(true)),
+      ]).then(done);
+    });
+    it("finds a references and resolves aliases", (done) => {
+      biblioDB
+        .addAll(data)
+        .then(
+          () => biblioDB.find("WHATWG-DOM")
+        )
+        .then(
+          result => expect(result.id).toEqual("WHATWG-DOM")
+        )
+        .then(
+          () => biblioDB.find("whatwg-dom") // alias
+        )
+        .then(
+          result => expect(result.title).toEqual("DOM Standard")
+        )
+        .then(
+          done
+        );
+    });
+  });
+  describe("resolveAlias() method", () => {
+    it("rejects if passed a bad id", (done) => {
+      var p1 = biblioDB.resolveAlias();
+      var p2 = biblioDB.resolveAlias(null);
+      var p3 = biblioDB.resolveAlias("");
+      Promise.all([
+        p1.catch(err => expect(err instanceof TypeError).toBe(true)),
+        p2.catch(err => expect(err instanceof TypeError).toBe(true)),
+        p3.catch(err => expect(err instanceof TypeError).toBe(true)),
+      ]).then(done);
+    });
+    it("resolves known aliases or return null when alias is unknown", (done)=>{
+      biblioDB
+        .addAll(data)
+        .then(
+          () => biblioDB.resolveAlias("whatwg-dom")
+        )
+        .then(
+          result => expect(result).toEqual("WHATWG-DOM")
+        )
+        .then(
+          () => biblioDB.resolveAlias("does not exist")
+        )
+        .then(
+          result => expect(result).toBe(null)
+        )
+        .then(
+          done
+        );
+    });
+  });
+  describe("close() method", () => {
+
+  });
+});

--- a/tests/test-main.js
+++ b/tests/test-main.js
@@ -15,7 +15,7 @@ var testFiles = Object.keys(window.__karma__.files)
     collector.push(nextFile);
     return collector;
   }, [])
-  .concat(["js/deps/async"]);
+  .concat(["js/deps/async", "js/deps/regenerator"]);
 
 require.config({
   // Karma serves files under /base, which is the basePath from your config file
@@ -28,6 +28,7 @@ require.config({
     "core/jquery-enhanced": "/base/js/core/jquery-enhanced",
     "core/pubsubhub": "/base/js/core/pubsubhub",
     "core/utils": "/base/js/core/utils",
+    "core/biblio-db": "/base/js/core/biblio-db",
     "w3c/linter": "/base/js/w3c/linter",
     "deps/jquery": "/base/js/deps/jquery",
     "deps/async": "/base/js/deps/async",

--- a/tests/testFiles.json
+++ b/tests/testFiles.json
@@ -1,5 +1,6 @@
 [
   "spec/core/best-practices-spec.js",
+  "spec/core/biblio-db-spec.js",
   "spec/core/biblio-spec.js",
   "spec/core/data-cite-spec.js",
   "spec/core/data-include-spec.js",


### PR DESCRIPTION
This part puts in place the IndexedDB infrastructure and corresponding tests. ReSpec doesn't actually start making use of IDB here. However, this proves that it can be loaded, and things can be added to the database (in the tests). 