### PR TITLE
feat: add URL query values to exported user config 

### DIFF
--- a/src/core/include-config.js
+++ b/src/core/include-config.js
@@ -3,33 +3,15 @@
 import { sub } from "core/pubsubhub";
 export const name = "core/include-config";
 
-function confFilter(key, val) {
-  switch (key) {
-    // DefinitionMap contains array of DOM elements that aren't serializable
-    // we replace them by their id`
-    case "definitionMap":
-      return Object.keys(val).reduce((ret, k) => {
-        ret[k] = val[k].map(d => d[0].id);
-      }, {});
-    default:
-      return val;
-  }
-}
+const userConfig = {};
+const amendConfig = newValues => Object.assign(userConfig, newValues);
 
-sub(
-  "start-all",
-  config => {
-    var script = document.createElement("script");
-    script.id = "initialUserConfig";
-    script.innerHTML = JSON.stringify(config, confFilter, 2);
-    script.type = "application/json";
-    sub(
-      "end-all",
-      () => {
-        document.head.appendChild(script);
-      },
-      { once: true }
-    );
-  },
-  { once: true }
-);
+sub("start-all", amendConfig);
+sub("amend-user-config", amendConfig);
+sub("end-all", () => {
+  const script = document.createElement("script");
+  script.id = "initialUserConfig";
+  script.type = "application/json";
+  script.innerHTML = JSON.stringify(userConfig, null, 2);
+  document.head.appendChild(script);
+});

--- a/src/core/override-configuration.js
+++ b/src/core/override-configuration.js
@@ -7,7 +7,7 @@
 // Note that fields are separated by semicolons and not ampersands.
 // TODO
 //  There could probably be a UI for this to make it even simpler.
-import { sub } from "core/pubsubhub";
+import { sub, pub } from "core/pubsubhub";
 
 export const name = "core/override-configuration";
 
@@ -33,5 +33,6 @@ function overrideConfig(config) {
       return collector;
     }, {});
   Object.assign(config, overrideProps);
+  pub("amend-user-config", overrideProps);
 }
 sub("start-all", overrideConfig, { once: true });

--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -389,7 +389,6 @@ export function run(conf, doc, cb) {
   conf.publishDate = conf.publishDate
     ? new Date(conf.publishDate)
     : new Date(doc.lastModified);
-
   conf.publishYear = conf.publishDate.getFullYear();
   conf.publishHumanDate = W3CDate.format(conf.publishDate);
   conf.isNoTrack = $.inArray(conf.specStatus, noTrackStatus) >= 0;
@@ -714,6 +713,12 @@ export function run(conf, doc, cb) {
         "please add the prerequisite content in the 'sotd' section"
     );
   }
+  // Requested by https://github.com/w3c/respec/issues/504
+  // Makes a record of a few auto-generated things.
+  pub("amend-user-config", {
+    publishISODate: conf.publishISODate,
+    generatedSubtitle: `${conf.longStatus} ${conf.publishHumanDate}`,
+  });
   cb();
 }
 

--- a/tests/spec/core/include-config-spec.js
+++ b/tests/spec/core/include-config-spec.js
@@ -10,6 +10,7 @@ describe("Core — Include config as JSON", function() {
       config: makeBasicConfig(),
       body: makeDefaultBody(),
     };
+    ops.config.publishDate = "1999-12-11";
     done();
   });
   it("should have a script tag with the correct attributes", function(done) {
@@ -20,10 +21,24 @@ describe("Core — Include config as JSON", function() {
       expect(script.type).toEqual("application/json");
     }).then(done);
   });
+  it("includes config options from query parameters", done => {
+    makeRSDoc(ops, doc => {
+      const conf = JSON.parse(doc.getElementById("initialUserConfig").textContent);
+      expect(conf.foo).toEqual("bar");
+      expect(conf.bar).toEqual(123);
+      expect(conf.baz.length).toEqual(3);
+      expect(conf.baz).toEqual([1, 2, 3]);
+    }, "spec/core/simple.html?foo=bar&bar=123&baz=[1,2,3]").then(done);
+  });
   it("should have the same content for the config and the script's text", function(
     done
   ) {
-    const expected = JSON.stringify(makeBasicConfig(), null, 2);
+    const expectedObj = Object.assign(makeBasicConfig(), {
+      publishDate: "1999-12-11",
+      publishISODate: "1999-12-11T00:00:00.000Z",
+      generatedSubtitle: "Editor's Draft 11 December 1999",
+    });
+    const expected = JSON.stringify(expectedObj, null, 2);
     makeRSDoc(ops, function(doc) {
       var text = doc.getElementById("initialUserConfig").innerHTML;
       expect(text).toEqual(expected);


### PR DESCRIPTION
closes #504. 

Exposes:
* `publishISODate`
* `generatedSubtitle`
* any query params added via the URL (e.g., ?foo=bar&baz=123). 
 