### PR TITLE
Refactor showPeople helper function

### DIFF
--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -170,14 +170,11 @@ hb.registerHelper("showPeople", function(name, items = []) {
     }
     if (p.note) ret += ` (${p.note})`;
     if (p.extras) {
-      var self = this;
       var resultHTML = p.extras
         // Remove empty names
-        .filter(function(extra) {
-          return extra.name && extra.name.trim();
-        })
+        .filter(extra => extra.name && extra.name.trim())
         // Convert to HTML
-        .map(function(extra) {
+        .map(extra => {
           var span = document.createElement("span");
           var textContainer = span;
           if (extra.class) {
@@ -188,7 +185,7 @@ hb.registerHelper("showPeople", function(name, items = []) {
             span.appendChild(a);
             a.href = extra.href;
             textContainer = a;
-            if (self.doRDFa) {
+            if (this.doRDFa) {
               a.setAttribute("property", "rdfs:seeAlso");
             }
           }

--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -122,7 +122,7 @@ hb.registerHelper("showPeople", function(name, items = []) {
   if (this.doRDFa) {
     if (name === "Editor") {
       bn = "_:editor0";
-      re = " property='bibo:editor' resource='" + bn + "'";
+      re = ` property='bibo:editor' resource='${bn}'`;
       rp = " property='rdf:first' typeof='foaf:Person'";
     } else if (name === "Author") {
       rp = " property='dc:contributor' typeof='foaf:Person'";
@@ -137,72 +137,38 @@ hb.registerHelper("showPeople", function(name, items = []) {
   for (var i = 0, n = items.length; i < n; i++) {
     var p = items[i];
     if (p.w3cid) {
-      editorid = " data-editor-id='" + parseInt(p.w3cid, 10) + "'";
+      editorid = ` data-editor-id='${parseInt(p.w3cid, 10)}'`;
     }
     if (this.doRDFa) {
-      ret +=
-        "<dd class='p-author h-card vcard' " +
-        re +
-        editorid +
-        "><span" +
-        rp +
-        ">";
+      ret += `<dd class='p-author h-card vcard' ${re}${editorid}><span${rp}>`;
       if (name === "Editor") {
         // Update to next sequence in rdf:List
-        bn = i < n - 1 ? "_:editor" + (i + 1) : "rdf:nil";
-        re = " resource='" + bn + "'";
+        bn = i < n - 1 ? `_:editor${i + 1}` : "rdf:nil";
+        re = ` resource='${bn}'`;
       }
     } else {
-      ret += "<dd class='p-author h-card vcard'" + editorid + ">";
+      ret += `<dd class='p-author h-card vcard'${editorid}>`;
     }
     if (p.url) {
       if (this.doRDFa) {
-        ret +=
-          "<meta" +
-          rn +
-          " content='" +
-          p.name +
-          "'><a class='u-url url p-name fn' " +
-          rpu +
-          " href='" +
-          p.url +
-          "'>" +
-          p.name +
-          "</a>";
+        ret += `<meta${rn} content='${p.name}'>` +
+          `<a class='u-url url p-name fn' ${rpu} href='${p.url}'>${p.name}</a>`;
       } else
-        ret +=
-          "<a class='u-url url p-name fn' href='" +
-          p.url +
-          "'>" +
-          p.name +
-          "</a>";
+        ret += `<a class='u-url url p-name fn' href='${p.url}'>${p.name}</a>`;
     } else {
-      ret += "<span" + rn + " class='p-name fn'>" + p.name + "</span>";
+      ret += `<span${rn} class='p-name fn'>${p.name}</span>`;
     }
     if (p.company) {
       ret += ", ";
       if (p.companyURL)
-        ret +=
-          "<a" +
-          rwu +
-          " class='p-org org h-org h-card' href='" +
-          p.companyURL +
-          "'>" +
-          p.company +
-          "</a>";
+        ret += `<a${rwu} class='p-org org h-org h-card' href='${p.companyURL}'>${p.company}</a>`;
       else ret += p.company;
     }
     if (p.mailto) {
-      ret +=
-        ", <span class='ed_mailto'><a class='u-email email' " +
-        rm +
-        " href='mailto:" +
-        p.mailto +
-        "'>" +
-        p.mailto +
-        "</a></span>";
+      ret += `, <span class='ed_mailto'>` +
+        `<a class='u-email email' ${rm} href='mailto:${p.mailto}'>${p.mailto}</a></span>`;
     }
-    if (p.note) ret += " (" + p.note + ")";
+    if (p.note) ret += ` (${p.note})`;
     if (p.extras) {
       var self = this;
       var resultHTML = p.extras
@@ -235,7 +201,7 @@ hb.registerHelper("showPeople", function(name, items = []) {
     if (this.doRDFa) {
       ret += "</span>\n";
       if (name === "Editor")
-        ret += "<span property='rdf:rest' resource='" + bn + "'></span>\n";
+        ret += `<span property='rdf:rest' resource='${bn}'></span>\n`;
     }
     ret += "</dd>\n";
   }

--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -91,6 +91,7 @@
 //      - "w3c-software", a permissive and attributions license (but GPL-compatible).
 //      - "w3c-software-doc", the W3C Software and Document License
 //            https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+import "deps/hyperhtml";
 import { concatDate, joinAnd, ISODate } from "core/utils";
 import hb from "handlebars.runtime";
 import { pub } from "core/pubsubhub";
@@ -109,6 +110,7 @@ const W3CDate = new Intl.DateTimeFormat(["en-AU"], {
 });
 
 hb.registerHelper("showPeople", function(name, items = []) {
+  const html = (...args) => hyperHTML.wire()(...args);
   // stuff to handle RDFa
   var re = "",
     rp = "",
@@ -175,21 +177,16 @@ hb.registerHelper("showPeople", function(name, items = []) {
         .filter(extra => extra.name && extra.name.trim())
         // Convert to HTML
         .map(extra => {
-          var span = document.createElement("span");
-          var textContainer = span;
-          if (extra.class) {
-            span.className = extra.class;
-          }
+          const span = html`<span class=${extra.class || null}></span>`
+          let textContainer = span;
           if (extra.href) {
-            var a = document.createElement("a");
-            span.appendChild(a);
-            a.href = extra.href;
-            textContainer = a;
-            if (this.doRDFa) {
-              a.setAttribute("property", "rdfs:seeAlso");
-            }
+            textContainer = html`<a
+              href=${extra.href || null}
+              property=${this.doRDFa ? "rdfs:seeAlso" : null}
+            ></a>`;
+            span.appendChild(textContainer);
           }
-          textContainer.innerHTML = extra.name;
+          textContainer.textContent = extra.name;
           return span.outerHTML;
         })
         .join(", ");


### PR DESCRIPTION
This PR uses hyperHTML for showPeople function, replacing previous simple-but-hard-to-read string concatenations.

cc: @marcoscaceres 

Probably a good chance to do some chat and make things in right direction, before any migrations for core IDL templates.