### PR TITLE
jsonld uses undefined "xsd" namespace

### DIFF
--- a/src/w3c/jsonld.js
+++ b/src/w3c/jsonld.js
@@ -15,10 +15,10 @@ export function run(conf, doc, cb) {
       "http://schema.org",
       {
         "@vocab": "http://schema.org/",
-        "@language": "en",
+        "@language": doc.documentElement.lang || "en",
         w3p: "http://www.w3.org/2001/02pd/rec54#",
         foaf: "http://xmlns.com/foaf/0.1/",
-        datePublished: { "@type": "xsd:date" },
+        datePublished: { "@type": "http://www.w3.org/2001/XMLSchema#date" },
         inLanguage: { "@language": null },
         isBasedOn: { "@type": "@id" },
         license: { "@type": "@id" },


### PR DESCRIPTION
Set JSON-LD `@langauge` from HTML `@lang`.
Fix `datePublished` `@type` to not use undefined `xsd` namespace.