### PR TITLE
refactor: remove WebIDL array support 

### DIFF
--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -58,15 +58,7 @@ function registerHelpers() {
     if (rhs.type === "identifier") {
       return options.fn(rhs.value);
     }
-    return (
-      "(" +
-      rhs.value
-        .map(function(item) {
-          return options.fn(item);
-        })
-        .join(",") +
-      ")"
-    );
+    return `(${rhs.value.map(options.fn)})`;
   });
   hb.registerHelper("param", function(obj) {
     return new hb.SafeString(
@@ -117,26 +109,20 @@ function registerHelpers() {
   });
   hb.registerHelper("join", function(arr, between, options) {
     return arr
-      .map(function(elem) {
-        return options.fn(elem);
-      })
+      .map(options.fn)
       .join(between);
   });
   hb.registerHelper("joinNonWhitespace", function(arr, between, options) {
     return arr
-      .filter(function(elem) {
-        return elem.type !== "ws";
-      })
-      .map(function(elem) {
-        return options.fn(elem);
-      })
+      .filter(elem => elem.type !== "ws")
+      .map(options.fn)
       .join(between);
   });
   // A block helper that emits an <a title> around its contents
   // if obj.dfn exists. If it exists, that implies that
   // there's another <dfn> for the object.
   hb.registerHelper("tryLink", function(obj, options) {
-    var content = options.fn(this);
+    const content = options.fn(this);
     const isDefaultJSON =
       obj.name === "toJSON" &&
       obj.extAttrs.some(({ name }) => name === "Default");
@@ -162,39 +148,26 @@ function registerHelpers() {
 }
 
 function idn(lvl) {
-  var str = "";
-  for (var i = 0; i < lvl; i++) {
-    str += "    ";
-  }
-  return str;
+  return "    ".repeat(lvl);
 }
 
 function idlType2Html(idlType) {
   if (typeof idlType === "string") {
-    return "<a>" + hb.Utils.escapeExpression(idlType) + "</a>";
+    return `<a>${hb.Utils.escapeExpression(idlType)}</a>`;
   }
   if (Array.isArray(idlType)) {
     return idlType.map(idlType2Html).join(", ");
   }
-  var nullable = idlType.nullable ? "?" : "";
+  const nullable = idlType.nullable ? "?" : "";
   if (idlType.union) {
-    return (
-      "(" +
-      idlType.idlType
-        .map(function(type) {
-          return idlType2Html(type);
-        })
-        .join(" or ") +
-      ")" +
-      nullable
-    );
+    return `(${idlType.idlType.map(idlType2Html).join(" or ")})${nullable}`;
   }
-  var type = "";
+  let type = "";
   if (idlType.generic) {
     type = standardTypes.has(idlType.generic)
       ? linkStandardType(idlType.generic)
       : idlType2Html(idlType.generic);
-    type = type + "&lt;" + idlType2Html(idlType.idlType) + ">";
+    type = `${type}&lt;${idlType2Html(idlType.idlType)}>`;
   } else {
     type = standardTypes.has(idlType.idlType)
       ? linkStandardType(idlType.idlType)
@@ -208,27 +181,16 @@ function linkStandardType(type) {
     return type;
   }
   const safeType = hb.Utils.escapeExpression(type);
-  return (
-    "<a data-cite='" + standardTypes.get(safeType) + "'>" + safeType + "</a>"
-  );
+  return `<a data-cite='${standardTypes.get(safeType)}'>${safeType}</a>`;
 }
 
 function idlType2Text(idlType) {
   if (typeof idlType === "string") {
     return idlType;
   }
-  var nullable = idlType.nullable ? "?" : "";
+  const nullable = idlType.nullable ? "?" : "";
   if (idlType.union) {
-    return (
-      "(" +
-      idlType.idlType
-        .map(function(type) {
-          return idlType2Text(type);
-        })
-        .join(" or ") +
-      ")" +
-      nullable
-    );
+    return `(${idlType.idlType.map(idlType2Text).join(" or ")})${nullable}`;
   }
   if (idlType.generic) {
     const types = []
@@ -241,12 +203,7 @@ function idlType2Text(idlType) {
 }
 
 function pads(num) {
-  // XXX
-  //  this might be more simply done as
-  //  return Array(num + 1).join(" ")
-  var str = "";
-  for (var i = 0; i < num; i++) str += " ";
-  return str;
+  return " ".repeat(num);
 }
 var whitespaceTypes = {
   ws: true,

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -497,18 +497,17 @@ function writeDefinition(obj, indent) {
       var members = obj.members.filter(function(member) {
         return !typeIsWhitespace(member.type);
       });
-      obj.members.forEach(function(it) {
+      for (const it of obj.members) {
         if (typeIsWhitespace(it.type)) {
-          return;
+          continue;
         }
-        var qualifiers = "";
-        if (it.required) qualifiers += "required ";
+        const qualifiers = it.required ? "required " : "";
         if (maxQualifiers < qualifiers.length)
           maxQualifiers = qualifiers.length;
 
         var typeLen = idlType2Text(it.idlType).length;
         if (maxType < typeLen) maxType = typeLen;
-      });
+      }
       var children = obj.members
         .map(function(it) {
           switch (it.type) {
@@ -799,21 +798,17 @@ function writeMultiLineComment(comment, indent) {
 }
 
 function writeMaplike(maplike, indent) {
-  var qualifiers = "";
-  if (maplike.readonly) qualifiers += "readonly ";
   return idlMaplikeTmpl({
     obj: maplike,
-    qualifiers: qualifiers,
+    qualifiers: maplike.readonly ? "readonly " : "",
     indent: indent,
   });
 }
 
 function writeIterable(iterable, indent) {
-  var qualifiers = "";
-  if (iterable.readonly) qualifiers += "readonly ";
   return idlIterableTmpl({
     obj: iterable,
-    qualifiers: qualifiers,
+    qualifiers: iterable.readonly ? "readonly " : "",
     indent: indent,
   });
 }

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -189,23 +189,6 @@ function idlType2Html(idlType) {
       nullable
     );
   }
-  if (idlType.array) {
-    var arrayStr = "";
-    for (var i = 0; i < idlType.array; ++i) {
-      if (idlType.nullableArray[i]) {
-        arrayStr += "?";
-      }
-      arrayStr += "[]";
-    }
-    return (
-      idlType2Html({
-        generic: idlType.generic,
-        idlType: idlType.idlType,
-      }) +
-      arrayStr +
-      nullable
-    );
-  }
   var type = "";
   if (idlType.generic) {
     type = standardTypes.has(idlType.generic)
@@ -244,23 +227,6 @@ function idlType2Text(idlType) {
         })
         .join(" or ") +
       ")" +
-      nullable
-    );
-  }
-  if (idlType.array) {
-    var arrayStr = "";
-    for (var i = 0; i < idlType.array; ++i) {
-      if (idlType.nullableArray[i]) {
-        arrayStr += "?";
-      }
-      arrayStr += "[]";
-    }
-    return (
-      idlType2Text({
-        generic: idlType.generic,
-        idlType: idlType.idlType,
-      }) +
-      arrayStr +
       nullable
     );
   }


### PR DESCRIPTION
as it has been removed from the spec.

Also includes several ES2015 refactorings for `registerHelpers()`, before we do #1136.