### PR TITLE
tests: allow testing in Edge

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -49,6 +49,11 @@ module.exports = function(config) {
         served: true,
       },
       {
+        pattern: "tests/*.html",
+        included: false,
+        served: true,
+      },
+      {
         pattern: "tests/**/*.html",
         included: false,
         served: true,
@@ -66,6 +71,7 @@ module.exports = function(config) {
     exclude: ["**/*.swp", "*.swp", ".DS_Store"],
 
     proxies: {
+      "/about-blank.html": "/base/tests/about-blank.html",
       "/js/": "/base/js/",
       "/tests/": "/base/tests/",
       "/spec/": "/base/tests/spec/",

--- a/tests/spec/SpecHelper.js
+++ b/tests/spec/SpecHelper.js
@@ -3,7 +3,7 @@
 "use strict";
 var iframes = [];
 
-function makeRSDoc(opts = {}, cb = () => {}, src = "about:blank", style = "") {
+function makeRSDoc(opts = {}, cb = () => {}, src = "about-blank.html", style = "") {
   return new Promise(function(resove, reject) {
     var ifr = document.createElement("iframe");
     opts = opts || {};


### PR DESCRIPTION
We use "about-blank.html" to simulate "about:blank", because
Edge won't let you access IndexedDB in about: URLs 🤷‍♂️.