### PR TITLE
fix: re-add sudo required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ install:
   - npm run build
   - npm run build:respec-w3c-common
 
+# use sudo to workaround https://github.com/w3c/respec/issues/1462 
+sudo: required
+
 addons:
 #  firefox: latest
   chrome: stable


### PR DESCRIPTION
This `sudo: required` is still required for the karma tests, which is not related with the new `--disable-sandbox` option.