### PR TITLE
docs(examples): use github config option

### DIFF
--- a/examples/basic.built.html
+++ b/examples/basic.built.html
@@ -5,15 +5,13 @@
     <title>Replace me with a real title</title>
     <script src="../builds/respec-w3c-common.js" class='remove'></script>
     <script class='remove'>
-      const respecConfig = {
+      var respecConfig = {
         specStatus: "ED",
         editors: [{
           name: "Your Name",
           url: "https://your-site.com",
         }],
-        processVersion: 2017,
-        edDraftURI: "https://some.github.repo",
-        shortName: "dahut"
+        github: "https://github.com/w3c/some-API/",
       };
     </script>
   </head>

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -12,9 +12,7 @@
           name: "Your Name",
           url: "https://your-site.com",
         }],
-        processVersion: 2018,
-        edDraftURI: "https://some.github.repo",
-        shortName: "dahut"
+        github: "https://github.com/w3c/some-API/",
       };
     </script>
   </head>


### PR DESCRIPTION
Want to encourage use of `github:`, instead of setting config options
manually.