### PR TITLE
fix(core/utils): handle nulls when checking TextNodes

### DIFF
--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -202,7 +202,7 @@ export function normalizePadding(text = "") {
   }
 
   function isTextNode(node) {
-    return node.nodeType === Node.TEXT_NODE;
+    return node !== null && node.nodeType === Node.TEXT_NODE;
   }
   // Force into body
   var parserInput = "<body>" + text;


### PR DESCRIPTION
This was triggering when parsing bad IDL, where stuff inside pre tags was being converted into actual nodes. Like:

```JS
Thing<Thing> foo;
```

Where `<Thing>` would become a DOM node, but we are expecting text nodes. 
 
