### PR TITLE
fix(core/webidl-index): support multiple idl blocks

### DIFF
--- a/src/core/webidl-index.js
+++ b/src/core/webidl-index.js
@@ -42,9 +42,11 @@ export function run(conf, doc, cb) {
   Array.from(document.querySelectorAll("pre.def.idl"))
     .map(elem => {
       const span = document.createElement("span");
-      const clone = elem.cloneNode(true).firstElementChild;
-      span.appendChild(clone);
-      span.appendChild(document.createTextNode("\n"));
+      const children = elem.cloneNode(true).children;
+      for(const child of Array.from(children)) {
+        span.appendChild(child);
+        span.appendChild(document.createTextNode("\n"));
+      };
       span.classList.add("respec-idl-separator");
       return span;
     })

--- a/src/core/webidl-index.js
+++ b/src/core/webidl-index.js
@@ -42,11 +42,11 @@ export function run(conf, doc, cb) {
   Array.from(document.querySelectorAll("pre.def.idl"))
     .map(elem => {
       const span = document.createElement("span");
-      const children = elem.cloneNode(true).children;
-      for(const child of Array.from(children)) {
+      const { children } = elem.cloneNode(true);
+      for (const child of Array.from(children)) {
         span.appendChild(child);
         span.appendChild(document.createTextNode("\n"));
-      };
+      }
       span.classList.add("respec-idl-separator");
       return span;
     })

--- a/tests/spec/core/idl-index-spec.js
+++ b/tests/spec/core/idl-index-spec.js
@@ -39,6 +39,40 @@ interface Bar {
     expect(header.textContent).toEqual("1. IDL Index");
   });
 
+  it("allows multi-block idl", async () => {
+    const body = `
+      ${makeDefaultBody()}
+      <section>
+        <pre class=idl>
+        [Constructor, Exposed=Window]
+        interface BeforeInstallPromptEvent : Event {
+            Promise&lt;PromptResponseObject&gt; prompt();
+        };
+        dictionary PromptResponseObject {
+          AppBannerPromptOutcome userChoice;
+        };
+        </pre>
+      </section>
+      <section id="idl-index"></section>
+    `;
+    const expectedIDL = `[Constructor,
+ Exposed=Window]
+interface BeforeInstallPromptEvent : Event {
+    Promise<PromptResponseObject> prompt();
+};
+dictionary PromptResponseObject {
+    AppBannerPromptOutcome userChoice;
+};\n`;
+    const ops = {
+      config: makeBasicConfig(),
+      body,
+    };
+    const doc = await makeRSDoc(ops);
+    const idlIndex = doc.querySelector("#idl-index");
+    expect(idlIndex).not.toBe(null);
+    expect(idlIndex.querySelector("pre").textContent).toEqual(expectedIDL);
+  });
+
   it("allows custom content and header", async () => {
     const body = `
       ${makeDefaultBody()}


### PR DESCRIPTION
For issue #1479 
The problem is appending only the first child.


Screenshot after changes: 

![peek 2018-02-11 20-30](https://user-images.githubusercontent.com/20224346/36074759-a3b4bd04-0f6a-11e8-9343-42efdf805faf.gif)


UPDATED SCREENSHOT

![peek 2018-02-11 23-24](https://user-images.githubusercontent.com/20224346/36076661-39e8d5ca-0f85-11e8-82c2-8bd897eff2b9.gif)
