### PR TITLE
Migrate to ES2017 async functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6601,11 +6601,6 @@
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
     },
-    "marcosc-async": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/marcosc-async/-/marcosc-async-4.0.3.tgz",
-      "integrity": "sha1-xYZvOCnnQwjFc8MP2R4nSJy4q1g="
-    },
     "marked": {
       "version": "0.3.12",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.12.tgz",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "highlight.js": "github:marcoscaceres/highlight.js#7b144b3b83ce296d5b29c5e4fc2ea2a65e9d3f32",
     "hyperhtml": "^2.5.4",
     "loading-indicator": "^2.0.0",
-    "marcosc-async": "^4.0.3",
     "marked": "^0.3.12",
     "nightmare": "^2.10.0",
     "prompt": "^1.0.0",

--- a/tests/test-build.js
+++ b/tests/test-build.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env mocha
 
 "use strict";
-const async = require("marcosc-async");
 const colors = require("colors");
 const fsp = require("fs-extra");
 const path = require("path");
@@ -20,11 +19,9 @@ colors.setTheme({
   warn: "yellow",
 });
 
-function checkIfFileExists(filePath) {
-  return async.task(function*() {
-    const stats = yield fsp.lstat(filePath);
-    return stats.isFile();
-  });
+async function checkIfFileExists(filePath) {
+  const stats = await fsp.lstat(filePath);
+  return stats.isFile();
 }
 
 describe("builder (tool)", function() {
@@ -37,22 +34,22 @@ describe("builder (tool)", function() {
   const latest = path.join(__dirname, "../builds/respec-w3c-common.js");
   it(
     "should have built default respec",
-    async(function*() {
-      yield Builder.build({ name: "w3c-common" });
-      expect(yield checkIfFileExists(latest)).to.equal(true);
-      expect(yield checkIfFileExists(latestMap)).to.equal(true);
-    })
+    async() => {
+      await Builder.build({ name: "w3c-common" });
+      expect(await checkIfFileExists(latest)).to.equal(true);
+      expect(await checkIfFileExists(latestMap)).to.equal(true);
+    }
   );
 
   describe("respec-w3c-common.build.js", function() {
     it(
       "should include the link to the sourcemap",
-      async(function*() {
-        var source = yield fsp.readFile(latest, "utf-8");
+      async() => {
+        const source = await fsp.readFile(latest, "utf-8");
         expect(source.search("respec-w3c-common.build.js.map")).to.not.equal(
           -1
         );
-      })
+      }
     );
   });
 });

--- a/tools/builder.js
+++ b/tools/builder.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 "use strict";
-const async = require("marcosc-async");
 const colors = require("colors");
 const fsp = require("fs-extra");
 const loading = require("loading-indicator");
@@ -69,7 +68,7 @@ const usageSections = [
  * @return {Promise} Resolves when done writing the files.
  */
 function appendBoilerplate(outPath, version, name) {
-  return async(function*(optimizedJs, sourceMap) {
+  return async(optimizedJs, sourceMap) => {
     const respecJs = `"use strict";
 /* ReSpec ${version}
 Created by Robin Berjon, http://berjon.com/ (@robinberjon)
@@ -91,8 +90,8 @@ require(['profile-${name}']);`;
     const mapPath = path.dirname(outPath) + `/respec-${name}.build.js.map`;
     const promiseToWriteJs = fsp.writeFile(outPath, result.code, "utf-8");
     const promiseToWriteMap = fsp.writeFile(mapPath, sourceMap, "utf-8");
-    yield Promise.all([promiseToWriteJs, promiseToWriteMap]);
-  }, Builder);
+    await Promise.all([promiseToWriteJs, promiseToWriteMap]);
+  };
 }
 
 const Builder = {
@@ -101,11 +100,11 @@ const Builder = {
    *
    * @returns {Promise<String>} The version string.
    */
-  getRespecVersion: async(function*() {
+  getRespecVersion: async() => {
     const packagePath = path.join(__dirname, "../package.json");
-    const content = yield fsp.readFile(packagePath, "utf-8");
+    const content = await fsp.readFile(packagePath, "utf-8");
     return JSON.parse(content).version;
-  }),
+  },
 
   /**
    * Async function runs Requirejs' optimizer to generate the output.
@@ -114,7 +113,7 @@ const Builder = {
    * @param  {[type]} options [description]
    * @return {[type]}         [description]
    */
-  build({ name }) {
+  async build({ name }) {
     if (!name) {
       throw new TypeError("name is required");
     }
@@ -126,43 +125,42 @@ const Builder = {
       frames: presets.clock,
       delay: 1,
     });
-    return async.task(function*() {
-      // optimisation settings
-      const buildVersion = yield this.getRespecVersion();
-      const outputWritter = appendBoilerplate(outPath, buildVersion, name);
-      const config = {
-        baseUrl: path.join(__dirname, "../js/"),
-        deps: ["deps/require"],
-        generateSourceMaps: true,
-        inlineText: true,
-        logLevel: 2, // Show uglify warnings and errors.
-        mainConfigFile: `js/profile-${name}.js`,
-        name: `profile-${name}`,
-        optimize: "none",
-        preserveLicenseComments: false,
-        useStrict: true,
+    
+    // optimisation settings
+    const buildVersion = await this.getRespecVersion();
+    const outputWritter = appendBoilerplate(outPath, buildVersion, name);
+    const config = {
+      baseUrl: path.join(__dirname, "../js/"),
+      deps: ["deps/require"],
+      generateSourceMaps: true,
+      inlineText: true,
+      logLevel: 2, // Show uglify warnings and errors.
+      mainConfigFile: `js/profile-${name}.js`,
+      name: `profile-${name}`,
+      optimize: "none",
+      preserveLicenseComments: false,
+      useStrict: true,
+    };
+    const promiseToWrite = new Promise((resolve, reject) => {
+      config.out = (concatinatedJS, sourceMap) => {
+        outputWritter(concatinatedJS, sourceMap).then(resolve).catch(reject);
       };
-      const promiseToWrite = new Promise((resolve, reject) => {
-        config.out = (concatinatedJS, sourceMap) => {
-          outputWritter(concatinatedJS, sourceMap).then(resolve).catch(reject);
-        };
-      });
-      r.optimize(config);
-      const buildDir = path.resolve(__dirname, "../builds/");
-      const workerDir = path.resolve(__dirname, "../worker/");
-      // copy respec-worker
-      fsp
-        .createReadStream(`${workerDir}/respec-worker.js`)
-        .pipe(fsp.createWriteStream(`${buildDir}/respec-worker.js`));
-      yield promiseToWrite;
-      loading.stop(timer);
-    }, this);
+    });
+    r.optimize(config);
+    const buildDir = path.resolve(__dirname, "../builds/");
+    const workerDir = path.resolve(__dirname, "../worker/");
+    // copy respec-worker
+    fsp
+      .createReadStream(`${workerDir}/respec-worker.js`)
+      .pipe(fsp.createWriteStream(`${buildDir}/respec-worker.js`));
+    await promiseToWrite;
+    loading.stop(timer);
   },
 };
 
 exports.Builder = Builder;
 if (require.main === module) {
-  async.task(function* run() {
+  (async function run() {
     let parsedArgs;
     try {
       parsedArgs = commandLineArgs(optionList);
@@ -180,11 +178,11 @@ if (require.main === module) {
       return;
     }
     try {
-      yield Builder.build({ name });
+      await Builder.build({ name });
     } catch (err) {
       console.error(colors.error(err.stack));
       return process.exit(1);
     }
     process.exit(0);
-  });
+  })();
 }

--- a/tools/respec2html.js
+++ b/tools/respec2html.js
@@ -2,7 +2,6 @@
 
 /*jshint node: true, browser: false*/
 "use strict";
-const async = require("marcosc-async");
 const colors = require("colors");
 const fetchAndWrite = require("./respecDocWriter").fetchAndWrite;
 colors.setTheme({

--- a/tools/respec2html.js
+++ b/tools/respec2html.js
@@ -96,7 +96,7 @@ const usageSections = [
   },
 ];
 
-async.task(function* run() {
+(async function run() {
   let parsedArgs;
   try {
     parsedArgs = commandLineArgs(optionList);
@@ -121,10 +121,10 @@ async.task(function* run() {
   const timeout = parsedArgs.timeout;
   const out = parsedArgs.out;
   try {
-    yield fetchAndWrite(src, out, whenToHalt, timeout);
+    await fetchAndWrite(src, out, whenToHalt, timeout);
   } catch (err) {
     console.error(colors.error(err.message));
     return process.exit(1);
   }
   process.exit(0);
-});
+})();


### PR DESCRIPTION
`package.json` forces Node.js 8+, we already use async functions elsewhere, so why not reduce a dependency 😁