### PR TITLE
Skip detectBrowsers when explicitly passing browsers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,6 @@ dist: trusty
 node_js:
   - lts/*
 
-before_install:
-  # see https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI
-  - "export DISPLAY=:99.0"
-  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16 -extension RANDR"
-  - export PATH="$PATH:$HOME/.rvm/bin"
-  - sleep 3
-
 install:
   - npm install
   - npm run build

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -13,7 +13,7 @@ module.exports = function(config) {
 
     // configuration
     detectBrowsers: {
-      enabled: true,
+      enabled: !config.browsers.length,
       usePhantomJS: false,
       postDetection(browsers) {
         return (
@@ -122,7 +122,7 @@ module.exports = function(config) {
     options.singleRun = true;
     options.concurrency = 1;
     options.reporters = ["mocha"];
-    options.browsers = ["Chrome"]; //"Firefox"
+    options.browsers = ["ChromeHeadless"]; //"Firefox"
   }
   config.set(options);
 };


### PR DESCRIPTION
This enables `npm run karma -- --browsers FirefoxHeadless` to skip automatic browser detection.

Bonus: Using ChromeHeadless does not require xvfb :+1: