### PR TITLE
refactor: use puppeteer instead of nightmare

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@types/node": {
-      "version": "7.0.52",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.52.tgz",
-      "integrity": "sha512-jjpyQsKGsOF/wUElNjfPULk+d8PKvJOIXk3IUeBYYmNCy5dMWfrI+JiixYNw8ppKOlcRwWTXFl0B+i5oGrf95Q=="
-    },
     "JSONStream": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
@@ -228,11 +223,6 @@
       "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
       "dev": true
     },
-    "array-find-index": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
-    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -359,8 +349,7 @@
     "async-limiter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
-      "dev": true
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
     },
     "asynckit": {
       "version": "0.4.0",
@@ -1340,22 +1329,6 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
       "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
     },
-    "camelcase-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-      "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
-      "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
-        }
-      }
-    },
     "capture-stack-trace": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
@@ -1614,11 +1587,6 @@
           "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8="
         }
       }
-    },
-    "clone": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.3.tgz",
-      "integrity": "sha1-KY1+IjFmD0DAA8LtMUDezz9TCF8="
     },
     "clone-deep": {
       "version": "0.3.0",
@@ -2000,14 +1968,6 @@
       "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=",
       "optional": true
     },
-    "currently-unhandled": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "requires": {
-        "array-find-index": "1.0.2"
-      }
-    },
     "custom-event": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
@@ -2065,21 +2025,6 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
-    "deep-defaults": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/deep-defaults/-/deep-defaults-1.0.4.tgz",
-      "integrity": "sha1-Gpdi4rbI1qTpkxuO5/+M3O4dF1A=",
-      "requires": {
-        "lodash": "3.0.1"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.0.1.tgz",
-          "integrity": "sha1-FNSQKKOLx0AkHRHi7NV+wG1zwZo="
-        }
-      }
-    },
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
@@ -2103,14 +2048,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
-    },
-    "defaults": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-      "requires": {
-        "clone": "1.0.3"
-      }
     },
     "defined": {
       "version": "1.0.0",
@@ -2491,59 +2428,6 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
-    "electron": {
-      "version": "1.7.11",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-1.7.11.tgz",
-      "integrity": "sha1-mTtqp54OeafPzDafTIE/vZoLCNk=",
-      "requires": {
-        "@types/node": "7.0.52",
-        "electron-download": "3.3.0",
-        "extract-zip": "1.6.6"
-      }
-    },
-    "electron-download": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/electron-download/-/electron-download-3.3.0.tgz",
-      "integrity": "sha1-LP1U1pZsAZxNSa1l++Zcyc3vaMg=",
-      "requires": {
-        "debug": "2.6.9",
-        "fs-extra": "0.30.0",
-        "home-path": "1.0.5",
-        "minimist": "1.2.0",
-        "nugget": "2.0.1",
-        "path-exists": "2.1.0",
-        "rc": "1.2.5",
-        "semver": "5.5.0",
-        "sumchecker": "1.3.1"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "0.30.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-          "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "2.6.2"
-          }
-        },
-        "jsonfile": {
-          "version": "2.4.0",
-          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-          "requires": {
-            "graceful-fs": "4.1.11"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        }
-      }
-    },
     "elliptic": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
@@ -2636,21 +2520,6 @@
         "has-binary2": "1.0.2"
       }
     },
-    "enqueue": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/enqueue/-/enqueue-1.0.2.tgz",
-      "integrity": "sha1-kBTpvOVw7pPKlubI5jrVTBkra8g=",
-      "requires": {
-        "sliced": "0.0.5"
-      },
-      "dependencies": {
-        "sliced": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz",
-          "integrity": "sha1-XtwETKTrb3gW1Qui/GPiXY/kcH8="
-        }
-      }
-    },
     "ent": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
@@ -2679,6 +2548,14 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
       "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+    },
+    "es6-promisify": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+      "requires": {
+        "es6-promise": "4.2.4"
+      }
     },
     "escape-html": {
       "version": "1.0.3",
@@ -4114,11 +3991,6 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
-    "function-source": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/function-source/-/function-source-0.1.0.tgz",
-      "integrity": "sha1-2RBL8+RniLVUaMAr8bL6vPj8Ga8="
-    },
     "gear": {
       "version": "0.9.7",
       "resolved": "https://registry.npmjs.org/gear/-/gear-0.9.7.tgz",
@@ -4254,11 +4126,6 @@
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
-    },
-    "get-stdin": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-      "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
     },
     "get-uri": {
       "version": "2.0.1",
@@ -4702,11 +4569,6 @@
         "os-tmpdir": "1.0.2"
       }
     },
-    "home-path": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/home-path/-/home-path-1.0.5.tgz",
-      "integrity": "sha1-eIspgVsS1Tus9XVkhHbm+QQdEz8="
-    },
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
@@ -4918,14 +4780,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
-    },
-    "indent-string": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "requires": {
-        "repeating": "2.0.1"
-      }
     },
     "indexof": {
       "version": "0.0.1",
@@ -5374,9 +5228,9 @@
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "jasmine-core": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.9.1.tgz",
-      "integrity": "sha1-trvB2OZSUNVvWIhGFwXr7uuI8i8=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-3.0.0.tgz",
+      "integrity": "sha1-jNsgzzNrG4aDDtxYsaiqxHRV6Uw=",
       "dev": true
     },
     "jasmine-reporters": {
@@ -5605,11 +5459,6 @@
           "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
         }
       }
-    },
-    "jsesc": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
     },
     "jshint": {
       "version": "2.5.11",
@@ -5962,11 +5811,6 @@
         "colors": "1.1.2"
       }
     },
-    "keypress": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.1.0.tgz",
-      "integrity": "sha1-SjGI1CkbZrT2XtuZ+AaqmuKTWSo="
-    },
     "kind-of": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
@@ -5979,6 +5823,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11"
       }
@@ -6490,15 +6335,6 @@
         "js-tokens": "3.0.2"
       }
     },
-    "loud-rejection": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-      "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
-      }
-    },
     "lowercase-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
@@ -6596,11 +6432,6 @@
         }
       }
     },
-    "map-obj": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
-    },
     "marked": {
       "version": "0.3.12",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.12.tgz",
@@ -6632,30 +6463,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
-    },
-    "meow": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-      "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
-      "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.4.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        }
-      }
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -6740,24 +6547,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.1.0.tgz",
       "integrity": "sha1-md9lelJXTCHJBXSX33QnkLK0wN4="
-    },
-    "minstache": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minstache/-/minstache-1.2.0.tgz",
-      "integrity": "sha1-/xzEA6woRPaNvxjGYhKb5+sO/EE=",
-      "requires": {
-        "commander": "1.0.4"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-1.0.4.tgz",
-          "integrity": "sha1-Xt6xruI8T7VBprcNaSq+8ZZpotM=",
-          "requires": {
-            "keypress": "0.1.0"
-          }
-        }
-      }
     },
     "mixin-object": {
       "version": "2.0.1",
@@ -7050,26 +6839,6 @@
       "dev": true,
       "optional": true
     },
-    "nightmare": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/nightmare/-/nightmare-2.10.0.tgz",
-      "integrity": "sha1-6cXVkLspb1loX9SCGML7rER2eyE=",
-      "requires": {
-        "debug": "2.6.9",
-        "deep-defaults": "1.0.4",
-        "defaults": "1.0.3",
-        "electron": "1.7.11",
-        "enqueue": "1.0.2",
-        "function-source": "0.1.0",
-        "jsesc": "0.5.0",
-        "minstache": "1.2.0",
-        "mkdirp": "0.5.1",
-        "once": "1.4.0",
-        "rimraf": "2.6.2",
-        "sliced": "1.0.1",
-        "split2": "2.2.0"
-      }
-    },
     "node-status-codes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
@@ -7201,177 +6970,6 @@
         "remove-trailing-separator": "1.1.0"
       }
     },
-    "nugget": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/nugget/-/nugget-2.0.1.tgz",
-      "integrity": "sha1-IBCVpIfhrTYIGzQy+jytpPjQcbA=",
-      "requires": {
-        "debug": "2.6.9",
-        "minimist": "1.2.0",
-        "pretty-bytes": "1.0.4",
-        "progress-stream": "1.2.0",
-        "request": "2.83.0",
-        "single-line-log": "1.1.2",
-        "throttleit": "0.0.2"
-      },
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-        },
-        "boom": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-          "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "cryptiles": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-          "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-          "requires": {
-            "boom": "5.2.0"
-          },
-          "dependencies": {
-            "boom": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-              "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-              "requires": {
-                "hoek": "4.2.0"
-              }
-            }
-          }
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-        },
-        "extend": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-        },
-        "form-data": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-          "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
-          }
-        },
-        "hawk": {
-          "version": "6.0.2",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-          "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-          "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.0",
-            "sntp": "2.1.0"
-          }
-        },
-        "hoek": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-          "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
-        },
-        "http-signature": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-          "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
-          }
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        },
-        "oauth-sign": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
-        },
-        "request": {
-          "version": "2.83.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-          "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
-          "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.1",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.2.1"
-          }
-        },
-        "sntp": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-          "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-          "requires": {
-            "hoek": "4.2.0"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "uuid": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
-        }
-      }
-    },
     "null-check": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
@@ -7404,11 +7002,6 @@
       "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
       "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
       "dev": true
-    },
-    "object-keys": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-      "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
     },
     "object.omit": {
       "version": "2.0.1",
@@ -7852,15 +7445,6 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
-    "pretty-bytes": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
-      "integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
-      "requires": {
-        "get-stdin": "4.0.1",
-        "meow": "3.7.0"
-      }
-    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -7878,14 +7462,10 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
       "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
     },
-    "progress-stream": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-1.2.0.tgz",
-      "integrity": "sha1-LNPP6jO6OonJwSHsM0er6asSX3c=",
-      "requires": {
-        "speedometer": "0.1.4",
-        "through2": "0.2.3"
-      }
+    "progress": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8="
     },
     "promise": {
       "version": "7.3.1",
@@ -7977,6 +7557,50 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
+    "puppeteer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.0.0.tgz",
+      "integrity": "sha512-e00NMdUL32YhBcua9OkVXHgyDEMBWJhDXkYNv0pyKRU1Z1OrsRm5zCpppAdxAsBI+/MJBspFNfOUZuZ24qPGMQ==",
+      "requires": {
+        "debug": "2.6.9",
+        "extract-zip": "1.6.6",
+        "https-proxy-agent": "2.1.1",
+        "mime": "1.4.1",
+        "progress": "2.0.0",
+        "proxy-from-env": "1.0.0",
+        "rimraf": "2.6.2",
+        "ws": "3.3.3"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.0.tgz",
+          "integrity": "sha512-c+R/U5X+2zz2+UCrCFv6odQzJdoqI+YecuhnAJLa1zYaMc13zPfwMwZrr91Pd1DYNo/yPRbiM4WVf9whgwFsIg==",
+          "requires": {
+            "es6-promisify": "5.0.0"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.1.1.tgz",
+          "integrity": "sha512-LK6tQUR/VOkTI6ygAfWUKKP95I+e6M1h7N3PncGu1CATHCnex+CAv9ttR0lbHu1Uk2PXm/WoAHFo6JCGwMjVMw==",
+          "requires": {
+            "agent-base": "4.2.0",
+            "debug": "3.1.0"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
+          }
+        }
+      }
     },
     "q": {
       "version": "1.4.1",
@@ -8288,15 +7912,6 @@
             "brace-expansion": "1.1.8"
           }
         }
-      }
-    },
-    "redent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-      "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
       }
     },
     "redis": {
@@ -8849,19 +8464,6 @@
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
       "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
     },
-    "signal-exit": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
-    },
-    "single-line-log": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/single-line-log/-/single-line-log-1.1.2.tgz",
-      "integrity": "sha1-wvg/Jzo+GhbtsJlWYdoO1e8DM2Q=",
-      "requires": {
-        "string-width": "1.0.2"
-      }
-    },
     "slack-node": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/slack-node/-/slack-node-0.2.0.tgz",
@@ -8877,11 +8479,6 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
       "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
       "dev": true
-    },
-    "sliced": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
-      "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
     },
     "slide": {
       "version": "1.1.6",
@@ -9325,62 +8922,6 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
     },
-    "speedometer": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-0.1.4.tgz",
-      "integrity": "sha1-mHbb0qFp0xFUAtSObqYynIgWpQ0="
-    },
-    "split2": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
-      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
-      "requires": {
-        "through2": "2.0.3"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-        },
-        "readable-stream": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-          "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "through2": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
-          "requires": {
-            "readable-stream": "2.3.3",
-            "xtend": "4.0.1"
-          }
-        },
-        "xtend": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
-        }
-      }
-    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -9723,14 +9264,6 @@
         "is-utf8": "0.2.1"
       }
     },
-    "strip-indent": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "requires": {
-        "get-stdin": "4.0.1"
-      }
-    },
     "strip-json-comments": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
@@ -9751,15 +9284,6 @@
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
-      }
-    },
-    "sumchecker": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-1.3.1.tgz",
-      "integrity": "sha1-ebs7RFbdBPGOvbwNcDodHa7FEF0=",
-      "requires": {
-        "debug": "2.6.9",
-        "es6-promise": "4.2.4"
       }
     },
     "supports-color": {
@@ -9841,24 +9365,10 @@
         "thenify": "3.3.0"
       }
     },
-    "throttleit": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
-      "integrity": "sha1-z+34jmDADdlpe2H90qg0OptoDq8="
-    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
-    },
-    "through2": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
-      "integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
-      "requires": {
-        "readable-stream": "1.1.14",
-        "xtend": "2.1.2"
-      }
     },
     "thunkify": {
       "version": "2.1.2",
@@ -9943,11 +9453,6 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-    },
-    "trim-newlines": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
     },
     "trim-right": {
       "version": "1.0.1",
@@ -10039,8 +9544,7 @@
     "ultron": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
-      "dev": true
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
     },
     "umd": {
       "version": "3.0.1",
@@ -10486,7 +9990,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
       "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
-      "dev": true,
       "requires": {
         "async-limiter": "1.0.0",
         "safe-buffer": "5.1.1",
@@ -10537,14 +10040,6 @@
       "integrity": "sha1-UqY+VsoLhKfzpfPWGHLxJq16WUM=",
       "dev": true,
       "optional": true
-    },
-    "xtend": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-      "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-      "requires": {
-        "object-keys": "0.4.0"
-      }
     },
     "y18n": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -85,8 +85,8 @@
     "hyperhtml": "^2.5.9",
     "loading-indicator": "^2.0.0",
     "marked": "^0.3.12",
-    "nightmare": "^2.10.0",
     "prompt": "^1.0.0",
+    "puppeteer": "^1.0.0",
     "snyk": "^1.69.6"
   },
   "snyk": true

--- a/tools/respec2html.js
+++ b/tools/respec2html.js
@@ -120,7 +120,7 @@ const usageSections = [
   const timeout = parsedArgs.timeout;
   const out = parsedArgs.out;
   try {
-    await fetchAndWrite(src, out, whenToHalt * 1000, timeout);
+    await fetchAndWrite(src, out, whenToHalt, timeout * 1000);
   } catch (err) {
     console.error(colors.error(err.message));
     return process.exit(1);

--- a/tools/respec2html.js
+++ b/tools/respec2html.js
@@ -120,7 +120,7 @@ const usageSections = [
   const timeout = parsedArgs.timeout;
   const out = parsedArgs.out;
   try {
-    await fetchAndWrite(src, out, whenToHalt, timeout);
+    await fetchAndWrite(src, out, whenToHalt * 1000, timeout);
   } catch (err) {
     console.error(colors.error(err.message));
     return process.exit(1);

--- a/tools/respec2html.js
+++ b/tools/respec2html.js
@@ -122,7 +122,7 @@ const usageSections = [
   try {
     await fetchAndWrite(src, out, whenToHalt, timeout * 1000);
   } catch (err) {
-    console.error(colors.error(err.message));
+    console.error(colors.error(err.stack));
     return process.exit(1);
   }
   process.exit(0);

--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -7,7 +7,7 @@
 /*jshint node: true, browser: false*/
 "use strict";
 const os = require("os");
-const puppeteer = require('puppeteer');
+const puppeteer = require("puppeteer");
 const colors = require("colors");
 const { promisify } = require("util");
 const fs = require("fs");

--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -70,7 +70,7 @@ async function fetchAndWrite(src, out, whenToHalt, timeout = 300000) {
     const handleConsoleMessages = makeConsoleMsgHandler(page);
     handleConsoleMessages(whenToHalt);
     if (!response.ok()) {
-      const warn = colors.warn(`📡 HTTP Error ${response.code}:`);
+      const warn = colors.warn(`📡 HTTP Error ${response.status()}:`);
       const msg = `${warn} ${colors.debug(url)}`;
       throw new Error(msg);
     }

--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -116,9 +116,7 @@ async function generateHTML(page, version, url) {
 }
 
 async function checkReSpecVersion(page) {
-  if (!(await page.evaluate(() => window.hasOwnProperty("respecVersion")))) {
-    throw new Error("No respecVersion is found");
-  }
+  await page.waitForFunction(() => window.hasOwnProperty("respecVersion"));
   const version = await page.evaluate(getVersion);
   const [mayor] = version;
   // The exportDocument() method only appeared in vesion 18.

--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -76,7 +76,7 @@ async function fetchAndWrite(src, out, whenToHalt, timeout = 300000) {
       const msg = `${warn} ${colors.debug(url)}`;
       throw new Error(msg);
     }
-    await checkIfReSpec(browser, page);
+    await checkIfReSpec(page);
     const version = await checkReSpecVersion(page);
     const html = await generateHTML(page, version, url);
     switch (out) {

--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -62,9 +62,7 @@ async function writeTo(outPath, data) {
  */
 async function fetchAndWrite(src, out, whenToHalt, timeout = 300000) {
   const userDataDir = await mkdtemp(os.tmpdir() + "/respec2html-");
-  const browser = await puppeteer.launch({
-    userDataDir
-  });
+  const browser = await puppeteer.launch({ userDataDir });
   try {
     const page = await browser.newPage();
     const url = parseURL(src).href;

--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -7,7 +7,7 @@
 /*jshint node: true, browser: false*/
 "use strict";
 const os = require("os");
-const Nightmare = require("nightmare");
+const puppeteer = require('puppeteer');
 const colors = require("colors");
 const { promisify } = require("util");
 const fs = require("fs");
@@ -21,16 +21,6 @@ colors.setTheme({
   warn: "yellow",
   info: "blue",
 });
-
-// Configuration for nightmare
-const config = {
-  show: false,
-  webPreferences: {
-    images: false,
-    defaultEncoding: "utf-8",
-    partition: "nopersist"
-  },
-};
 
 /**
  * Writes "data" to a particular outPath as UTF-8.
@@ -71,41 +61,47 @@ async function writeTo(outPath, data) {
  *                              Rejects on errors.
  */
 async function fetchAndWrite(src, out, whenToHalt, timeout = 300000) {
-  const userData = await mkdtemp(os.tmpdir() + "/respec2html-");
-  const nightmare = new Nightmare({ ...config, waitTimeout: timeout * 1000, paths: { userData } });
-  nightmare.useragent("respec2html");
-  const url = parseURL(src).href;
-  const handleConsoleMessages = makeConsoleMsgHandler(nightmare);
-  handleConsoleMessages(whenToHalt);
-  const response = await nightmare.goto(url);
-  if (response.code !== 200) {
-    const warn = colors.warn(`📡 HTTP Error ${response.code}:`);
-    const msg = `${warn} ${colors.debug(url)}`;
-    nightmare.proc.kill();
-    throw new Error(msg);
+  const userDataDir = await mkdtemp(os.tmpdir() + "/respec2html-");
+  const browser = await puppeteer.launch({
+    userDataDir
+  });
+  try {
+    const page = await browser.newPage();
+    const url = parseURL(src).href;
+    const response = await page.goto(url, { timeout });
+    const handleConsoleMessages = makeConsoleMsgHandler(page);
+    handleConsoleMessages(whenToHalt);
+    if (!response.ok()) {
+      const warn = colors.warn(`📡 HTTP Error ${response.code}:`);
+      const msg = `${warn} ${colors.debug(url)}`;
+      throw new Error(msg);
+    }
+    await checkIfReSpec(browser, page);
+    const version = await checkReSpecVersion(page);
+    const html = await generateHTML(page, version, url);
+    switch (out) {
+      case null:
+        process.stdout.write(html);
+        break;
+      case "":
+        break;
+      default:
+        try {
+          await writeTo(out, html);
+        } catch (err) {
+          throw err;
+        }
+    }
+    return html;
   }
-  await checkIfReSpec(nightmare, url);
-  const version = await checkReSpecVersion(nightmare);
-  const html = await generateHTML(nightmare, version, url);
-  switch (out) {
-    case null:
-      process.stdout.write(html);
-      break;
-    case "":
-      break;
-    default:
-      try {
-        await writeTo(out, html);
-      } catch (err) {
-        throw err;
-      }
+  finally {
+    browser.close();
   }
-  return html;
 }
 
-async function generateHTML(nightmare, version, url) {
+async function generateHTML(page, version, url) {
   try {
-    return await nightmare.evaluate(evaluateHTML).end();
+    return await page.evaluate(evaluateHTML);
   } catch (err) {
     const msg =
       `\n😭  Sorry, there was an error generating the HTML. Please report this issue!\n` +
@@ -119,12 +115,11 @@ async function generateHTML(nightmare, version, url) {
   }
 }
 
-async function checkReSpecVersion(nightmare) {
-  const version = await nightmare
-    .wait(() => {
-      return window.hasOwnProperty("respecVersion");
-    })
-    .evaluate(getVersion);
+async function checkReSpecVersion(page) {
+  if (!(await page.evaluate(() => window.hasOwnProperty("respecVersion")))) {
+    throw new Error("No respecVersion is found");
+  }
+  const version = await page.evaluate(getVersion);
   const [mayor] = version;
   // The exportDocument() method only appeared in vesion 18.
   if (mayor < 18) {
@@ -141,13 +136,12 @@ async function checkReSpecVersion(nightmare) {
   return version;
 }
 
-async function checkIfReSpec(nightmare, url) {
-  const isRespecDoc = await nightmare.evaluate(isRespec);
+async function checkIfReSpec(page) {
+  const isRespecDoc = await page.evaluate(isRespec);
   if (!isRespecDoc) {
     const msg = `${colors.warn(
       "🕵️‍♀️  That doesn't seem to be a ReSpec document. Please check manually:"
-    )} ${colors.debug(url)}`;
-    nightmare.proc.kill();
+    )} ${colors.debug(page.url)}`;
     throw new Error(msg);
   }
   return isRespecDoc;
@@ -206,10 +200,10 @@ function getVersion() {
 /**
  * Handles messages from the browser's Console API.
  *
- * @param  {Nightmare} nightmare Instance of Nightmare to listen on.
+ * @param  {puppeteer.Page} page Instance of page to listen on.
  * @return {Function}
  */
-function makeConsoleMsgHandler(nightmare) {
+function makeConsoleMsgHandler(page) {
   /**
    * Specifies what to do when the browser emits "error" and "warn" console
    * messages.
@@ -220,28 +214,25 @@ function makeConsoleMsgHandler(nightmare) {
    * @return {Void}
    */
   return function handleConsoleMessages(whenToHalt) {
-    nightmare.on("console", (type, message) => {
+    page.on("console", message => {
+      const type = message.type();
+      const text = message.text();
       const abortOnWarning = whenToHalt.haltOnWarn && type === "warn";
       const abortOnError = whenToHalt.haltOnError && type === "error";
-      const output = `ReSpec ${type}: ${colors.debug(message)}`;
+      const output = `ReSpec ${type}: ${colors.debug(text)}`;
       switch (type) {
         case "error":
-          if (typeof message === "object") {
-            console.error(message);
-          } else {
-            console.error(colors.error(`😱 ${output}`));
-          }
+          console.error(colors.error(`😱 ${output}`));
           break;
         case "warn":
-          // Ignore Nightmare's poling of respecDone
-          if (/document\.respecDone/.test(message)) {
+          // Ignore polling of respecDone
+          if (/document\.respecDone/.test(text)) {
             return;
           }
           console.warn(colors.warn(`🚨 ${output}`));
           break;
       }
       if (abortOnError || abortOnWarning) {
-        nightmare.proc.kill();
         process.exit(1);
       }
     });


### PR DESCRIPTION
[`puppeteer`](https://developers.google.com/web/tools/puppeteer/) is a first-party wrapper library of Chromium made by Google. It directly uses Chromium instead of Electron (which again uses Chromium), and has less dependencies (80 total dependencies for `nightmare` whereas 16 for `puppeteer`.)

This still requires a real browser (Chromium) but in a lighter way.

Ultimately, but not in this PR, we can use puppeteer-installed Chromium to be used in karma tests so that GPU-less CLI environments can use it easily.