### PR TITLE
chore(.travis): use linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,11 +24,11 @@ jobs:
   include:
     - stage: Test build
       script: ./tests/test-build.js
-    - stage: Test headless
-      script:
-        - yarn run build
-        - yarn run build:respec-w3c-common
-        - yarn run test:headless
+    # - stage: Test headless
+    #   script:
+    #     - yarn run build
+    #     - yarn run build:respec-w3c-common
+    #     - yarn run test:headless
     - stage: Test karma
       script:
         - yarn run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,14 +23,6 @@ cache: yarn
 jobs:
   include:
     - stage: Test build
-      script: ./tests/test-build.js
-    # - stage: Test headless
-    #   script:
-    #     - yarn run build
-    #     - yarn run build:respec-w3c-common
-    #     - yarn run test:headless
-    - stage: Test karma
-      script:
-        - yarn run build
-        - yarn run build:respec-w3c-common
-        - travis_retry karma start --single-run --reporters mocha karma.conf.js
+      script: yarn run pretest
+      script: yarn run test:headless
+      script: travis_retry karma start --single-run --reporters mocha karma.conf.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - yarn run build
 
 addons:
-  firefox: latest
+#  firefox: latest
   chrome: stable
 
 cache: yarn

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,18 @@
-# os: linux
-# osx_image: xcode9
-os: osx
 language: node_js
-sudo: required
-# dist: trusty
+dist: trusty
 node_js:
   - v8
 
-# before_install:
-#   # see https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI
-#   - "export DISPLAY=:99.0"
-#   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16 -extension RANDR"
-#   - export PATH="$PATH:$HOME/.rvm/bin"
-#   - sleep 3
+before_install:
+  # see https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI
+  - "export DISPLAY=:99.0"
+  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16 -extension RANDR"
+  - export PATH="$PATH:$HOME/.rvm/bin"
+  - sleep 3
 
 install:
   - yarn install
   - yarn run build
-  - yarn run build:respec-w3c-common
 
 addons:
   firefox: latest
@@ -27,8 +22,15 @@ cache: yarn
 
 jobs:
   include:
-    - stage: Tests
+    - stage: Test build
       script: ./tests/test-build.js
-      script: yarn run pretest
-      script: yarn run test:headless
-      script: travis_retry karma start --single-run --reporters mocha karma.conf.js
+    - stage: Test headless
+      script:
+        - yarn run build
+        - yarn run build:respec-w3c-common
+        - yarn run test:headless
+    - stage: Test karma
+      script:
+        - yarn run build
+        - yarn run build:respec-w3c-common
+        - travis_retry karma start --single-run --reporters mocha karma.conf.js

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -120,7 +120,7 @@ module.exports = function(config) {
     options.detectBrowsers.enabled = false;
     options.autoWatch = false;
     options.singleRun = true;
-    options.concurrency = 2;
+    options.concurrency = 1;
     options.reporters = ["mocha"];
     options.browsers = ["Firefox", "Chrome"]; //"FirefoxNightly"
   }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -122,7 +122,7 @@ module.exports = function(config) {
     options.singleRun = true;
     options.concurrency = 1;
     options.reporters = ["mocha"];
-    options.browsers = ["Firefox", "Chrome"]; //"FirefoxNightly"
+    options.browsers = ["Chrome"]; //"Firefox"
   }
   config.set(options);
 };

--- a/tests/test-main.js
+++ b/tests/test-main.js
@@ -40,4 +40,4 @@ require.config({
 });
 
 // Attempt to reduce timeout errors
-jasmine.DEFAULT_TIMEOUT_INTERVAL = jasmine.DEFAULT_TIMEOUT_INTERVAL * 3;
+jasmine.DEFAULT_TIMEOUT_INTERVAL = jasmine.DEFAULT_TIMEOUT_INTERVAL;

--- a/tests/test-main.js
+++ b/tests/test-main.js
@@ -40,4 +40,4 @@ require.config({
 });
 
 // Attempt to reduce timeout errors
-jasmine.DEFAULT_TIMEOUT_INTERVAL = jasmine.DEFAULT_TIMEOUT_INTERVAL * 2;
+jasmine.DEFAULT_TIMEOUT_INTERVAL = jasmine.DEFAULT_TIMEOUT_INTERVAL * 3;


### PR DESCRIPTION
Travis' MacOS builds are taking about 3-8 hours to get queued, so they are not longer an viable option. Switching to Linux, but having to drop Firefox in the process. Firefox on CI environments is too slow and flaky - so it's too unreliable. 