### PR TITLE
chore(package): use uglify-es 3.3.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10014,9 +10014,9 @@
       "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
     },
     "uglify-es": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.8.tgz",
-      "integrity": "sha512-j8li0jWcAN6yBuAVYFZEFyYINZAm4WEdMwkA6qXFi4TLrze3Mp0Le7QjW6LR9HQjQJ2zRa9VgnFLs3PatijWOw==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.7.tgz",
+      "integrity": "sha512-fGMnE6SsDRsCjxm78C+lv7MuXsse/dtF7QuTUT43BYf4jlxPjd+XTnGB8YjaCQJ3sv2LT4zk0mwpp9+QJocU6g==",
       "dev": true,
       "requires": {
         "commander": "2.13.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10014,21 +10014,15 @@
       "integrity": "sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0="
     },
     "uglify-es": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.2.2.tgz",
-      "integrity": "sha512-l+s5VLzFwGJfS+fbqaGf/Dfwo1MF13jLOF2ekL0PytzqEqQ6cVppvHf4jquqFok+35USMpKjqkYxy6pQyUcuug==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/uglify-es/-/uglify-es-3.3.8.tgz",
+      "integrity": "sha512-j8li0jWcAN6yBuAVYFZEFyYINZAm4WEdMwkA6qXFi4TLrze3Mp0Le7QjW6LR9HQjQJ2zRa9VgnFLs3PatijWOw==",
       "dev": true,
       "requires": {
-        "commander": "2.12.2",
+        "commander": "2.13.0",
         "source-map": "0.6.1"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.12.2",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
-          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
-          "dev": true
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "moment": "^2.20.1",
     "requirejs": "^2.3.5",
     "text": "github:requirejs/text#d04de4ffd7bf5ba6cb80cdca2d40d4f6f52a1b1f",
-    "uglify-es": "3.2.2",
+    "uglify-es": "3.3.8",
     "url-search-params": "^0.10.0",
     "webidl2": "^10.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "moment": "^2.20.1",
     "requirejs": "^2.3.5",
     "text": "github:requirejs/text#d04de4ffd7bf5ba6cb80cdca2d40d4f6f52a1b1f",
-    "uglify-es": "3.3.8",
+    "uglify-es": "3.3.7",
     "url-search-params": "^0.10.0",
     "webidl2": "^10.2.0"
   },


### PR DESCRIPTION
~~The last malfunctioning version was 3.3.9 so try 3.3.8.~~

The last known good version is 3.3.7, so use it rather than older 3.2.2.