### PR TITLE
Use lowercase when linking to enum values

### DIFF
--- a/js/core/webidl-contiguous.js
+++ b/js/core/webidl-contiguous.js
@@ -475,7 +475,7 @@ define(
                   }
                 }
                 children += idlEnumItemTmpl({
-                  lname: item.toString() ? item.toString() : "the-empty-string",
+                  lname: item.toString() ? item.toString().toLowerCase() : "the-empty-string",
                   name: item.toString(),
                   parentID: obj.name.toLowerCase(),
                   indent: indent + 1,


### PR DESCRIPTION
Otherwise, respec creates a broken link