### PR TITLE
Node 8 required

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "license": "W3C",
   "description": "A technical specification pre-processor.",
   "engines": {
-    "node": ">=5"
+    "node": ">=8",
+    "npm": ">=5"
   },
   "bin": {
     "respec2html": "./tools/respec2html.js"


### PR DESCRIPTION
It's my understanding that the current release of Respec requires Node.js &ge; 8. Is that so?

This makes that explicit in `package.json`.