### PR TITLE
fix: use monospace font for <a>s that link back to IDL

### DIFF
--- a/js/core/link-to-dfn.js
+++ b/js/core/link-to-dfn.js
@@ -66,7 +66,10 @@ define(
               if (dfn.closest('code,pre').length ||
                 (dfn.contents().length === 1 && dfn.children('code').length === 1)) {
                 // only add code to IDL when the definition matches
-                if (dfn[0].dataset.hasOwnProperty("idl") && dfn[0].dataset.title !== $ant[0].textContent.trim()) {
+                const term = $ant[0].textContent.trim();
+                const isIDL = dfn[0].dataset.hasOwnProperty("idl");
+                const isSameText = (isIDL) ? dfn[0].dataset.title === term : dfn[0].textContent.trim() === term;
+                if (isIDL && !isSameText) {
                   return true;
                 }
                 $ant.wrapInner('<code></code>');

--- a/js/core/webidl-contiguous.js
+++ b/js/core/webidl-contiguous.js
@@ -945,6 +945,8 @@ define(
       // Mark the definition as code.
       dfn.attr("id", "dom-" + (parent ? parent + "-" : "") + name);
       dfn.attr("data-idl", "");
+      dfn.attr("data-title", dfn[0].textContent);
+
       dfn.attr("data-dfn-for", parent);
       if (dfn.children("code").length === 0 && dfn.parents("code").length === 0)
         dfn.wrapInner("<code></code>");

--- a/tests/spec/core/link-to-dfn-spec.js
+++ b/tests/spec/core/link-to-dfn-spec.js
@@ -1,0 +1,32 @@
+"use strict";
+describe("Core — Link to definitions", function() {
+  afterAll(function(done) {
+    flushIframes();
+    done();
+  });
+  it("links to IDL definitions and wraps in code if needed", function(done) {
+    const bodyText = `
+    <section data-link-for="Request">
+      <h2><dfn>Request</dfn> interface</h2>
+      <pre class="idl">
+        interface Request {};
+      </pre>
+      <p id="codeWrap">A <a>Request</a> object.</p>
+      <p id="noCodeWrap">An instance of <a lt="Request">the request interface</a>.</p>
+    </section>`;
+    var ops = {
+      config: makeBasicConfig(),
+      body: makeDefaultBody() + bodyText,
+    };
+    makeRSDoc(ops, doc => {
+      const hasCode = doc.body.querySelector("#codeWrap a");
+      expect(hasCode).toBeTruthy();
+      expect(hasCode.firstElementChild.localName).toEqual("code");
+      expect(hasCode.textContent).toEqual("Request");
+      const noCodeWrap = doc.body.querySelector("#noCodeWrap a");
+      expect(noCodeWrap).toBeTruthy();
+      expect(noCodeWrap.querySelector("code")).toBeFalsy();
+      expect(noCodeWrap.textContent).toEqual("the request interface");
+    }).then(done);
+  });
+});

--- a/tests/testFiles.json
+++ b/tests/testFiles.json
@@ -17,6 +17,7 @@
   "spec/core/inlines-spec.js",
   "spec/core/issues-notes-spec.js",
   "spec/core/jquery-enhanced-spec.js",
+  "spec/core/link-to-dfn-spec.js",
   "spec/core/markdown-spec.js",
   "spec/core/override-configuration-spec.js",
   "spec/core/pre-process-spec.js",


### PR DESCRIPTION
* closes #1088