### PR TITLE
make save-html a core module

### DIFF
--- a/js/profile-w3c-common.js
+++ b/js/profile-w3c-common.js
@@ -61,7 +61,7 @@ define(
     "core/id-headers",
     "core/rdfa",
     "core/location-hash",
-    "ui/save-html",
+    "core/save-html",
     "ui/search-specref",
     "ui/dfn-list",
     "ui/about-respec",

--- a/src/core/save-html.js
+++ b/src/core/save-html.js
@@ -1,10 +1,10 @@
-// Module ui/save-html
+// Module core/save-html
 // Saves content to HTML when asked to
 import { xmlEscape, removeReSpec } from "core/utils";
 import { pub } from "core/pubsubhub";
 import { ui } from "core/ui";
 import { l10n, lang } from "core/l10n";
-export const name = "ui/save-html";
+export const name = "core/save-html";
 
 const downloadLinks = [
   {
@@ -37,7 +37,7 @@ let button;
 if (supportsDownload) {
   button = ui.addCommand(
     l10n[lang].save_snapshot,
-    "ui/save-html",
+    "core/save-html",
     "Ctrl+Shift+Alt+S",
     "💾"
   );

--- a/src/w3c/style.js
+++ b/src/w3c/style.js
@@ -27,7 +27,7 @@ function attachFixupScript(doc, version) {
 // Other plugins might subsequently push it down, but at least we start
 // at the right place. When ReSpec exports the HTML, it again moves the
 // meta viewport to the top of the head - so to make sure it's the first
-// thing the browser sees. See js/ui/save-html.js.
+// thing the browser sees. See js/core/save-html.js.
 function createMetaViewport() {
   const meta = document.createElement("meta");
   meta.name = "viewport";

--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -173,7 +173,7 @@ async function evaluateHTML() {
   try {
     await document.respecIsReady;
     const exportDocument = await new Promise(resolve => {
-      require(["ui/save-html"], ({ exportDocument }) => {
+      require(["core/save-html"], ({ exportDocument }) => {
         resolve(exportDocument);
       });
     });


### PR DESCRIPTION
For #1419 
@marcoscaceres @saschanaz  I just moved ```save-html``` to ```core``` and changed wherever it is referenced. Tests are to be written. It would be great if you could help taking forward this PR. What tests are to be written? How to capture downloadable files inside tests?