### PR TITLE
fix: prevent unordered tests from conflicting

### DIFF
--- a/tests/spec/core/linter-rules/no-headingless-sections-spec.js
+++ b/tests/spec/core/linter-rules/no-headingless-sections-spec.js
@@ -12,7 +12,7 @@ describe("Core Linter Rule - 'no-headingless-sections'", () => {
   });
   const doc = document.implementation.createHTMLDocument("test doc");
   beforeEach(() => {
-    // Make sure every test get an empty document
+    // Make sure every unordered test get an empty document
     // See: https://github.com/w3c/respec/pull/1495
     while (doc.body.firstChild) {
       doc.body.removeChild(doc.body.firstChild);

--- a/tests/spec/core/linter-rules/no-headingless-sections-spec.js
+++ b/tests/spec/core/linter-rules/no-headingless-sections-spec.js
@@ -12,6 +12,8 @@ describe("Core Linter Rule - 'no-headingless-sections'", () => {
   });
   const doc = document.implementation.createHTMLDocument("test doc");
   beforeEach(() => {
+    // Make sure every test get an empty document
+    // See: https://github.com/w3c/respec/pull/1495
     while (doc.body.firstChild) {
       doc.body.removeChild(doc.body.firstChild);
     }

--- a/tests/spec/core/linter-rules/no-headingless-sections-spec.js
+++ b/tests/spec/core/linter-rules/no-headingless-sections-spec.js
@@ -11,6 +11,11 @@ describe("Core Linter Rule - 'no-headingless-sections'", () => {
     });
   });
   const doc = document.implementation.createHTMLDocument("test doc");
+  beforeEach(() => {
+    while (doc.body.firstChild) {
+      doc.body.removeChild(doc.body.firstChild);
+    }
+  });
   it("returns error when heading is missing section", async () => {
     const section = doc.createElement("section");
     doc.body.appendChild(section);


### PR DESCRIPTION
jasmine-core 3.0 [defaults to running in unordered way](https://github.com/jasmine/jasmine/blob/master/release_notes/3.0.md) and this causes failure on no-headingless-sections tests:

```
  Core Linter Rule - 'no-headingless-sections'
    √ complains when a nested section doesn't have a heading
    × returns error when heading is missing section
    √ doesn't complain when sections do have a heading
```

```
  Core Linter Rule - 'no-headingless-sections'
    √ returns error when heading is missing section
    √ doesn't complain when sections do have a heading
    √ complains when a nested section doesn't have a heading
```

This PR clears `doc` before each test to prevent this failure.