### PR TITLE
BREAKING CHANGE: use markdown for error/warn

### DIFF
--- a/js/core/ui.js
+++ b/js/core/ui.js
@@ -10,8 +10,14 @@
 //  - once we have something decent, merge, ship as 3.2.0
 "use strict";
 define(
-  ["shortcut", "core/pubsubhub", "deps/text!ui/ui.css", "core/jquery-enhanced"],
-  function(shortcut, pubsubhub, css) {
+  [
+    "shortcut",
+    "core/pubsubhub",
+    "deps/text!ui/ui.css",
+    "core/utils",
+    "core/jquery-enhanced",
+  ],
+  function(shortcut, pubsubhub, css, utils) {
     // Opportunistically inserts the style, with the chance to reduce some FOUC
     const styleElement = document.createElement("style");
     styleElement.id = "respec-ui-styles";
@@ -140,7 +146,22 @@ define(
                 .hide()
                 .end();
             } else {
-              $("<li></li>").text(err).appendTo($ul);
+              const tmp = document.createElement("tmp");
+              tmp.innerHTML = utils.markdownToHtml(err);
+              const li = document.createElement("li");
+              // if it's only a single element, just copy the contents into li
+              if (tmp.firstElementChild === tmp.lastElementChild) {
+                while (
+                  tmp.firstElementChild &&
+                  tmp.firstElementChild.hasChildNodes()
+                ) {
+                  li.appendChild(tmp.firstElementChild.firstChild);
+                }
+                // Otherwise, take everything.
+              } else {
+                li.innerHTML = tmp.innerHTML;
+              }
+              $ul[0].appendChild(li);
             }
           }
           ui.freshModal(title, $ul, this);

--- a/js/ui/ui.css
+++ b/js/ui/ui.css
@@ -140,23 +140,29 @@
   list-style: none;
   font-family: sans-serif;
   background-color: rgb(255, 251, 230);
-  font-size: .9em;
+  font-size: .85em;
 }
 
-.respec-warning-list li,
-.respec-error-list li {
+.respec-warning-list>li,
+.respec-error-list>li {
   padding: 0.4em 0.7em;
 }
 
-.respec-warning-list li::before {
+.respec-warning-list>li::before {
   content: "⚠️";
   padding-right: .5em;
+}
+.respec-warning-list p,
+.respec-error-list p {
+  padding: 0;
+  margin: 0;
 }
 
 .respec-warning-list li {
   color: rgb(92, 59, 0);
   border-bottom: thin solid rgb(255, 245, 194);
 }
+
 
 .respec-error-list,
 .respec-error-list li {
@@ -172,6 +178,12 @@
   padding: 0.4em 0.7em;
   color: rgb(92, 59, 0);
   border-bottom: thin solid rgb(255, 215, 215);
+}
+
+.respec-error-list li>p {
+  margin: 0;
+  padding: 0;
+  display: inline-block;
 }
 
 #respec-overlay {
@@ -218,7 +230,7 @@
   font-size: 1em;
 }
 
-.respec-modal .inside p {
+.respec-modal .inside div p {
   padding-left: 1cm;
 }
 
@@ -260,7 +272,6 @@
     text-decoration-color: red;
   }
 }
-
 
 .respec-button-copy-paste {
   position: absolute;

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -34,6 +34,11 @@ module.exports = function(config) {
         served: true,
       },
       {
+        pattern: "js/deps/marked.js",
+        included: false,
+        served: true,
+      },
+      {
         pattern: "js/**/*.*",
         included: false,
         served: true,
@@ -64,6 +69,10 @@ module.exports = function(config) {
       "/js/": "/base/js/",
       "/tests/": "/base/tests/",
       "/spec/": "/base/tests/spec/",
+      "/deps/": "/base/js/deps/",
+      "/js/deps/": "/base/js/deps/",
+      "/base/deps/": "/base/js/deps/",
+      "/base/deps/marked.js": "/base/js/deps/marked.js",
     },
 
     // preprocess matching files before serving them to the browser

--- a/src/core/biblio-db.js
+++ b/src/core/biblio-db.js
@@ -208,9 +208,9 @@ export const biblioDB = {
     Object.keys(data)
       .filter(key => {
         if (typeof data[key] === "string") {
-          let msg =
-            "Legacy SpecRef entries are not supported: [[" + key + "]]. ";
-          msg += "Please update it at https://github.com/tobie/specref/";
+          let msg = `Legacy SpecRef entries are not supported: \`[[${key}]]\`. `;
+          msg +=
+            "Please update it to the new format at [specref repo](https://github.com/tobie/specref/)";
           pub("error", msg);
           return false;
         }

--- a/src/core/biblio.js
+++ b/src/core/biblio.js
@@ -45,7 +45,6 @@ const REF_STATUSES = new Map([
   ["WG-NOTE", "W3C Working Group Note"],
 ]);
 
-
 const defaultsReference = Object.freeze({
   authors: [],
   date: "",
@@ -56,23 +55,25 @@ const defaultsReference = Object.freeze({
   etAl: false,
 });
 
-const endNormalizer = function(endStr){
+const endNormalizer = function(endStr) {
   return str => {
     const trimmed = str.trim();
-    const result = !trimmed || trimmed.endsWith(endStr) ? trimmed : trimmed + endStr;
+    const result = !trimmed || trimmed.endsWith(endStr)
+      ? trimmed
+      : trimmed + endStr;
     return result;
-  }
-}
+  };
+};
 
 const endWithDot = endNormalizer(".");
 
-export function wireReference(rawRef, target="_blank") {
-  if(typeof rawRef !== "object"){
+export function wireReference(rawRef, target = "_blank") {
+  if (typeof rawRef !== "object") {
     throw new TypeError("Only modern object refereces are allowed");
   }
   const ref = Object.assign({}, defaultsReference, rawRef);
   const authors = ref.authors.join("; ") + (ref.etAl ? " et al" : "");
-  const status = REF_STATUSES.get(ref.status) || ref.status
+  const status = REF_STATUSES.get(ref.status) || ref.status;
   return hyperHTML.wire(ref)`
     <cite>
       <a
@@ -164,7 +165,7 @@ function bibref(conf) {
       while (refcontent && refcontent.aliasOf) {
         if (circular[refcontent.aliasOf]) {
           refcontent = null;
-          const msg = `Circular reference in biblio DB between [${ref}] and [${key}].`;
+          const msg = `Circular reference in biblio DB between [\`${ref}\`] and [\`${key}\`].`;
           pub("error", msg);
         } else {
           key = refcontent.aliasOf;
@@ -194,12 +195,12 @@ function bibref(conf) {
     if (aliases[k].length > 1) {
       let msg = `[${k}] is referenced in ${aliases[k].length} ways: `;
       msg += `(${aliases[k].map(item => `'${item}'`).join(", ")}). This causes`;
-      msg += ` duplicate entries in the reference section.`;
+      msg += ` duplicate entries in the References section.`;
       pub("warn", msg);
     }
   }
   for (var item in badrefs) {
-    const msg = `Bad reference: [${item}] (appears ${badrefs[item]} times)`;
+    const msg = `Bad reference: [\`${item}\`] (appears ${badrefs[item]} times)`;
     if (badrefs.hasOwnProperty(item)) pub("error", msg);
   }
 }

--- a/src/core/data-include.js
+++ b/src/core/data-include.js
@@ -77,7 +77,7 @@ export function run(conf, doc, cb) {
       const text = await response.text();
       processResponse(text, id, url);
     } catch (err) {
-      const msg = `data-include failed: ${url} (${err.message}). See console for details.`;
+      const msg = `\`data-include\` failed: \`${url}\` (${err.message}). See console for details.`;
       console.error("data-include failed for element: ", el, err);
       pub("error", msg);
     }

--- a/src/core/figures.js
+++ b/src/core/figures.js
@@ -20,21 +20,20 @@ export function run(conf, doc, cb) {
       $caption = $("<figcaption/>").text(title);
 
     // change old syntax to something HTML5 compatible
+    let badSyntax = "div.figure";
     if ($figure.is("div")) {
-      pub(
-        "warn",
-        "You are using the deprecated div.figure syntax; please switch to <figure>."
-      );
       $figure.append($caption);
       $figure.renameElement("figure");
     } else {
-      pub(
-        "warn",
-        "You are using the deprecated img.figure syntax; please switch to <figure>."
-      );
+      badSyntax = "img.figure";
       $figure.wrap("<figure></figure>");
       $figure.parent().append($caption);
     }
+    pub(
+      "warn",
+      `You are using the deprecated ${badSyntax} syntax; please switch to \`<figure>\`. ` +
+        `Your document has been updated to use \`<figure>\` instead ❤️.`
+    );
   });
 
   // process all figures
@@ -44,7 +43,8 @@ export function run(conf, doc, cb) {
       $cap = $fig.find("figcaption"),
       tit = $cap.text(),
       id = $fig.makeID("fig", tit);
-    if (!$cap.length) pub("warn", "A <figure> should contain a <figcaption>.");
+    if (!$cap.length)
+      pub("warn", "A `<figure>` should contain a `<figcaption>`.");
 
     // set proper caption title
     num++;

--- a/src/core/jquery-enhanced.js
+++ b/src/core/jquery-enhanced.js
@@ -19,7 +19,7 @@ window.$.fn.renameElement = function(name) {
         $newEl[0].setAttributeNS(at.namespaceURI, at.name, at.value);
       } catch (err) {
         var msg = "Your HTML markup is malformed. Error in: \n";
-        msg += this.outerHTML;
+        msg += "```HTML\n" + this.outerHTML + "\n```";
         pub("error", msg);
         break; // no point in continuing with this element
       }

--- a/src/core/markdown.js
+++ b/src/core/markdown.js
@@ -43,34 +43,16 @@
  * The whitespace of pre elements are left alone.
  **/
 
-import marked from "deps/marked";
-import { normalizePadding } from "core/utils";
 import beautify from "deps/beautify-html";
 import beautifyOps from "core/beautify-options";
-
+import { markdownToHtml } from "core/utils";
 export const name = "core/markdown";
-
-marked.setOptions({
-  sanitize: false,
-  gfm: true,
-});
-
-function toHTML(text) {
-  const normalizedLeftPad = normalizePadding(text);
-  // As markdown is pulled from HTML, > and & are already escaped and
-  // so blockquotes aren't picked up by the parser. This fixes it.
-  const potentialMarkdown = normalizedLeftPad
-    .replace(/&gt;/gm, ">")
-    .replace(/&amp;/gm, "&");
-  const result = marked(potentialMarkdown);
-  return result;
-}
 
 function processElements(selector) {
   return element => {
     const elements = Array.from(element.querySelectorAll(selector));
     elements.reverse().forEach(element => {
-      element.innerHTML = toHTML(element.innerHTML);
+      element.innerHTML = markdownToHtml(element.innerHTML);
     });
     return elements;
   };

--- a/src/core/rdfa.js
+++ b/src/core/rdfa.js
@@ -7,6 +7,14 @@ export function run(conf, doc, cb) {
   if (!conf.doRDFa) {
     return cb();
   }
+  // Do abstract
+  const $abs = $("#abstract", doc);
+  if ($abs.length) {
+    var rel = "dc:abstract", ref = $abs.attr("property");
+    if (ref) rel = ref + " " + rel;
+    $abs.attr({ property: rel });
+  }
+
   $("section,nav").each(function() {
     var $sec = $(this),
       resource = "",

--- a/src/core/requirements.js
+++ b/src/core/requirements.js
@@ -28,7 +28,7 @@ export function run(conf, doc, cb) {
       txt = $req.find("> a").text();
     } else {
       txt = "Req. not found '" + id + "'";
-      pub("error", "Requirement not found in a.reqRef: " + id);
+      pub("error", "Requirement not found in element `a.reqRef`: " + id);
     }
     $ref.text(txt);
   });

--- a/src/w3c/abstract.js
+++ b/src/w3c/abstract.js
@@ -1,18 +1,20 @@
 // Module w3c/abstract
 // Handle the abstract section properly.
+import "deps/regenerator";
 import { pub } from "core/pubsubhub";
 
-export function run(conf, doc, cb) {
-  var $abs = $("#abstract");
-  if ($abs.length) {
-    if ($abs.find("p").length === 0) $abs.contents().wrapAll($("<p></p>"));
-    $abs.prepend("<h2>" + conf.l10n.abstract + "</h2>");
-    $abs.addClass("introductory");
-    if (conf.doRDFa) {
-      var rel = "dc:abstract", ref = $abs.attr("property");
-      if (ref) rel = ref + " " + rel;
-      $abs.attr({ property: rel });
-    }
-  } else pub("error", "Document must have one element with ID 'abstract'");
-  cb();
+export async function run(conf) {
+  const abs = document.getElementById("abstract");
+  if (!abs) {
+    pub("error", `Document must have one element with \`id="abstract"`);
+    return;
+  }
+  abs.classList.add("introductory");
+  let abstractHeading = document.querySelector("#abstract>h2");
+  if (abstractHeading) {
+    return;
+  }
+  abstractHeading = document.createElement("h2");
+  abstractHeading.innerText = conf.l10n.abstract;
+  abs.insertAdjacentElement("afterbegin", abstractHeading);
 }

--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -347,8 +347,7 @@ const licenses = {
   "w3c-software-doc": {
     name: "W3C Software and Document Notice and License",
     short: "W3C Software and Document",
-    url:
-      "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document",
+    url: "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document",
   },
   "cc-by": {
     name: "Creative Commons Attribution 4.0 International Public License",
@@ -367,23 +366,31 @@ export function run(conf, doc, cb) {
   conf.isW3CSoftAndDocLicense = conf.license === "w3c-software-doc";
   if (
     conf.specStatus === "webspec" &&
-    !$.inArray(conf.license, ["cc0", "w3c-software"])
-  )
-    pub("error", "You cannot use that license with WebSpecs.");
+    !["cc0", "w3c-software"].includes(conf.license)
+  ) {
+    let msg = `You cannot use license "\`${conf.license}\`" with W3C Specs. `;
+    msg += `Please set \`respecConfig.license: "w3c-software-doc"\` instead.`;
+    pub("error", msg);
+  }
   if (
     conf.specStatus !== "webspec" &&
-    !$.inArray(conf.license, ["cc-by", "w3c"])
-  )
-    pub("error", "You cannot use that license with that type of document.");
+    !["cc-by", "w3c"].includes(conf.license)
+  ) {
+    let msg = `You cannot use license "\`${conf.license}\`" with W3C Specs. `;
+    msg += `Please set \`respecConfig.license: "w3c-software-doc"\` instead.`;
+    pub("error", msg);
+  }
   conf.licenseInfo = licenses[conf.license];
-  conf.isCGBG = $.inArray(conf.specStatus, cgbg) >= 0;
+  conf.isCGBG = cgbg.includes(conf.specStatus);
   conf.isCGFinal = conf.isCGBG && /G-FINAL$/.test(conf.specStatus);
   conf.isBasic = conf.specStatus === "base";
   conf.isRegular = !conf.isCGBG && !conf.isBasic;
-  if (!conf.specStatus)
-    pub("error", "Missing required configuration: specStatus");
-  if (conf.isRegular && !conf.shortName)
-    pub("error", "Missing required configuration: shortName");
+  if (!conf.specStatus) {
+    pub("error", "Missing required configuration: `specStatus`");
+  }
+  if (conf.isRegular && !conf.shortName) {
+    pub("error", "Missing required configuration: `shortName`");
+  }
   conf.title = doc.title || "No Title";
   if (!conf.subtitle) conf.subtitle = "";
   conf.publishDate = conf.publishDate
@@ -391,14 +398,14 @@ export function run(conf, doc, cb) {
     : new Date(doc.lastModified);
   conf.publishYear = conf.publishDate.getFullYear();
   conf.publishHumanDate = W3CDate.format(conf.publishDate);
-  conf.isNoTrack = $.inArray(conf.specStatus, noTrackStatus) >= 0;
+  conf.isNoTrack = noTrackStatus.includes(conf.specStatus);
   conf.isRecTrack = conf.noRecTrack
     ? false
-    : $.inArray(conf.specStatus, recTrackStatus) >= 0;
+    : recTrackStatus.includes(conf.specStatus);
   conf.isMemberSubmission = conf.specStatus === "Member-SUBM";
   conf.isTeamSubmission = conf.specStatus === "Team-SUBM";
   conf.isSubmission = conf.isMemberSubmission || conf.isTeamSubmission;
-  conf.anOrA = $.inArray(conf.specStatus, precededByAn) >= 0 ? "an" : "a";
+  conf.anOrA = precededByAn.includes(conf.specStatus) ? "an" : "a";
   conf.isTagFinding =
     conf.specStatus === "finding" || conf.specStatus === "draft-finding";
   if (!conf.edDraftURI) {
@@ -435,8 +442,9 @@ export function run(conf, doc, cb) {
       conf.latestVersion + "-" + ISODate.format(conf.publishDate);
   }
   if (conf.previousPublishDate) {
-    if (!conf.previousMaturity && !conf.isTagFinding)
-      pub("error", "previousPublishDate is set, but not previousMaturity");
+    if (!conf.previousMaturity && !conf.isTagFinding) {
+      pub("error", "`previousPublishDate` is set, but not `previousMaturity`.");
+    }
     if (!(conf.previousPublishDate instanceof Date))
       conf.previousPublishDate = new Date(conf.previousPublishDate);
     var pmat = status2maturity[conf.previousMaturity]
@@ -473,7 +481,8 @@ export function run(conf, doc, cb) {
     )
       pub(
         "error",
-        "Document on track but no previous version: Add previousMaturity previousPublishDate to ReSpec's config."
+        "Document on track but no previous version:" +
+          " Add `previousMaturity`, and `previousPublishDate` to ReSpec's config."
       );
     if (!conf.prevVersion) conf.prevVersion = "";
   }
@@ -631,10 +640,10 @@ export function run(conf, doc, cb) {
   ) {
     pub(
       "error",
-      "If one of 'wg', 'wgURI', or 'wgPatentURI' is an array, they all have to be."
+      "If one of '`wg`', '`wgURI`', or '`wgPatentURI`' is an array, they all have to be."
     );
   }
-  if ($.isArray(conf.wg)) {
+  if (Array.isArray(conf.wg)) {
     conf.multipleWGs = conf.wg.length > 1;
     conf.wgHTML = joinAnd(conf.wg, function(wg, idx) {
       return "the <a href='" + conf.wgURI[idx] + "'>" + wg + "</a>";
@@ -658,19 +667,22 @@ export function run(conf, doc, cb) {
   if (conf.specStatus === "PR" && !conf.crEnd) {
     pub(
       "error",
-      "Status is PR but no crEnd is specified (needed to indicate end of previous CR)"
+      `\`specStatus\` is "PR" but no \`crEnd\` is specified (needed to indicate end of previous CR).`
     );
   }
 
   if (conf.specStatus === "CR" && !conf.crEnd) {
-    pub("error", "Status is CR but no crEnd is specified");
+    pub(
+      "error",
+      `\`specStatus\` is "CR", but no \`crEnd\` is specified in Respec config.`
+    );
   }
   conf.humanCREnd = conf.crEnd
     ? W3CDate.format(new Date(conf.crEnd))
     : humanNow;
 
   if (conf.specStatus === "PR" && !conf.prEnd) {
-    pub("error", "Status is PR but no prEnd is specified");
+    pub("error", `\`specStatus\` is "PR" but no \`prEnd\` is specified.`);
     conf.prEnd = new Date();
   }
   conf.humanPREnd = conf.prEnd
@@ -692,7 +704,7 @@ export function run(conf, doc, cb) {
   if (conf.isIGNote && !conf.charterDisclosureURI)
     pub(
       "error",
-      "IG-NOTEs must link to charter's disclosure section using charterDisclosureURI"
+      "IG-NOTEs must link to charter's disclosure section using `charterDisclosureURI`."
     );
   // ensure subjectPrefix is encoded before using template
   if (conf.subjectPrefix !== "")
@@ -703,7 +715,7 @@ export function run(conf, doc, cb) {
   if (!conf.implementationReportURI && (conf.isCR || conf.isPR || conf.isRec)) {
     pub(
       "error",
-      "CR, PR, and REC documents need to have an implementationReportURI defined."
+      "CR, PR, and REC documents need to have an `implementationReportURI` defined."
     );
   }
   if (conf.isTagFinding && !conf.additionalContent) {

--- a/src/w3c/linter.js
+++ b/src/w3c/linter.js
@@ -55,9 +55,8 @@ export function run(conf, doc, cb) {
   // for Rec Track docs
   if (conf.isRecTrack && !hasPriSecConsiderations(doc)) {
     warn =
-      "This specification doesn't appear to have any 'Privacy' " +
-      "or 'Security' considerations sections. Please consider adding one" +
-      ", see https://w3ctag.github.io/security-questionnaire/";
+      "No 'Privacy' or 'Security' considerations sections found. Please see " +
+      "[Self-Review Questionnaire](https://w3ctag.github.io/security-questionnaire/).";
     warnings.push(warn);
   }
 
@@ -66,9 +65,9 @@ export function run(conf, doc, cb) {
     var httpURLs = findHTTPProps(conf, doc.location.href);
     if (httpURLs.length) {
       warn =
-        "There are insecure URLs in your respecConfig! Please change " +
-        "the following properties to use 'https://': " +
-        httpURLs.join(", ") +
+        "Insecure URLs in `respecConfig`! Please change " +
+        "the following members to 'https://': \n " +
+        httpURLs.map(item => `\`${item}\``).join(", ") +
         ".";
       warnings.push(warn);
     }

--- a/src/w3c/style.js
+++ b/src/w3c/style.js
@@ -106,7 +106,7 @@ document.head.insertBefore(elements, document.head.firstChild);
 
 export function run(conf, doc, cb) {
   if (!conf.specStatus) {
-    var warn = "'specStatus' missing from ReSpec config. Defaulting to 'base'.";
+    var warn = "`respecConfig.specStatus` missing. Defaulting to 'base'.";
     conf.specStatus = "base";
     pub("warn", warn);
   }

--- a/tests/spec/core/override-configuration-spec.js
+++ b/tests/spec/core/override-configuration-spec.js
@@ -6,7 +6,7 @@ describe("Core — Override Configuration", function() {
   });
   it("should override a simple string setting", function(done) {
     var url =
-      "spec/core/simple.html?specStatus=RSCND;previousMaturity=REC;previousPublishDate=1994-12-12";
+      "spec/core/simple.html?specStatus=RSCND&previousMaturity=REC&previousPublishDate=1994-12-12";
     var test = function(doc) {
       expect($(".head h2", doc).text()).toMatch(/W3C Rescinded Recommendation/);
       expect(

--- a/tests/spec/w3c/abstract-spec.js
+++ b/tests/spec/w3c/abstract-spec.js
@@ -4,13 +4,13 @@ describe("W3C — Abstract", function() {
     flushIframes();
     done();
   });
-  it("should include an h2, set the class, and wrap the content", function(
+  it("should include an h2, set the class", function(
     done
   ) {
     var ops = {
       config: makeBasicConfig(),
       body: makeDefaultBody(),
-      abstract: "<section id='abstract'>test abstract</section>",
+      abstract: "<section id='abstract'><p>test abstract</p></section>",
     };
     makeRSDoc(ops, function(doc) {
       var $abs = $("#abstract", doc);


### PR DESCRIPTION
Closes #1085. Noticeable changes: 

 * core/utils - gains `markdownToHtml()` method. 
 * core/rdfa - moved abstract processing into there. 
 * w3c/abstract - no longer wraps text content into paragraphs (because that's gross).

 Globally: 
  * use native `array.includes()` to check for things.
  * less jQuery here and there.

 