### PR TITLE
Fix bug in detecting wrong configuration for multiple WGs

### DIFF
--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -672,7 +672,7 @@ export function run(conf, doc, cb) {
   var wgPotentialArray = [conf.wg, conf.wgURI, conf.wgPatentURI];
   if (
     wgPotentialArray.some(item => Array.isArray(item)) &&
-    wgPotentialArray.every(item => Array.isArray(item))
+    !wgPotentialArray.every(item => Array.isArray(item))
   ) {
     pub(
       "error",


### PR DESCRIPTION
Right now, respec complains if all of wg, wgUri, and wgPatentUri are arrays, when it should complain only if some but not all are
Bug was introduced in 0b706ce8ce3b524ba442bedd154dfb056503e131