### PR TITLE
tests: run karma against build instead

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -29,6 +29,10 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [{
+        pattern: "builds/**/*.*",
+        included: false,
+        served: true,
+      }, {
         pattern: "js/**/*.*",
         included: false,
         served: true,

--- a/tests/spec/SpecHelper.js
+++ b/tests/spec/SpecHelper.js
@@ -54,9 +54,10 @@ function decorateDocument(doc, opts) {
     var configText = "var respecConfig = " + JSON.stringify(opts.config || {}) + ";";
     config.classList.add("remove");
     config.innerText = configText;
+    var isKarma = (!!window.__karma__);
     var loadAttr = {
-      src: "/js/deps/require.js",
-      "data-main": path + (opts.profile || "profile-w3c-common")
+      src: (isKarma) ? new URL("/base/builds/respec-w3c-common.js", location).href : "/js/deps/require.js",
+      "data-main": (isKarma) ? "" : path + (opts.profile || "profile-w3c-common")
     };
     Object
       .keys(loadAttr)


### PR DESCRIPTION
As we can't see the errors, it doesn't make sense to run Karma/Travis against the unbuilt version.