### PR TITLE
fix(respec2.css): remove acronym styles

### DIFF
--- a/js/core/css/respec2.css
+++ b/js/core/css/respec2.css
@@ -19,13 +19,6 @@ em.rfc2119 {
   color: #900;
 }
 
-h1 acronym,
-h2 acronym,
-h3 acronym,
-h4 acronym,
-h5 acronym,
-h6 acronym,
-a acronym,
 h1 abbr,
 h2 abbr,
 h3 abbr,


### PR DESCRIPTION
The acronym element was made redudant in HTML5, so this is no longer needed.