### PR TITLE
refactor(w3c/headers): use w3c defaults

### DIFF
--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -230,12 +230,6 @@ export function run(conf, doc, cb) {
   if (conf.isUnofficial) {
     conf.logos = [];
   }
-  // Default include RDFa document metadata
-  if (conf.doRDFa === undefined) conf.doRDFa = true;
-  // validate configuration and derive new configuration values
-  if (!conf.license) {
-    conf.license = "w3c-software-doc";
-  }
   conf.isCCBY = conf.license === "cc-by";
   conf.isW3CSoftAndDocLicense = conf.license === "w3c-software-doc";
   if (["cc-by", "w3c"].includes(conf.license)) {


### PR DESCRIPTION
These were already always defined via the w3c defaults, so these checks are redundant. 