### PR TITLE
fix(w3c/jsonld): make async, used description

### DIFF
--- a/js/profile-w3c-common.js
+++ b/js/profile-w3c-common.js
@@ -59,7 +59,6 @@ define(
     "w3c/informative",
     "w3c/permalinks",
     "core/id-headers",
-    "w3c/jsonld",
     "core/location-hash",
     "ui/save-html",
     "ui/search-specref",
@@ -71,6 +70,7 @@ define(
     "core/webidl-clipboard",
     "core/data-tests",
     "core/list-sorter",
+    "w3c/jsonld",
     /*Linter must be the last thing to run*/
     "core/linter",
   ],

--- a/src/core/seo.js
+++ b/src/core/seo.js
@@ -13,22 +13,15 @@ export async function run(conf, doc, cb) {
   if (!firstParagraph) {
     return; // no abstract, so nothing to do
   }
-  const insertMetaDescription = makeDescriptionInserter(firstParagraph);
-  if (window.requestIdleCallback) {
-    window.requestIdleCallback(insertMetaDescription);
-  } else {
-    insertMetaDescription();
-  }
+  insertMetaDescription(firstParagraph);
 }
 
-function makeDescriptionInserter(firstParagraph) {
-  return () => {
-    // Normalize whitespace: trim, remove new lines, tabs, etc.
-    const doc = firstParagraph.ownerDocument;
-    const content = firstParagraph.textContent.replace(/\s+/, " ").trim();
-    const metaElem = doc.createElement("meta");
-    metaElem.name = "description";
-    metaElem.content = content;
-    doc.head.appendChild(metaElem);
-  };
+function insertMetaDescription(firstParagraph) {
+  // Normalize whitespace: trim, remove new lines, tabs, etc.
+  const doc = firstParagraph.ownerDocument;
+  const content = firstParagraph.textContent.replace(/\s+/, " ").trim();
+  const metaElem = doc.createElement("meta");
+  metaElem.name = "description";
+  metaElem.content = content;
+  doc.head.appendChild(metaElem);
 }

--- a/src/w3c/jsonld.js
+++ b/src/w3c/jsonld.js
@@ -54,7 +54,7 @@ export async function run(conf, doc, cb) {
   }
 
   // description from meta description
-  const description = doc.head.querySelector("meta[description]");
+  const description = doc.head.querySelector("meta[name=description]");
   if (description) {
     jsonld.description = description.content;
   }

--- a/src/w3c/jsonld.js
+++ b/src/w3c/jsonld.js
@@ -75,7 +75,7 @@ export async function run(conf, doc, cb) {
 
   const script = doc.createElement("script");
   script.type = "application/ld+json";
-  script.textContent = JSON.stringify(jsonld);
+  script.textContent = JSON.stringify(jsonld, null, 2);
   doc.head.appendChild(script);
 }
 

--- a/tests/spec/w3c/jsonld-spec.js
+++ b/tests/spec/w3c/jsonld-spec.js
@@ -78,7 +78,7 @@ describe("Core — JSON-LD", () => {
     });
   });
 
-  it("should describe editors and contributors", async () => {
+  it("describes editors and contributors", async () => {
     const ops = { config, body };
     const doc = await makeRSDoc(ops);
 
@@ -96,7 +96,7 @@ describe("Core — JSON-LD", () => {
     });
   });
 
-  it("should describe contributors", async () => {
+  it("describes contributors", async () => {
     const ops = { config, body };
     const doc = await makeRSDoc(ops);
 
@@ -112,7 +112,7 @@ describe("Core — JSON-LD", () => {
     });
   });
 
-  it("should describe citations", async () => {
+  it("describes citations", async () => {
     const ops = { config, body };
     const doc = await makeRSDoc(ops);
 

--- a/tests/spec/w3c/jsonld-spec.js
+++ b/tests/spec/w3c/jsonld-spec.js
@@ -1,68 +1,73 @@
 "use strict";
 describe("Core — JSON-LD", () => {
   afterAll(flushIframes);
-  const body = "<html><title>Basic Title</title></head>" +
-    "<section id='sotd'><p>foo</p></section><section id='toc'></section>" +
-    "<p>foo [[!TestRef1]] [[TestRef2]] [[!TestRef3]]</p>";
+  const body = `
+    <html>
+    <title>Basic Title</title>
+    <section id="sotd">
+      <p>foo</p>
+    </section>
+    <section id="toc"></section>
+    <p>foo [[!TestRef1]] [[TestRef2]] [[!TestRef3]]</p>
+  `;
   const config = {
-      editors: [
-        {
-          name: "Gregg Kellogg",
-          url: "http://URI",
-          company: "COMPANY",
-          companyURL: "http://COMPANY",
-          mailto: "EMAIL"
-        },
-      ],
-      authors: [
-        {
-          name: "Gregg Kellogg",
-        },
-        {
-          name: "Shane McCarron",
-        },
-      ],
-      shortName: "some-spec",
-      publishDate: "2013-06-25",
-      previousPublishDate: "2012-06-07",
-      previousMaturity: "REC",
-      specStatus: "PER",
-      perEnd: "2014-06-25",
-      wgPatentURI: "http://www.w3.org/fake-patent-uri",
-      doJsonLd: true,
-      localBiblio: {
-        TestRef1: {
-          title: "Test ref title",
-          href: "http://test.com/1",
-          authors: ["William Shakespeare"],
-          publisher: "Publishers Inc.",
-        },
-        TestRef2: {
-          title: "Second test",
-          href: "http://test.com/2",
-          authors: ["Another author"],
-          publisher: "Testing 123",
-        },
-        TestRef3: {
-          title: "Third test",
-          href: "http://test.com/3",
-          publisher: "Publisher Here",
-        },
+    editors: [
+      {
+        name: "Gregg Kellogg",
+        url: "http://URI",
+        company: "COMPANY",
+        companyURL: "http://COMPANY",
+        mailto: "EMAIL"
       },
-    };
+    ],
+    authors: [
+      {
+        name: "Gregg Kellogg",
+      },
+      {
+        name: "Shane McCarron",
+      },
+    ],
+    shortName: "some-spec",
+    publishDate: "2013-06-25",
+    previousPublishDate: "2012-06-07",
+    previousMaturity: "REC",
+    specStatus: "PER",
+    perEnd: "2014-06-25",
+    wgPatentURI: "http://www.w3.org/fake-patent-uri",
+    doJsonLd: true,
+    localBiblio: {
+      TestRef1: {
+        title: "Test ref title",
+        href: "http://test.com/1",
+        authors: ["William Shakespeare"],
+        publisher: "Publishers Inc.",
+      },
+      TestRef2: {
+        title: "Second test",
+        href: "http://test.com/2",
+        authors: ["Another author"],
+        publisher: "Testing 123",
+      },
+      TestRef3: {
+        title: "Third test",
+        href: "http://test.com/3",
+        publisher: "Publisher Here",
+      },
+    },
+  };
 
-  it("should create basic document information", async () => {
-    const ops = {config, body};
+  it("includes basic document information", async () => {
+    const ops = { config, body };
     const doc = await makeRSDoc(ops);
-
     const script = doc.querySelector("script[type='application/ld+json']");
     const jsonld = JSON.parse(script.textContent);
     expect(jsonld["@context"]).toContain("http://schema.org");
-    expect(jsonld.id).toEqual("https://www.w3.org/TR/2013/PER-some-spec-20130625/")
+    expect(jsonld.id).toEqual("https://www.w3.org/TR/some-spec/")
     expect(jsonld.type).toContain("TechArticle");
     expect(jsonld.type).toContain("w3p:PER");
     expect(jsonld.datePublished).toEqual("2013-06-25");
-    expect(jsonld.description).toContain("Abstract");
+    expect(jsonld.description).toContain("test abstract");
     expect(jsonld.inLanguage).toEqual("en");
     expect(jsonld.isBasedOn).toEqual("https://www.w3.org/TR/2012/REC-some-spec-20120607/");
     expect(jsonld.license).toEqual("https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document")
@@ -74,7 +79,7 @@ describe("Core — JSON-LD", () => {
   });
 
   it("should describe editors and contributors", async () => {
-    const ops = {config, body};
+    const ops = { config, body };
     const doc = await makeRSDoc(ops);
 
     const script = doc.querySelector("script[type='application/ld+json']");
@@ -92,7 +97,7 @@ describe("Core — JSON-LD", () => {
   });
 
   it("should describe contributors", async () => {
-    const ops = {config, body};
+    const ops = { config, body };
     const doc = await makeRSDoc(ops);
 
     const script = doc.querySelector("script[type='application/ld+json']");
@@ -108,7 +113,7 @@ describe("Core — JSON-LD", () => {
   });
 
   it("should describe citations", async () => {
-    const ops = {config, body};
+    const ops = { config, body };
     const doc = await makeRSDoc(ops);
 
     const script = doc.querySelector("script[type='application/ld+json']");
@@ -135,7 +140,7 @@ describe("Core — JSON-LD", () => {
 
   it("adds an additional copyright holder", async () => {
     const ops = {
-      config: Object.assign({}, config, {additionalCopyrightHolders: ["ACME"]}),
+      config: {...config, additionalCopyrightHolders: ["ACME"] },
       body
     };
     const doc = await makeRSDoc(ops);
@@ -145,6 +150,6 @@ describe("Core — JSON-LD", () => {
     expect(jsonld.copyrightHolder).toEqual([{
       name: "World Wide Web Consortium",
       url: "https://www.w3.org/"
-    }, {name: "ACME"}]);
+    }, { name: "ACME" }]);
   });
 });


### PR DESCRIPTION
This makes jsonld get added after processing, so to not block critical content rendering. 

Additionally, it fixes the `description`, to use the one we already have in the document's head. The whitespace has been cleaned up nicely, and only uses the first paragraph of the abstract.  