### PR TITLE
Link to duplicate dfns

### DIFF
--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -3,12 +3,21 @@
 // to the matching definitions.
 import { linkInlineCitations } from "core/data-cite";
 import { pub } from "core/pubsubhub";
+import { lang as defaultLang } from "./l10n";
 export const name = "core/link-to-dfn";
+const l10n = {
+  en: {
+    "duplicate": "This is defined more than once in the document."
+  }
+};
+const lang = defaultLang in l10n ? defaultLang : "en";
+
 export function run(conf, doc, cb) {
   doc.normalize();
   var titles = {};
   Object.keys(conf.definitionMap).forEach(function(title) {
     titles[title] = {};
+    var listOfDuplicateDfns = [];
     conf.definitionMap[title].forEach(function(dfn) {
       if (dfn.attr("data-idl") === undefined) {
         // Non-IDL definitions aren't "for" an interface.
@@ -24,13 +33,14 @@ export function run(conf, doc, cb) {
         if (oldIsDfn && newIsDfn) {
           // Only complain if the user provides 2 <dfn>s
           // for the same term.
-          pub(
-            "error",
-            "Duplicate definition of '" +
-              (dfn_for ? dfn_for + "/" : "") +
-              title +
-              "'"
-          );
+          dfn.addClass("respec-offending-element");
+          if (dfn.attr("title") === undefined) {
+            dfn.attr("title", l10n[lang].duplicate);
+          }
+          if (dfn.attr("id") === undefined) {
+            dfn.makeID(null, title);
+          }
+          listOfDuplicateDfns.push(dfn[0]);
         }
         if (oldIsDfn) {
           // Don't overwrite <dfn> definitions.
@@ -46,6 +56,15 @@ export function run(conf, doc, cb) {
         }
       }
     });
+    if (listOfDuplicateDfns.length > 0) {
+      const dfnsList = listOfDuplicateDfns.map((elem, i) => {
+        return `[${i + 1}](#${elem.id})`;
+      }).join(", ");
+      pub(
+        "error",
+        `Duplicate definitions of '${title}' at: ${dfnsList}.`
+      );
+    }
   });
   $("a:not([href]):not([data-cite]):not(.logo)").each(function() {
     var $ant = $(this);

--- a/tests/spec/core/link-to-dfn-spec.js
+++ b/tests/spec/core/link-to-dfn-spec.js
@@ -44,4 +44,36 @@ describe("Core — Link to definitions", function() {
     expect(noCodeWrap.querySelector("code")).toBeFalsy();
     expect(noCodeWrap.textContent).toEqual("the request interface");
   });
+
+  it("checks for duplicate definitions", async () => {
+    const bodyText = `
+      <section>
+        <h2>Test Section</h2>
+        <dfn>Test1</dfn>
+        <dfn id="duplicate-definition">Test1</dfn>
+        <dfn>Test1</dfn>
+        <dfn title="test1">Test1</dfn>
+      </section>`;
+    const ops = {
+      config: makeBasicConfig(),
+      body: makeDefaultBody() + bodyText,
+    };
+    const doc = await makeRSDoc(ops);
+    const dfnList = doc.body.querySelectorAll("dfn");
+
+    const dfn1 = dfnList[1];
+    expect(dfn1).toBeTruthy();
+    expect(dfn1.classList).toContain("respec-offending-element");
+    expect(dfn1.id).toBe("duplicate-definition");
+
+    const dfn2 = dfnList[2];
+    expect(dfn2).toBeTruthy();
+    expect(dfn2.classList).toContain("respec-offending-element");
+    expect(dfn2.id).toBeDefined();
+
+    const dfn3 = dfnList[3];
+    expect(dfn3).toBeTruthy();
+    expect(dfn3.classList).toContain("respec-offending-element");
+    expect(dfn3.title).toBe("test1");
+  });
 });


### PR DESCRIPTION
fixes: #1427 
I had already showed a GIF in https://github.com/w3c/respec/issues/1427#issuecomment-362926979 where I had added three `dfns` of `country` to cause the error
Please review marcosc