### PR TITLE
feat: enable data-cite on dfn

### DIFF
--- a/js/core/link-to-dfn.js
+++ b/js/core/link-to-dfn.js
@@ -41,7 +41,6 @@ define(
             }
           });
         });
-        dataCite.linkInlineCitations(doc);
         $("a:not([href]):not([data-cite])").each(function() {
           var $ant = $(this);
           if ($ant.hasClass("externalDFN")) return;
@@ -49,7 +48,11 @@ define(
           var foundDfn = linkTargets.some(function(target) {
             if (titles[target.title] && titles[target.title][target.for_]) {
               var dfn = titles[target.title][target.for_];
-              $ant.attr("href", "#" + dfn.prop("id")).addClass("internalDFN");
+              if(dfn[0].dataset.cite){
+                $ant[0].dataset.cite = dfn[0].dataset.cite;
+              } else {
+                $ant.attr("href", "#" + dfn.prop("id")).addClass("internalDFN");
+              }
               // add a bikeshed style indication of the type of link
               if (!$ant.attr("data-link-type")) {
                 $ant.attr("data-link-type", "dfn");
@@ -82,6 +85,7 @@ define(
             $ant.replaceWith($ant.contents());
           }
         });
+        dataCite.linkInlineCitations(doc);
         // done linking, so clean up
         function attrToDataAttr(name) {
           return function(elem) {

--- a/src/core/data-cite.js
+++ b/src/core/data-cite.js
@@ -32,12 +32,24 @@ async function toLookupRequest(elem) {
   if (frag) {
     href += frag;
   }
-  elem.href = href;
+  switch (elem.localName) {
+    case "a":
+      elem.href = href;
+      break;
+    case "dfn":
+      const a = elem.ownerDocument.createElement("a");
+      a.href = href;
+      while (elem.firstChild) {
+        a.appendChild(elem.firstChild);
+      }
+      elem.appendChild(a, elem);
+      break;
+  }
 }
 
 function cleanElement(elem) {
   ["data-cite", "data-cite-frag"]
-    .filter(attrName => elem.hasAttribute(attrName))
+  .filter(attrName => elem.hasAttribute(attrName))
     .forEach(attrName => elem.removeAttribute(attrName))
 }
 
@@ -60,7 +72,7 @@ function toCiteDetails({ dataset }) {
 
 export function run(conf, doc, cb) {
   Array
-    .from(doc.querySelectorAll(["a[data-cite]"]))
+    .from(doc.querySelectorAll(["dfn[data-cite], a[data-cite]"]))
     .filter(el => el.dataset.cite)
     .map(toCiteDetails)
     .reduce((conf, { isNormative, key }) => {
@@ -75,7 +87,7 @@ export function run(conf, doc, cb) {
 }
 
 export async function linkInlineCitations(doc) {
-  const citedSpecs = doc.querySelectorAll("a[data-cite]");
+  const citedSpecs = doc.querySelectorAll("dfn[data-cite], a[data-cite]");
   const lookupRequests = Array
     .from(citedSpecs)
     .map(toLookupRequest);

--- a/tests/spec/core/data-cite-spec.js
+++ b/tests/spec/core/data-cite-spec.js
@@ -4,6 +4,34 @@ describe("Core — data-cite attribute", () => {
     flushIframes();
     done();
   });
+  it("links directly to externally defined references", done => {
+    const ops = {
+      config: makeBasicConfig(),
+      body: makeDefaultBody() + `
+        <section>
+          <p id="t1"><a>inline link</a></p>
+          <p id="t2"><dfn data-cite="!WHATWG-HTML#test">inline link</dfn></p>
+        </section>
+      `,
+    };
+    makeRSDoc(ops).then(doc => {
+      const a = doc.querySelector("#t1 > a");
+      expect(a.textContent).toEqual("inline link");
+      expect(a.href).toEqual("https://html.spec.whatwg.org/multipage/#test");
+      expect(a.hasAttribute("data-cite")).toEqual(false);
+      expect(doc.querySelector("#bib-WHATWG-HTML").closest("section").id)
+        .toEqual("normative-references");
+      // Definition part
+      const dfn = doc.querySelector("#t2 > dfn");
+      expect(dfn).toBeTruthy();
+      const dfnA = doc.querySelector("#t2 > dfn > a");
+      expect(dfnA.textContent).toEqual("inline link");
+      expect(dfnA.href).toEqual("https://html.spec.whatwg.org/multipage/#test");
+      expect(dfnA.hasAttribute("data-cite")).toEqual(false);
+      expect(doc.querySelector("#bib-WHATWG-HTML").closest("section").id)
+        .toEqual("normative-references");
+    }).then(done);
+  });
   it("links data-cite attributes as normative reference", done => {
     const ops = {
       config: makeBasicConfig(),


### PR DESCRIPTION
This enables citing definitions in other specs:

```HTML
<p>The <a>bar</a>...</p> 
<p>The <dfn data-cite="!foo#bar">bar</a></p>
```

Which automatically:

 * links "bar" to the external spec
 * links the dfn to the external spec
 * add the reference to the References section
