### PR TITLE
feat(core/biblio): support different bibliographical styles

### DIFF
--- a/src/core/biblio.js
+++ b/src/core/biblio.js
@@ -235,7 +235,6 @@ function bibref(conf) {
         } else {
           key = refcontent.aliasOf;
           refcontent = conf.biblio[key];
-          { biblioStyle: refstyle }  = conf;
           circular[key] = true;
         }
       }

--- a/src/core/biblio.js
+++ b/src/core/biblio.js
@@ -93,6 +93,82 @@ export function wireReference(rawRef, target = "_blank") {
   `;
 }
 
+// const html = (...args) => hyperHTML.bind(doc.createDocumentFragment())(...args);
+
+// // Author, A. (Year, Month Date of Publication). Article title. Retrieved from URL
+// function entryToAPA(ref) {
+//   const { title } = ref.title;
+//   const authors =
+//     ref.authors && ref.authors.length
+//       ? `${ref.authors.join("; ")} ${ref.etAl ? " et al" : ""}.`
+//       : "";
+//   const date = ref.date ? `(${ref.date})` : "";
+//   return html`
+//     ${authors} ${date} ${
+//     ref.href
+//       ? html`<a href="${ref.href}"><cite>${title}</cite></a>.`
+//       : `${ref.title}`
+//   }
+//     ${
+//       ref.href
+//         ? html`Retrieved from URL: ${html`<a href="${ref.href}">${
+//             ref.href
+//           }</a>`}`
+//         : ""
+//     }
+//   `;
+// }
+
+// //Author’s Last name, First name. “Title of the Article or Individual Page.” Title of the website, Name of the publisher, Date of publication, URL.
+// function entryToMLA(ref) {
+//   const authors =
+//     ref.authors && ref.authors.length
+//       ? `${ref.authors.join("; ")} ${ref.etAl ? " et al" : ""}.`
+//       : "";
+//   const date = ref.date ? `${ref.date}, ` : "";
+//   const title = ref.title;
+//   const publisher = ref.publisher
+//     ? `${ref.publisher} ${ref.publisher.endsWith(".")}`
+//     : "";
+
+//   return html`
+// 	${authors} ${
+//     ref.href
+//       ? html`<a href="${ref.href}"><cite>${title}</cite></a>.`
+//       : `${ref.title}`
+//   } ${publisher} ${date} ${
+//     ref.href ? html`<a href="${ref.href}">${ref.href}</a>` : ""
+//   }`;
+// }
+
+// //what ReSpec currently does...
+// function entryToW3C(ref) {
+//   const title = ref.title;
+//   const authors =
+//     ref.authors && ref.authors.length
+//       ? `${ref.authors.join("; ")} ${ref.etAl ? " et al" : "."}.`
+//       : "";
+//   const publisher = ref.publisher
+//     ? `${ref.publisher} ${ref.publisher.endsWith(".")}`
+//     : "";
+//   const date = ref.date ? `${ref.date}. ` : "";
+//   const status = ref.status
+//     ? (REF_STATUSES.get(ref.status) || ref.status) + ". "
+//     : "";
+
+//   return html`
+//   	${
+//       ref.href
+//         ? html`<a href="${ref.href}"><cite>${title}</cite></a>.`
+//         : `${ref.title}`
+//     } ${authors} ${publisher} ${date} ${status} ${
+//     ref.href ? html`<a href="${ref.href}">${ref.href}</a>` : ""
+//   }`;
+// }
+
+
+
+
 // Author, A. (Year, Month Date of Publication). Article title. Retrieved from URL
 function entryToAPA(ref) {
   const authors =

--- a/src/core/biblio.js
+++ b/src/core/biblio.js
@@ -206,7 +206,7 @@ function bibref(conf) {
         .appendTo($dl);
       var $dd = $("<dd></dd>").appendTo($dl);
       var refcontent = conf.biblio[ref];
-      var refstyle = conf.biblioStyle[key];
+      var refstyle = conf.biblioStyle;
       var circular = {};
       var key = ref;
       circular[ref] = true;
@@ -218,7 +218,7 @@ function bibref(conf) {
         } else {
           key = refcontent.aliasOf;
           refcontent = conf.biblio[key];
-          refstyle = conf.biblioStyle[key];
+          refstyle = conf.biblioStyle;
           circular[key] = true;
         }
       }

--- a/src/core/biblio.js
+++ b/src/core/biblio.js
@@ -93,97 +93,30 @@ export function wireReference(rawRef, target = "_blank") {
   `;
 }
 
-// const html = (...args) => hyperHTML.bind(doc.createDocumentFragment())(...args);
-
-// // Author, A. (Year, Month Date of Publication). Article title. Retrieved from URL
-// function entryToAPA(ref) {
-//   const { title } = ref.title;
-//   const authors =
-//     ref.authors && ref.authors.length
-//       ? `${ref.authors.join("; ")} ${ref.etAl ? " et al" : ""}.`
-//       : "";
-//   const date = ref.date ? `(${ref.date})` : "";
-//   return html`
-//     ${authors} ${date} ${
-//     ref.href
-//       ? html`<a href="${ref.href}"><cite>${title}</cite></a>.`
-//       : `${ref.title}`
-//   }
-//     ${
-//       ref.href
-//         ? html`Retrieved from URL: ${html`<a href="${ref.href}">${
-//             ref.href
-//           }</a>`}`
-//         : ""
-//     }
-//   `;
-// }
-
-// //Author’s Last name, First name. “Title of the Article or Individual Page.” Title of the website, Name of the publisher, Date of publication, URL.
-// function entryToMLA(ref) {
-//   const authors =
-//     ref.authors && ref.authors.length
-//       ? `${ref.authors.join("; ")} ${ref.etAl ? " et al" : ""}.`
-//       : "";
-//   const date = ref.date ? `${ref.date}, ` : "";
-//   const title = ref.title;
-//   const publisher = ref.publisher
-//     ? `${ref.publisher} ${ref.publisher.endsWith(".")}`
-//     : "";
-
-//   return html`
-// 	${authors} ${
-//     ref.href
-//       ? html`<a href="${ref.href}"><cite>${title}</cite></a>.`
-//       : `${ref.title}`
-//   } ${publisher} ${date} ${
-//     ref.href ? html`<a href="${ref.href}">${ref.href}</a>` : ""
-//   }`;
-// }
-
-// //what ReSpec currently does...
-// function entryToW3C(ref) {
-//   const title = ref.title;
-//   const authors =
-//     ref.authors && ref.authors.length
-//       ? `${ref.authors.join("; ")} ${ref.etAl ? " et al" : "."}.`
-//       : "";
-//   const publisher = ref.publisher
-//     ? `${ref.publisher} ${ref.publisher.endsWith(".")}`
-//     : "";
-//   const date = ref.date ? `${ref.date}. ` : "";
-//   const status = ref.status
-//     ? (REF_STATUSES.get(ref.status) || ref.status) + ". "
-//     : "";
-
-//   return html`
-//   	${
-//       ref.href
-//         ? html`<a href="${ref.href}"><cite>${title}</cite></a>.`
-//         : `${ref.title}`
-//     } ${authors} ${publisher} ${date} ${status} ${
-//     ref.href ? html`<a href="${ref.href}">${ref.href}</a>` : ""
-//   }`;
-// }
-
-
-
+const html = (...args) => hyperHTML.bind(doc.createDocumentFragment())(...args);
 
 // Author, A. (Year, Month Date of Publication). Article title. Retrieved from URL
 function entryToAPA(ref) {
+  const { title } = ref.title;
   const authors =
     ref.authors && ref.authors.length
       ? `${ref.authors.join("; ")} ${ref.etAl ? " et al" : ""}.`
       : "";
-  const date = ref.date ? `(${ref.date}).` : "";
-  const title = ref.href
-    ? `<a href="${ref.href}"><cite>${ref.title}</cite></a>. `
-    : `${ref.title}`;
-  const url = ref.href
-    ? `Retrieved from URL: <a href="${ref.href}">${ref.href}</a>`
-    : "";
-
-  return `${authors} ${date} ${title} ${url}`;
+  const date = ref.date ? `(${ref.date})` : "";
+  return html`
+    ${authors} ${date} ${
+    ref.href
+      ? html`<a href="${ref.href}"><cite>${title}</cite></a>.`
+      : `${ref.title}`
+  }
+    ${
+      ref.href
+        ? html`Retrieved from URL: ${html`<a href="${ref.href}">${
+            ref.href
+          }</a>`}`
+        : ""
+    }
+  `;
 }
 
 //Author’s Last name, First name. “Title of the Article or Individual Page.” Title of the website, Name of the publisher, Date of publication, URL.
@@ -193,22 +126,24 @@ function entryToMLA(ref) {
       ? `${ref.authors.join("; ")} ${ref.etAl ? " et al" : ""}.`
       : "";
   const date = ref.date ? `${ref.date}, ` : "";
-  const title = ref.href
-    ? `<a href="${ref.href}"> "<cite>${ref.title}</cite>" </a>. `
-    : `${ref.title}`;
-  const url = ref.href ? `<a href="${ref.href}">${ref.href}</a>` : "";
+  const title = ref.title;
   const publisher = ref.publisher
     ? `${ref.publisher} ${ref.publisher.endsWith(".")}`
     : "";
 
-  return `${authors} ${title} ${publisher} ${date} ${url}`;
+  return html`
+	${authors} ${
+    ref.href
+      ? html`<a href="${ref.href}"><cite>${title}</cite></a>.`
+      : `${ref.title}`
+  } ${publisher} ${date} ${
+    ref.href ? html`<a href="${ref.href}">${ref.href}</a>` : ""
+  }`;
 }
 
-// what ReSpec currently does...
+//what ReSpec currently does...
 function entryToW3C(ref) {
-  const title = ref.href
-    ? `<a href="${ref.href}"> <cite>${ref.title}</cite> </a>. `
-    : `${ref.title}`;
+  const title = ref.title;
   const authors =
     ref.authors && ref.authors.length
       ? `${ref.authors.join("; ")} ${ref.etAl ? " et al" : "."}.`
@@ -220,9 +155,15 @@ function entryToW3C(ref) {
   const status = ref.status
     ? (REF_STATUSES.get(ref.status) || ref.status) + ". "
     : "";
-  const url = ref.href ? `URL: <a href="${ref.href}">${ref.href}</a>` : "";
 
-  return `${title} ${authors} ${publisher} ${date} ${status} ${url}`;
+  return html`
+  	${
+      ref.href
+        ? html`<a href="${ref.href}"><cite>${title}</cite></a>.`
+        : `${ref.title}`
+    } ${authors} ${publisher} ${date} ${status} ${
+    ref.href ? html`<a href="${ref.href}">${ref.href}</a>` : ""
+  }`;
 }
 
 export function stringifyReference(ref, style) {

--- a/src/core/biblio.js
+++ b/src/core/biblio.js
@@ -190,6 +190,9 @@ function bibref(conf) {
   var informs = refKeys.informativeReferences;
   var norms = refKeys.normativeReferences;
   var aliases = {};
+  
+  // the bibliographical style to use
+  const { biblioStyle: refstyle } = conf;
 
   if (!informs.length && !norms.length && !conf.refNote) return;
   var $refsec = $(
@@ -223,7 +226,6 @@ function bibref(conf) {
         .appendTo($dl);
       var $dd = $("<dd></dd>").appendTo($dl);
       var refcontent = conf.biblio[ref];
-      const { biblioStyle: refstyle }  = conf;
       var circular = {};
       var key = ref;
       circular[ref] = true;

--- a/src/core/biblio.js
+++ b/src/core/biblio.js
@@ -126,7 +126,7 @@ function entryToMLA(ref) {
       ? `${ref.authors.join("; ")} ${ref.etAl ? " et al" : ""}.`
       : "";
   const date = ref.date ? `${ref.date}, ` : "";
-  const title = ref.title;
+  const title = `"${ref.title}." `;
   const publisher = ref.publisher
     ? `${ref.publisher} ${ref.publisher.endsWith(".")}`
     : "";
@@ -135,7 +135,7 @@ function entryToMLA(ref) {
 	${authors} ${
     ref.href
       ? html`<a href="${ref.href}"><cite>${title}</cite></a>.`
-      : `${ref.title}`
+      : `${title}`
   } ${publisher} ${date} ${
     ref.href ? html`<a href="${ref.href}">${ref.href}</a>` : ""
   }`;
@@ -223,7 +223,7 @@ function bibref(conf) {
         .appendTo($dl);
       var $dd = $("<dd></dd>").appendTo($dl);
       var refcontent = conf.biblio[ref];
-      var refstyle = conf.biblioStyle;
+      const { biblioStyle: refstyle }  = conf;
       var circular = {};
       var key = ref;
       circular[ref] = true;

--- a/src/core/biblio.js
+++ b/src/core/biblio.js
@@ -97,7 +97,7 @@ const html = (...args) => hyperHTML.bind(doc.createDocumentFragment())(...args);
 
 // Author, A. (Year, Month Date of Publication). Article title. Retrieved from URL
 function entryToAPA(ref) {
-  const { title } = ref.title;
+  const { title } = ref;
   const authors =
     ref.authors && ref.authors.length
       ? `${ref.authors.join("; ")} ${ref.etAl ? " et al" : ""}.`
@@ -107,7 +107,7 @@ function entryToAPA(ref) {
     ${authors} ${date} ${
     ref.href
       ? html`<a href="${ref.href}"><cite>${title}</cite></a>.`
-      : `${ref.title}`
+      : html`<cite>${title}</cite>`
   }
     ${
       ref.href
@@ -135,7 +135,7 @@ function entryToMLA(ref) {
 	${authors} ${
     ref.href
       ? html`<a href="${ref.href}"><cite>${title}</cite></a>.`
-      : `${title}`
+      : html`><cite>${title}</cite>`
   } ${publisher} ${date} ${
     ref.href ? html`<a href="${ref.href}">${ref.href}</a>` : ""
   }`;
@@ -143,7 +143,7 @@ function entryToMLA(ref) {
 
 //what ReSpec currently does...
 function entryToW3C(ref) {
-  const title = ref.title;
+  const { title } = ref;
   const authors =
     ref.authors && ref.authors.length
       ? `${ref.authors.join("; ")} ${ref.etAl ? " et al" : "."}.`
@@ -160,7 +160,7 @@ function entryToW3C(ref) {
   	${
       ref.href
         ? html`<a href="${ref.href}"><cite>${title}</cite></a>.`
-        : `${ref.title}`
+        : html`<cite>${title}</cite>`
     } ${authors} ${publisher} ${date} ${status} ${
     ref.href ? html`<a href="${ref.href}">${ref.href}</a>` : ""
   }`;
@@ -235,7 +235,7 @@ function bibref(conf) {
         } else {
           key = refcontent.aliasOf;
           refcontent = conf.biblio[key];
-          refstyle = conf.biblioStyle;
+          { biblioStyle: refstyle }  = conf;
           circular[key] = true;
         }
       }

--- a/tests/spec/core/biblio-spec.js
+++ b/tests/spec/core/biblio-spec.js
@@ -36,6 +36,11 @@ describe("W3C — Bibliographic References", () => {
         href: "http://test.com",
         publisher: "Publisher Here",
       },
+      TestRef4: {
+        title: "Fourth test",
+        href: "http://test.com",
+        authors: ["And another author"],
+      },
       FOOBARGLOP: {
         aliasOf: "BARBAR",
       },
@@ -46,7 +51,7 @@ describe("W3C — Bibliographic References", () => {
   };
   const body = `
     <section id='sotd'>
-      <p>foo [[!TestRef1]] [[TestRef2]] [[!TestRef3]]</p>
+      <p>foo [[!TestRef1]] [[TestRef2]] [[!TestRef3]] [[TestRef4]]</p>
     </section>
     <section id='sample'>
       <h2>Privacy</h2>
@@ -101,6 +106,18 @@ describe("W3C — Bibliographic References", () => {
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/Publisher Here\.\s/);
   });
+
+  it("displays the reference for APA citation", async() => {
+    // Make sure the reference is added.
+    let ref = doc.querySelector("#bib-TestRef4 + dd");
+    expect(ref).toBeTruthy();
+    // This prevents Jasmine from taking down the whole test suite if SpecRef is down.
+    if (!specRefOk) {
+      throw new Error(
+        "SpecRef seems to be down. Can't proceed with this spec."
+      );
+    }
+  }
 
   it("resolves a localy-aliased spec", () => {
     const ref = doc.querySelector("#bib-FOOBARGLOP + dd");

--- a/tests/spec/core/biblio-spec.js
+++ b/tests/spec/core/biblio-spec.js
@@ -1,7 +1,7 @@
 "use strict";
 describe("W3C — Bibliographic References", () => {
   //Configuration for default of ReSpec
-  const conf1 = {
+  const confDefault = {
     editors: [
       {
         name: "Robin Berjon"
@@ -47,18 +47,8 @@ describe("W3C — Bibliographic References", () => {
   };
 
   //Configuration for APA citation
-  const conf2 = {
-    editors: [
-      {
-        name: "Robin Berjon"
-      }
-    ],
-    edDraftURI: "https://foo",
-    shortName: "Foo",
-    specStatus: "WD",
-    prevVersion: "FPWD",
-    previousMaturity: "WD",
-    previousPublishDate: "2013-12-17",
+  const confAPA = {
+    ...confDefault,
     biblioStyle: "APA",
     localBiblio: {
       Zzz: {
@@ -67,25 +57,25 @@ describe("W3C — Bibliographic References", () => {
       aaa: {
         title: "First Reference"
       },
-      TestRef4: {
+      TestRef1: {
         title: "Test ref title",
         href: "http://test.com",
         authors: ["William Shakespeare"]
       },
-      TestRef5: {
+      TestRef2: {
         title: "Second test",
         href: "http://test.com"
       },
-      TestRef6: {
+      TestRef3: {
         title: "Third test"
       },
-      TestRef7: {
+      TestRef4: {
         authors: ["William Shakespeare"]
       },
-      TestRef8: {
+      TestRef5: {
         href: "http://test.com"
       },
-      TestRef9: {
+      TestRef6: {
         href: "http://test.com",
         authors: ["William Shakespeare"]
       },
@@ -99,18 +89,8 @@ describe("W3C — Bibliographic References", () => {
   };
 
   //Configuration for MLA citation
-  const conf3 = {
-    editors: [
-      {
-        name: "Robin Berjon"
-      }
-    ],
-    edDraftURI: "https://foo",
-    shortName: "Foo",
-    specStatus: "WD",
-    prevVersion: "FPWD",
-    previousMaturity: "WD",
-    previousPublishDate: "2013-12-17",
+  const confMLA = {
+    ...confDefault,
     biblioStyle: "MLA",
     localBiblio: {
       Zzz: {
@@ -119,30 +99,30 @@ describe("W3C — Bibliographic References", () => {
       aaa: {
         title: "First Reference"
       },
-      TestRef10: {
+      TestRef1: {
         title: "Test ref title",
         href: "http://test.com",
         authors: ["William Shakespeare"],
         publisher: "Publishers Inc."
       },
-      TestRef11: {
+      TestRef2: {
         title: "Second test",
         href: "http://test.com"
       },
-      TestRef12: {
+      TestRef3: {
         title: "Third test",
         publisher: "Publisher Here"
       },
-      TestRef13: {
+      TestRef4: {
         title: "Test ref title",
         href: "http://test.com",
         authors: ["William Shakespeare"]
       },
-      TestRef14: {
+      TestRef5: {
         title: "Test ref title",
         authors: ["William Shakespeare"]
       },
-      TestRef15: {
+      TestRef6: {
         authors: ["William Shakespeare"],
         publisher: "Publishers Inc."
       },
@@ -155,37 +135,9 @@ describe("W3C — Bibliographic References", () => {
     }
   };
 
-  const body1 = `
+  const body = `
     <section id='sotd'>
-      <p>foo [[!TestRef1]] [[TestRef2]] [[!TestRef3]]</p>
-    </section>
-    <section id='sample'>
-      <h2>Privacy</h2>
-      <p>foo [[!FOOBARGLOP]] bar</p>
-    </section>
-    <section>
-      <h2>Sorted</h2>
-      <p>From [[!Zzz]] to [[!aaa]]</p>
-    </secton>
-  `;
-
-  const body2 = `
-    <section id='sotd'>
-      <p>foo [[!TestRef4]] [[TestRef5]] [[!TestRef6]] [[TestRef7]] [[!TestRef8]] [[TestRef9]]</p>
-    </section>
-    <section id='sample'>
-      <h2>Privacy</h2>
-      <p>foo [[!FOOBARGLOP]] bar</p>
-    </section>
-    <section>
-      <h2>Sorted</h2>
-      <p>From [[!Zzz]] to [[!aaa]]</p>
-    </secton>
-  `;
-
-  const body3 = `
-    <section id='sotd'>
-      <p>foo [[!TestRef10]] [[TestRef11]] [[!TestRef12]] [[TestRef13]] [[!TestRef14]] [[TestRef15]]</p>
+      <p>foo [[!TestRef1]] [[TestRef2]] [[!TestRef3]] [[!TestRef4]] [[TestRef5]] [[!TestRef6]]</p>
     </section>
     <section id='sample'>
       <h2>Privacy</h2>
@@ -200,12 +152,12 @@ describe("W3C — Bibliographic References", () => {
   afterAll(flushIframes);
   const bibRefsURL = new URL("https://specref.herokuapp.com/bibrefs");
 
-  let doc1, doc2, doc3;
+  let docDefault, docAPA, docMLA;
   let specRefOk;
   beforeAll(async () => {
-    doc1 = await makeRSDoc({ conf1, body1 });
-    doc2 = await makeRSDoc({ conf2, body2 });
-    doc3 = await makeRSDoc({ conf3, body3 });
+    docDefault = await makeRSDoc({ confDefault, body });
+    docAPA = await makeRSDoc({ confAPA, body });
+    docMLA = await makeRSDoc({ confMLA, body });
     specRefOk = (await fetch(bibRefsURL, { method: "HEAD" })).ok;
   });
 
@@ -215,14 +167,14 @@ describe("W3C — Bibliographic References", () => {
 
   it("includes a dns-prefetch to bibref server", () => {
     const host = bibRefsURL.host;
-    const link = doc1.querySelector(`link[rel='dns-prefetch'][href*='${host}']`);
+    const link = docDefault.querySelector(`link[rel='dns-prefetch'][href*='${host}']`);
     expect(link).toBeTruthy();
     expect(link.classList.contains("removeOnSave")).toBeTruthy();
   });
 
   it("displays the publisher when present", () => {
     // Make sure the reference is added.
-    let ref = doc1.querySelector("#bib-TestRef1 + dd");
+    let ref = docDefault.querySelector("#bib-TestRef1 + dd");
     expect(ref).toBeTruthy();
     // This prevents Jasmine from taking down the whole test suite if SpecRef is down.
     if (!specRefOk) {
@@ -233,47 +185,47 @@ describe("W3C — Bibliographic References", () => {
     expect(ref.textContent).toMatch(/Publishers Inc\.\s/);
     ref = null;
     // Make sure the ". " is automatically added to publisher.
-    ref = doc1.querySelector("#bib-TestRef2 + dd");
+    ref = docDefault.querySelector("#bib-TestRef2 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/Testing 123\.\s/);
     ref = null;
     // Make sure publisher is shown even when there is no author
-    ref = doc1.querySelector("#bib-TestRef3 + dd");
+    ref = docDefault.querySelector("#bib-TestRef3 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/Publisher Here\.\s/);
   });
 
   it("displays the reference for APA citation", () => {
     // Make sure the reference is added.
-    let ref = doc2.querySelector("#bib-TestRef4 + dd");
+    let ref = docAPA.querySelector("#bib-TestRef1 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/William Shakespeare\.\s/);
     expect(ref.textContent).toMatch(/Test ref title\.\s/);
     expect(ref.textContent).toMatch("Retrieved from URL: http://test.com/");
     ref = null;
     //title,url
-    ref = doc2.querySelector("#bib-TestRef5 + dd");
+    ref = docAPA.querySelector("#bib-TestRef2 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/Second test\.\s/);
     expect(ref.textContent).toMatch("Retrieved from URL: http://test.com/");
     ref = null;
     //title
-    ref = doc2.querySelector("#bib-TestRef6 + dd");
+    ref = docAPA.querySelector("#bib-TestRef3 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/Third test\.\s/);
     ref = null;
     //author
-    ref = doc2.querySelector("#bib-TestRef7 + dd");
+    ref = docAPA.querySelector("#bib-TestRef4 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/William Shakespeare\.\s/);
     ref = null;
     //url
-    ref = doc2.querySelector("#bib-TestRef8 + dd");
+    ref = docAPA.querySelector("#bib-TestRef5 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch("Retrieved from URL: http://test.com/");
     ref = null;
     //author,url
-    ref = doc2.querySelector("#bib-TestRef9 + dd");
+    ref = docAPA.querySelector("#bib-TestRef6 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/William Shakespeare\.\s/);
     expect(ref.textContent).toMatch("Retrieved from URL: http://test.com/");
@@ -281,7 +233,7 @@ describe("W3C — Bibliographic References", () => {
 
   it("displays the reference for MLA citation", () => {
     // Make sure the reference is added.
-    let ref = doc3.querySelector("#bib-TestRef10 + dd");
+    let ref = docMLA.querySelector("#bib-TestRef1 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/William Shakespeare\.\s/);
     expect(ref.textContent).toMatch(/"Test ref title\."\s/);
@@ -289,32 +241,32 @@ describe("W3C — Bibliographic References", () => {
     expect(ref.textContent).toMatch("http://test.com");
     ref = null;
     // title,url
-    ref = doc3.querySelector("#bib-TestRef11 + dd");
+    ref = docMLA.querySelector("#bib-TestRef2 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/"Second test"/);
     expect(ref.textContent).toMatch("http://test.com");
     ref = null;
     // publisher,title
-    ref = doc3.querySelector("#bib-TestRef12 + dd");
+    ref = docMLA.querySelector("#bib-TestRef3 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/Publisher Here,/);
     expect(ref.textContent).toMatch(/"Third test\."\s/);
     ref = null;
     // title,url,author
-    ref = doc3.querySelector("#bib-TestRef13 + dd");
+    ref = docMLA.querySelector("#bib-TestRef4 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/"Test ref title\."\s/);
     expect(ref.textContent).toMatch("http://test.com");
     expect(ref.textContent).toMatch(/William Shakespeare\.\s/);
     ref = null;
     // title,author
-    ref = doc3.querySelector("#bib-TestRef14 + dd");
+    ref = docMLA.querySelector("#bib-TestRef5 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/"Test ref title\."\s/);
     expect(ref.textContent).toMatch(/William Shakespeare\.\s/);
     ref = null;
     // publisher,author
-    ref = doc3.querySelector("#bib-TestRef15 + dd");
+    ref = docMLA.querySelector("#bib-TestRef6 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/Publishers Inc\.\s/);
     expect(ref.textContent).toMatch(/William Shakespeare\.\s/);
@@ -322,15 +274,15 @@ describe("W3C — Bibliographic References", () => {
   });
 
   it("resolves a localy-aliased spec", () => {
-    const ref = doc1.querySelector("#bib-FOOBARGLOP + dd");
+    const ref = docDefault.querySelector("#bib-FOOBARGLOP + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/BARBAR/);
   });
   it("sorts references as if they were lowercase", () => {
-    const { textContent: first } = doc1.querySelector(
+    const { textContent: first } = docDefault.querySelector(
       "#normative-references dt:first-of-type"
     );
-    const { textContent: last } = doc1.querySelector(
+    const { textContent: last } = docDefault.querySelector(
       "#normative-references dt:last-of-type"
     );
     expect(first).toMatch("[a]");

--- a/tests/spec/core/biblio-spec.js
+++ b/tests/spec/core/biblio-spec.js
@@ -37,6 +37,13 @@ describe("W3C — Bibliographic References", () => {
         href: "http://test.com",
         publisher: "Publisher Here"
       },
+      TestRef5: {
+        href: "http://test.com"
+      },
+      TestRef6: {
+        href: "http://test.com",
+        authors: ["William Shakespeare"]
+      },
       FOOBARGLOP: {
         aliasOf: "BARBAR"
       },
@@ -50,89 +57,12 @@ describe("W3C — Bibliographic References", () => {
   const confAPA = {
     ...confDefault,
     biblioStyle: "APA",
-    localBiblio: {
-      Zzz: {
-        title: "Last Reference"
-      },
-      aaa: {
-        title: "First Reference"
-      },
-      TestRef1: {
-        title: "Test ref title",
-        href: "http://test.com",
-        authors: ["William Shakespeare"]
-      },
-      TestRef2: {
-        title: "Second test",
-        href: "http://test.com"
-      },
-      TestRef3: {
-        title: "Third test"
-      },
-      TestRef4: {
-        authors: ["William Shakespeare"]
-      },
-      TestRef5: {
-        href: "http://test.com"
-      },
-      TestRef6: {
-        href: "http://test.com",
-        authors: ["William Shakespeare"]
-      },
-      FOOBARGLOP: {
-        aliasOf: "BARBAR"
-      },
-      BARBAR: {
-        title: "The BARBAR Spec"
-      }
-    }
   };
 
   //Configuration for MLA citation
   const confMLA = {
     ...confDefault,
     biblioStyle: "MLA",
-    localBiblio: {
-      Zzz: {
-        title: "Last Reference"
-      },
-      aaa: {
-        title: "First Reference"
-      },
-      TestRef1: {
-        title: "Test ref title",
-        href: "http://test.com",
-        authors: ["William Shakespeare"],
-        publisher: "Publishers Inc."
-      },
-      TestRef2: {
-        title: "Second test",
-        href: "http://test.com"
-      },
-      TestRef3: {
-        title: "Third test",
-        publisher: "Publisher Here"
-      },
-      TestRef4: {
-        title: "Test ref title",
-        href: "http://test.com",
-        authors: ["William Shakespeare"]
-      },
-      TestRef5: {
-        title: "Test ref title",
-        authors: ["William Shakespeare"]
-      },
-      TestRef6: {
-        authors: ["William Shakespeare"],
-        publisher: "Publishers Inc."
-      },
-      FOOBARGLOP: {
-        aliasOf: "BARBAR"
-      },
-      BARBAR: {
-        title: "The BARBAR Spec"
-      }
-    }
   };
 
   const body = `

--- a/tests/spec/core/biblio-spec.js
+++ b/tests/spec/core/biblio-spec.js
@@ -67,25 +67,25 @@ describe("W3C — Bibliographic References", () => {
       aaa: {
         title: "First Reference"
       },
-      TestRef1: {
+      TestRef4: {
         title: "Test ref title",
         href: "http://test.com",
         authors: ["William Shakespeare"]
       },
-      TestRef2: {
+      TestRef5: {
         title: "Second test",
         href: "http://test.com"
       },
-      TestRef3: {
+      TestRef6: {
         title: "Third test"
       },
-      TestRef4: {
+      TestRef7: {
         authors: ["William Shakespeare"]
       },
-      TestRef5: {
+      TestRef8: {
         href: "http://test.com"
       },
-      TestRef6: {
+      TestRef9: {
         href: "http://test.com",
         authors: ["William Shakespeare"]
       },
@@ -119,30 +119,30 @@ describe("W3C — Bibliographic References", () => {
       aaa: {
         title: "First Reference"
       },
-      TestRef1: {
+      TestRef10: {
         title: "Test ref title",
         href: "http://test.com",
         authors: ["William Shakespeare"],
         publisher: "Publishers Inc."
       },
-      TestRef2: {
+      TestRef11: {
         title: "Second test",
         href: "http://test.com"
       },
-      TestRef3: {
+      TestRef12: {
         title: "Third test",
         publisher: "Publisher Here"
       },
-      TestRef4: {
+      TestRef13: {
         title: "Test ref title",
         href: "http://test.com",
         authors: ["William Shakespeare"]
       },
-      TestRef5: {
+      TestRef14: {
         title: "Test ref title",
         authors: ["William Shakespeare"]
       },
-      TestRef6: {
+      TestRef15: {
         authors: ["William Shakespeare"],
         publisher: "Publishers Inc."
       },
@@ -171,7 +171,7 @@ describe("W3C — Bibliographic References", () => {
 
   const body2 = `
     <section id='sotd'>
-      <p>foo [[!TestRef1]] [[TestRef2]] [[!TestRef3]] [[TestRef4]] [[!TestRef5]] [[TestRef6]]</p>
+      <p>foo [[!TestRef4]] [[TestRef5]] [[!TestRef6]] [[TestRef7]] [[!TestRef8]] [[TestRef9]]</p>
     </section>
     <section id='sample'>
       <h2>Privacy</h2>
@@ -185,7 +185,7 @@ describe("W3C — Bibliographic References", () => {
 
   const body3 = `
     <section id='sotd'>
-      <p>foo [[!TestRef1]] [[TestRef2]] [[!TestRef3]] [[TestRef4]] [[!TestRef5]] [[TestRef6]]</p>
+      <p>foo [[!TestRef10]] [[TestRef11]] [[!TestRef12]] [[TestRef13]] [[!TestRef14]] [[TestRef15]]</p>
     </section>
     <section id='sample'>
       <h2>Privacy</h2>
@@ -200,7 +200,7 @@ describe("W3C — Bibliographic References", () => {
   afterAll(flushIframes);
   const bibRefsURL = new URL("https://specref.herokuapp.com/bibrefs");
 
-  let doc1, doc2, doc3;
+  const doc1, doc2, doc3;
   let specRefOk;
   beforeAll(async () => {
     doc1 = await makeRSDoc({ conf1, body1 });
@@ -243,45 +243,45 @@ describe("W3C — Bibliographic References", () => {
     expect(ref.textContent).toMatch(/Publisher Here\.\s/);
   });
 
-  it("displays the reference for APA citation", async () => {
+  it("displays the reference for APA citation", () => {
     // Make sure the reference is added.
-    let ref = doc2.querySelector("#bib-TestRef1 + dd");
+    let ref = doc2.querySelector("#bib-TestRef4 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/William Shakespeare\.\s/);
     expect(ref.textContent).toMatch(/Test ref title\.\s/);
     expect(ref.textContent).toMatch("Retrieved from URL: http://test.com/");
     ref = null;
     //title,url
-    ref = doc2.querySelector("#bib-TestRef2 + dd");
+    ref = doc2.querySelector("#bib-TestRef5 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/Second test\.\s/);
     expect(ref.textContent).toMatch("Retrieved from URL: http://test.com/");
     ref = null;
     //title
-    ref = doc2.querySelector("#bib-TestRef3 + dd");
+    ref = doc2.querySelector("#bib-TestRef6 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/Third test\.\s/);
     ref = null;
     //author
-    ref = doc2.querySelector("#bib-TestRef4 + dd");
+    ref = doc2.querySelector("#bib-TestRef7 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/William Shakespeare\.\s/);
     ref = null;
     //url
-    ref = doc2.querySelector("#bib-TestRef5 + dd");
+    ref = doc2.querySelector("#bib-TestRef8 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch("Retrieved from URL: http://test.com/");
     ref = null;
     //author,url
-    ref = doc2.querySelector("#bib-TestRef6 + dd");
+    ref = doc2.querySelector("#bib-TestRef9 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/William Shakespeare\.\s/);
     expect(ref.textContent).toMatch("Retrieved from URL: http://test.com/");
   });
 
-  it("displays the reference for MLA citation", async () => {
+  it("displays the reference for MLA citation", () => {
     // Make sure the reference is added.
-    let ref = doc3.querySelector("#bib-TestRef1 + dd");
+    let ref = doc3.querySelector("#bib-TestRef10 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/William Shakespeare\.\s/);
     expect(ref.textContent).toMatch(/"Test ref title\."\s/);
@@ -289,32 +289,32 @@ describe("W3C — Bibliographic References", () => {
     expect(ref.textContent).toMatch("http://test.com");
     ref = null;
     // title,url
-    ref = doc3.querySelector("#bib-TestRef2 + dd");
+    ref = doc3.querySelector("#bib-TestRef11 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/"Second test"/);
     expect(ref.textContent).toMatch("http://test.com");
     ref = null;
     // publisher,title
-    ref = doc3.querySelector("#bib-TestRef3 + dd");
+    ref = doc3.querySelector("#bib-TestRef12 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/Publisher Here,/);
     expect(ref.textContent).toMatch(/"Third test\."\s/);
     ref = null;
     // title,url,author
-    ref = doc3.querySelector("#bib-TestRef4 + dd");
+    ref = doc3.querySelector("#bib-TestRef13 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/"Test ref title\."\s/);
     expect(ref.textContent).toMatch("http://test.com");
     expect(ref.textContent).toMatch(/William Shakespeare\.\s/);
     ref = null;
     // title,author
-    ref = doc3.querySelector("#bib-TestRef5 + dd");
+    ref = doc3.querySelector("#bib-TestRef14 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/"Test ref title\."\s/);
     expect(ref.textContent).toMatch(/William Shakespeare\.\s/);
     ref = null;
     // publisher,author
-    ref = doc3.querySelector("#bib-TestRef6 + dd");
+    ref = doc3.querySelector("#bib-TestRef15 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/Publishers Inc\.\s/);
     expect(ref.textContent).toMatch(/William Shakespeare\.\s/);

--- a/tests/spec/core/biblio-spec.js
+++ b/tests/spec/core/biblio-spec.js
@@ -1,12 +1,11 @@
 "use strict";
 describe("W3C — Bibliographic References", () => {
-
   //Configuration for default of ReSpec
   const conf1 = {
     editors: [
       {
-        name: "Robin Berjon",
-      },
+        name: "Robin Berjon"
+      }
     ],
     edDraftURI: "https://foo",
     shortName: "Foo",
@@ -16,43 +15,43 @@ describe("W3C — Bibliographic References", () => {
     previousPublishDate: "2013-12-17",
     localBiblio: {
       Zzz: {
-        title: "Last Reference",
+        title: "Last Reference"
       },
       aaa: {
-        title: "First Reference",
+        title: "First Reference"
       },
       TestRef1: {
         title: "Test ref title",
         href: "http://test.com",
         authors: ["William Shakespeare"],
-        publisher: "Publishers Inc.",
+        publisher: "Publishers Inc."
       },
       TestRef2: {
         title: "Second test",
         href: "http://test.com",
         authors: ["Another author"],
-        publisher: "Testing 123",
+        publisher: "Testing 123"
       },
       TestRef3: {
         title: "Third test",
         href: "http://test.com",
-        publisher: "Publisher Here",
+        publisher: "Publisher Here"
       },
       FOOBARGLOP: {
-        aliasOf: "BARBAR",
+        aliasOf: "BARBAR"
       },
       BARBAR: {
-        title: "The BARBAR Spec",
-      },
-    },
-  }
+        title: "The BARBAR Spec"
+      }
+    }
+  };
 
   //Configuration for APA citation
   const conf2 = {
     editors: [
       {
-        name: "Robin Berjon",
-      },
+        name: "Robin Berjon"
+      }
     ],
     edDraftURI: "https://foo",
     shortName: "Foo",
@@ -63,48 +62,48 @@ describe("W3C — Bibliographic References", () => {
     biblioStyle: "APA",
     localBiblio: {
       Zzz: {
-        title: "Last Reference",
+        title: "Last Reference"
       },
       aaa: {
-        title: "First Reference",
+        title: "First Reference"
       },
       TestRef1: {
         title: "Test ref title",
         href: "http://test.com",
-        authors: ["William Shakespeare"],
+        authors: ["William Shakespeare"]
       },
       TestRef2: {
         title: "Second test",
-        href: "http://test.com",
+        href: "http://test.com"
       },
       TestRef3: {
-        title: "Third test",
+        title: "Third test"
       },
       TestRef4: {
-        authors: ["William Shakespeare"],
+        authors: ["William Shakespeare"]
       },
       TestRef5: {
-        href: "http://test.com",
+        href: "http://test.com"
       },
       TestRef6: {
         href: "http://test.com",
-        authors: ["William Shakespeare"],
+        authors: ["William Shakespeare"]
       },
       FOOBARGLOP: {
-        aliasOf: "BARBAR",
+        aliasOf: "BARBAR"
       },
       BARBAR: {
-        title: "The BARBAR Spec",
-      },
-    },
-  }
+        title: "The BARBAR Spec"
+      }
+    }
+  };
 
   //Configuration for MLA citation
   const conf3 = {
     editors: [
       {
-        name: "Robin Berjon",
-      },
+        name: "Robin Berjon"
+      }
     ],
     edDraftURI: "https://foo",
     shortName: "Foo",
@@ -112,50 +111,49 @@ describe("W3C — Bibliographic References", () => {
     prevVersion: "FPWD",
     previousMaturity: "WD",
     previousPublishDate: "2013-12-17",
-   biblioStyle: "MLA",
-   localBiblio: {
+    biblioStyle: "MLA",
+    localBiblio: {
       Zzz: {
-        title: "Last Reference",
+        title: "Last Reference"
       },
       aaa: {
-        title: "First Reference",
+        title: "First Reference"
       },
       TestRef1: {
         title: "Test ref title",
         href: "http://test.com",
         authors: ["William Shakespeare"],
-        publisher: "Publishers Inc.",
+        publisher: "Publishers Inc."
       },
       TestRef2: {
         title: "Second test",
-        href: "http://test.com",
+        href: "http://test.com"
       },
       TestRef3: {
         title: "Third test",
-        publisher: "Publisher Here",
+        publisher: "Publisher Here"
       },
       TestRef4: {
         title: "Test ref title",
         href: "http://test.com",
-        authors: ["William Shakespeare"],
+        authors: ["William Shakespeare"]
       },
       TestRef5: {
         title: "Test ref title",
-        authors: ["William Shakespeare"],
+        authors: ["William Shakespeare"]
       },
       TestRef6: {
         authors: ["William Shakespeare"],
-        publisher: "Publishers Inc.",
+        publisher: "Publishers Inc."
       },
       FOOBARGLOP: {
-        aliasOf: "BARBAR",
+        aliasOf: "BARBAR"
       },
       BARBAR: {
-        title: "The BARBAR Spec",
-      },
-    },
-   }
- }
+        title: "The BARBAR Spec"
+      }
+    }
+  };
 
   const body1 = `
     <section id='sotd'>
@@ -217,7 +215,7 @@ describe("W3C — Bibliographic References", () => {
 
   it("includes a dns-prefetch to bibref server", () => {
     const host = bibRefsURL.host;
-    const link = doc.querySelector(`link[rel='dns-prefetch'][href*='${host}']`);
+    const link = doc1.querySelector(`link[rel='dns-prefetch'][href*='${host}']`);
     expect(link).toBeTruthy();
     expect(link.classList.contains("removeOnSave")).toBeTruthy();
   });
@@ -245,7 +243,7 @@ describe("W3C — Bibliographic References", () => {
     expect(ref.textContent).toMatch(/Publisher Here\.\s/);
   });
 
-  it("displays the reference for APA citation", async() => { //change this
+  it("displays the reference for APA citation", async () => {
     // Make sure the reference is added.
     let ref = doc2.querySelector("#bib-TestRef1 + dd");
     expect(ref).toBeTruthy();
@@ -279,15 +277,10 @@ describe("W3C — Bibliographic References", () => {
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/William Shakespeare\.\s/);
     expect(ref.textContent).toMatch("Retrieved from URL: http://test.com/");
-  }
+  });
 
-  it("displays the reference for MLA citation", async() => { //change this
+  it("displays the reference for MLA citation", async () => {
     // Make sure the reference is added.
-
-      TestRef6: {
-        authors: ["William Shakespeare"],
-        publisher: "Publishers Inc.",
-
     let ref = doc3.querySelector("#bib-TestRef1 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/William Shakespeare\.\s/);
@@ -295,38 +288,38 @@ describe("W3C — Bibliographic References", () => {
     expect(ref.textContent).toMatch(/Publishers Inc,/);
     expect(ref.textContent).toMatch("http://test.com");
     ref = null;
-    // Make sure the ". " is automatically added to publisher.
+    // title,url
     ref = doc3.querySelector("#bib-TestRef2 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/"Second test"/);
     expect(ref.textContent).toMatch("http://test.com");
     ref = null;
-    // Make sure publisher is shown even when there is no author
+    // publisher,title
     ref = doc3.querySelector("#bib-TestRef3 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/Publisher Here,/);
     expect(ref.textContent).toMatch(/"Third test\."\s/);
     ref = null;
-    // Make sure publisher is shown even when there is no author
+    // title,url,author
     ref = doc3.querySelector("#bib-TestRef4 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/"Test ref title\."\s/);
     expect(ref.textContent).toMatch("http://test.com");
     expect(ref.textContent).toMatch(/William Shakespeare\.\s/);
     ref = null;
-    // Make sure publisher is shown even when there is no author
+    // title,author
     ref = doc3.querySelector("#bib-TestRef5 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/"Test ref title\."\s/);
     expect(ref.textContent).toMatch(/William Shakespeare\.\s/);
     ref = null;
-    // Make sure publisher is shown even when there is no author
+    // publisher,author
     ref = doc3.querySelector("#bib-TestRef6 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/Publishers Inc\.\s/);
     expect(ref.textContent).toMatch(/William Shakespeare\.\s/);
     ref = null;
-  }
+  });
 
   it("resolves a localy-aliased spec", () => {
     const ref = doc1.querySelector("#bib-FOOBARGLOP + dd");

--- a/tests/spec/core/biblio-spec.js
+++ b/tests/spec/core/biblio-spec.js
@@ -1,6 +1,8 @@
 "use strict";
 describe("W3C — Bibliographic References", () => {
-  const config = {
+
+  //Configuration for default of ReSpec
+  const conf1 = {
     editors: [
       {
         name: "Robin Berjon",
@@ -36,10 +38,57 @@ describe("W3C — Bibliographic References", () => {
         href: "http://test.com",
         publisher: "Publisher Here",
       },
-      TestRef4: {
-        title: "Fourth test",
+      FOOBARGLOP: {
+        aliasOf: "BARBAR",
+      },
+      BARBAR: {
+        title: "The BARBAR Spec",
+      },
+    },
+  }
+
+  //Configuration for APA citation
+  const conf2 = {
+    editors: [
+      {
+        name: "Robin Berjon",
+      },
+    ],
+    edDraftURI: "https://foo",
+    shortName: "Foo",
+    specStatus: "WD",
+    prevVersion: "FPWD",
+    previousMaturity: "WD",
+    previousPublishDate: "2013-12-17",
+    biblioStyle: "APA",
+    localBiblio: {
+      Zzz: {
+        title: "Last Reference",
+      },
+      aaa: {
+        title: "First Reference",
+      },
+      TestRef1: {
+        title: "Test ref title",
         href: "http://test.com",
-        authors: ["And another author"],
+        authors: ["William Shakespeare"],
+      },
+      TestRef2: {
+        title: "Second test",
+        href: "http://test.com",
+      },
+      TestRef3: {
+        title: "Third test",
+      },
+      TestRef4: {
+        authors: ["William Shakespeare"],
+      },
+      TestRef5: {
+        href: "http://test.com",
+      },
+      TestRef6: {
+        href: "http://test.com",
+        authors: ["William Shakespeare"],
       },
       FOOBARGLOP: {
         aliasOf: "BARBAR",
@@ -48,10 +97,97 @@ describe("W3C — Bibliographic References", () => {
         title: "The BARBAR Spec",
       },
     },
-  };
-  const body = `
+  }
+
+  //Configuration for MLA citation
+  const conf3 = {
+    editors: [
+      {
+        name: "Robin Berjon",
+      },
+    ],
+    edDraftURI: "https://foo",
+    shortName: "Foo",
+    specStatus: "WD",
+    prevVersion: "FPWD",
+    previousMaturity: "WD",
+    previousPublishDate: "2013-12-17",
+   biblioStyle: "MLA",
+   localBiblio: {
+      Zzz: {
+        title: "Last Reference",
+      },
+      aaa: {
+        title: "First Reference",
+      },
+      TestRef1: {
+        title: "Test ref title",
+        href: "http://test.com",
+        authors: ["William Shakespeare"],
+        publisher: "Publishers Inc.",
+      },
+      TestRef2: {
+        title: "Second test",
+        href: "http://test.com",
+      },
+      TestRef3: {
+        title: "Third test",
+        publisher: "Publisher Here",
+      },
+      TestRef4: {
+        title: "Test ref title",
+        href: "http://test.com",
+        authors: ["William Shakespeare"],
+      },
+      TestRef5: {
+        title: "Test ref title",
+        authors: ["William Shakespeare"],
+      },
+      TestRef6: {
+        authors: ["William Shakespeare"],
+        publisher: "Publishers Inc.",
+      },
+      FOOBARGLOP: {
+        aliasOf: "BARBAR",
+      },
+      BARBAR: {
+        title: "The BARBAR Spec",
+      },
+    },
+   }
+ }
+
+  const body1 = `
     <section id='sotd'>
-      <p>foo [[!TestRef1]] [[TestRef2]] [[!TestRef3]] [[TestRef4]]</p>
+      <p>foo [[!TestRef1]] [[TestRef2]] [[!TestRef3]]</p>
+    </section>
+    <section id='sample'>
+      <h2>Privacy</h2>
+      <p>foo [[!FOOBARGLOP]] bar</p>
+    </section>
+    <section>
+      <h2>Sorted</h2>
+      <p>From [[!Zzz]] to [[!aaa]]</p>
+    </secton>
+  `;
+
+  const body2 = `
+    <section id='sotd'>
+      <p>foo [[!TestRef1]] [[TestRef2]] [[!TestRef3]] [[TestRef4]] [[!TestRef5]] [[TestRef6]]</p>
+    </section>
+    <section id='sample'>
+      <h2>Privacy</h2>
+      <p>foo [[!FOOBARGLOP]] bar</p>
+    </section>
+    <section>
+      <h2>Sorted</h2>
+      <p>From [[!Zzz]] to [[!aaa]]</p>
+    </secton>
+  `;
+
+  const body3 = `
+    <section id='sotd'>
+      <p>foo [[!TestRef1]] [[TestRef2]] [[!TestRef3]] [[TestRef4]] [[!TestRef5]] [[TestRef6]]</p>
     </section>
     <section id='sample'>
       <h2>Privacy</h2>
@@ -66,10 +202,12 @@ describe("W3C — Bibliographic References", () => {
   afterAll(flushIframes);
   const bibRefsURL = new URL("https://specref.herokuapp.com/bibrefs");
 
-  let doc;
+  let doc1, doc2, doc3;
   let specRefOk;
   beforeAll(async () => {
-    doc = await makeRSDoc({ config, body });
+    doc1 = await makeRSDoc({ conf1, body1 });
+    doc2 = await makeRSDoc({ conf2, body2 });
+    doc3 = await makeRSDoc({ conf3, body3 });
     specRefOk = (await fetch(bibRefsURL, { method: "HEAD" })).ok;
   });
 
@@ -86,7 +224,7 @@ describe("W3C — Bibliographic References", () => {
 
   it("displays the publisher when present", () => {
     // Make sure the reference is added.
-    let ref = doc.querySelector("#bib-TestRef1 + dd");
+    let ref = doc1.querySelector("#bib-TestRef1 + dd");
     expect(ref).toBeTruthy();
     // This prevents Jasmine from taking down the whole test suite if SpecRef is down.
     if (!specRefOk) {
@@ -97,38 +235,109 @@ describe("W3C — Bibliographic References", () => {
     expect(ref.textContent).toMatch(/Publishers Inc\.\s/);
     ref = null;
     // Make sure the ". " is automatically added to publisher.
-    ref = doc.querySelector("#bib-TestRef2 + dd");
+    ref = doc1.querySelector("#bib-TestRef2 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/Testing 123\.\s/);
     ref = null;
     // Make sure publisher is shown even when there is no author
-    ref = doc.querySelector("#bib-TestRef3 + dd");
+    ref = doc1.querySelector("#bib-TestRef3 + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/Publisher Here\.\s/);
   });
 
-  it("displays the reference for APA citation", async() => {
+  it("displays the reference for APA citation", async() => { //change this
     // Make sure the reference is added.
-    let ref = doc.querySelector("#bib-TestRef4 + dd");
+    let ref = doc2.querySelector("#bib-TestRef1 + dd");
     expect(ref).toBeTruthy();
-    // This prevents Jasmine from taking down the whole test suite if SpecRef is down.
-    if (!specRefOk) {
-      throw new Error(
-        "SpecRef seems to be down. Can't proceed with this spec."
-      );
-    }
+    expect(ref.textContent).toMatch(/William Shakespeare\.\s/);
+    expect(ref.textContent).toMatch(/Test ref title\.\s/);
+    expect(ref.textContent).toMatch("Retrieved from URL: http://test.com/");
+    ref = null;
+    //title,url
+    ref = doc2.querySelector("#bib-TestRef2 + dd");
+    expect(ref).toBeTruthy();
+    expect(ref.textContent).toMatch(/Second test\.\s/);
+    expect(ref.textContent).toMatch("Retrieved from URL: http://test.com/");
+    ref = null;
+    //title
+    ref = doc2.querySelector("#bib-TestRef3 + dd");
+    expect(ref).toBeTruthy();
+    expect(ref.textContent).toMatch(/Third test\.\s/);
+    ref = null;
+    //author
+    ref = doc2.querySelector("#bib-TestRef4 + dd");
+    expect(ref).toBeTruthy();
+    expect(ref.textContent).toMatch(/William Shakespeare\.\s/);
+    ref = null;
+    //url
+    ref = doc2.querySelector("#bib-TestRef5 + dd");
+    expect(ref).toBeTruthy();
+    expect(ref.textContent).toMatch("Retrieved from URL: http://test.com/");
+    ref = null;
+    //author,url
+    ref = doc2.querySelector("#bib-TestRef6 + dd");
+    expect(ref).toBeTruthy();
+    expect(ref.textContent).toMatch(/William Shakespeare\.\s/);
+    expect(ref.textContent).toMatch("Retrieved from URL: http://test.com/");
+  }
+
+  it("displays the reference for MLA citation", async() => { //change this
+    // Make sure the reference is added.
+
+      TestRef6: {
+        authors: ["William Shakespeare"],
+        publisher: "Publishers Inc.",
+
+    let ref = doc3.querySelector("#bib-TestRef1 + dd");
+    expect(ref).toBeTruthy();
+    expect(ref.textContent).toMatch(/William Shakespeare\.\s/);
+    expect(ref.textContent).toMatch(/"Test ref title\."\s/);
+    expect(ref.textContent).toMatch(/Publishers Inc,/);
+    expect(ref.textContent).toMatch("http://test.com");
+    ref = null;
+    // Make sure the ". " is automatically added to publisher.
+    ref = doc3.querySelector("#bib-TestRef2 + dd");
+    expect(ref).toBeTruthy();
+    expect(ref.textContent).toMatch(/"Second test"/);
+    expect(ref.textContent).toMatch("http://test.com");
+    ref = null;
+    // Make sure publisher is shown even when there is no author
+    ref = doc3.querySelector("#bib-TestRef3 + dd");
+    expect(ref).toBeTruthy();
+    expect(ref.textContent).toMatch(/Publisher Here,/);
+    expect(ref.textContent).toMatch(/"Third test\."\s/);
+    ref = null;
+    // Make sure publisher is shown even when there is no author
+    ref = doc3.querySelector("#bib-TestRef4 + dd");
+    expect(ref).toBeTruthy();
+    expect(ref.textContent).toMatch(/"Test ref title\."\s/);
+    expect(ref.textContent).toMatch("http://test.com");
+    expect(ref.textContent).toMatch(/William Shakespeare\.\s/);
+    ref = null;
+    // Make sure publisher is shown even when there is no author
+    ref = doc3.querySelector("#bib-TestRef5 + dd");
+    expect(ref).toBeTruthy();
+    expect(ref.textContent).toMatch(/"Test ref title\."\s/);
+    expect(ref.textContent).toMatch(/William Shakespeare\.\s/);
+    ref = null;
+    // Make sure publisher is shown even when there is no author
+    ref = doc3.querySelector("#bib-TestRef6 + dd");
+    expect(ref).toBeTruthy();
+    expect(ref.textContent).toMatch(/Publishers Inc\.\s/);
+    expect(ref.textContent).toMatch(/William Shakespeare\.\s/);
+    ref = null;
   }
 
   it("resolves a localy-aliased spec", () => {
-    const ref = doc.querySelector("#bib-FOOBARGLOP + dd");
+    const ref = doc1.querySelector("#bib-FOOBARGLOP + dd");
     expect(ref).toBeTruthy();
     expect(ref.textContent).toMatch(/BARBAR/);
   });
   it("sorts references as if they were lowercase", () => {
-    const { textContent: first } = doc.querySelector(
+    const { textContent: first } = doc1.querySelector(
       "#normative-references dt:first-of-type"
     );
-    const { textContent: last } = doc.querySelector(
+    const { textContent: last } = doc1.querySelector(
       "#normative-references dt:last-of-type"
     );
     expect(first).toMatch("[a]");

--- a/tests/spec/core/biblio-spec.js
+++ b/tests/spec/core/biblio-spec.js
@@ -37,10 +37,10 @@ describe("W3C — Bibliographic References", () => {
         href: "http://test.com",
         publisher: "Publisher Here",
       },
-      TestRef5: {
+      RefWithOnlyHref: {
         href: "http://test.com",
       },
-      TestRef6: {
+      RefWithOnlyHrefAndAuthor: {
         href: "http://test.com",
         authors: ["William Shakespeare"],
       },
@@ -67,7 +67,7 @@ describe("W3C — Bibliographic References", () => {
 
   const body = `
     <section id='sotd'>
-      <p>foo [[!TestRef1]] [[TestRef2]] [[!TestRef3]] [[!TestRef4]] [[TestRef5]] [[!TestRef6]]</p>
+      <p>foo [[!TestRef1]] [[TestRef2]] [[!TestRef3]] [[RefWithOnlyHref]] [[!RefWithOnlyHrefAndAuthor]]</p>
     </section>
     <section id='sample'>
       <h2>Privacy</h2>
@@ -128,82 +128,126 @@ describe("W3C — Bibliographic References", () => {
   });
 
   it("displays the reference for APA citation", () => {
-    // Make sure the reference is added.
     let ref = docAPA.querySelector("#bib-TestRef1 + dd");
     expect(ref).toBeTruthy();
-    expect(ref.textContent).toMatch(/William Shakespeare\.\s/);
-    expect(ref.textContent).toMatch(/Test ref title\.\s/);
-    expect(ref.textContent).toMatch("Retrieved from URL: http://test.com/");
-    ref = null;
-    //title,url
-    ref = docAPA.querySelector("#bib-TestRef2 + dd");
-    expect(ref).toBeTruthy();
-    expect(ref.textContent).toMatch(/Second test\.\s/);
-    expect(ref.textContent).toMatch("Retrieved from URL: http://test.com/");
-    ref = null;
-    //title
+    let finalString = "William Shakespeare. (2013-12-17). Test ref title. Retrieved from URL: http://test.com/";
+    expect(ref.textContent.trim()).toEqual(finalString); 
+    //Make sure that the right things are hyperlinked
+    let anchors = ref.querySelectorAll("a");
+    expect(anchors.length).toEqual(2);
+    let [title, retrievedFrom] = [...anchors];
+    expect(title.href).toEqual("http://test.com/");
+    expect(title.firstElementChild.localName).toEqual("cite");
+    expect(title.firstElementChild.textContent).toEqual("Test ref title");
+    expect(retrievedFrom.href).toEqual("http://test.com/");
+    ref = finalString = null;
+
     ref = docAPA.querySelector("#bib-TestRef3 + dd");
     expect(ref).toBeTruthy();
-    expect(ref.textContent).toMatch(/Third test\.\s/);
-    ref = null;
-    //author
-    ref = docAPA.querySelector("#bib-TestRef4 + dd");
-    expect(ref).toBeTruthy();
-    expect(ref.textContent).toMatch(/William Shakespeare\.\s/);
-    ref = null;
-    //url
-    ref = docAPA.querySelector("#bib-TestRef5 + dd");
-    expect(ref).toBeTruthy();
-    expect(ref.textContent).toMatch("Retrieved from URL: http://test.com/");
-    ref = null;
-    //author,url
-    ref = docAPA.querySelector("#bib-TestRef6 + dd");
-    expect(ref).toBeTruthy();
-    expect(ref.textContent).toMatch(/William Shakespeare\.\s/);
-    expect(ref.textContent).toMatch("Retrieved from URL: http://test.com/");
+    finalString = "(2013-12-17). Third test. Retrieved from URL: http://test.com/";
+    expect(ref.textContent.trim()).toEqual(finalString); 
+    //Make sure that the right things are hyperlinked
+    anchors = ref.querySelectorAll("a");
+    expect(anchors.length).toEqual(2);
+    [title, retrievedFrom] = [...anchors];
+    expect(title.href).toEqual("http://test.com/");
+    expect(title.firstElementChild.localName).toEqual("cite");
+    expect(title.firstElementChild.textContent).toEqual("Third test");
+    expect(retrievedFrom.href).toEqual("http://test.com/");
   });
 
   it("displays the reference for MLA citation", () => {
-    // Make sure the reference is added.
     let ref = docMLA.querySelector("#bib-TestRef1 + dd");
     expect(ref).toBeTruthy();
-    expect(ref.textContent).toMatch(/William Shakespeare\.\s/);
-    expect(ref.textContent).toMatch(/"Test ref title\."\s/);
-    expect(ref.textContent).toMatch(/Publishers Inc,/);
-    expect(ref.textContent).toMatch("http://test.com");
-    ref = null;
-    // title,url
+    let finalString = "William Shakespeare. \"Test ref title.\" Publishers Inc., 2013-12-17, http://test.com/";
+    expect(ref.textContent.trim()).toEqual(finalString); 
+    //Make sure that the right things are hyperlinked
+    let anchors = ref.querySelectorAll("a");
+    expect(anchors.length).toEqual(2);
+    let [title, retrievedFrom] = [...anchors];
+    expect(title.href).toEqual("http://test.com/");
+    expect(title.firstElementChild.localName).toEqual("cite");
+    expect(title.firstElementChild.textContent).toEqual("\"Test ref title.\"");
+    expect(retrievedFrom.href).toEqual("http://test.com/");
+    ref = finalString = null;
+
     ref = docMLA.querySelector("#bib-TestRef2 + dd");
     expect(ref).toBeTruthy();
-    expect(ref.textContent).toMatch(/"Second test"/);
-    expect(ref.textContent).toMatch("http://test.com");
-    ref = null;
-    // publisher,title
+    finalString = "Another author. \"Second test.\" Testing 123, 2013-12-17, http://test.com/";
+    expect(ref.textContent.trim()).toEqual(finalString);
+    //Make sure that the right things are hyperlinked 
+    anchors = ref.querySelectorAll("a");
+    expect(anchors.length).toEqual(2);
+    [title, retrievedFrom] = [...anchors];
+    expect(title.href).toEqual("http://test.com/");
+    expect(title.firstElementChild.localName).toEqual("cite");
+    expect(title.firstElementChild.textContent).toEqual("\"Second test.\"");
+    expect(retrievedFrom.href).toEqual("http://test.com/");
+    ref = finalString = null;
+
     ref = docMLA.querySelector("#bib-TestRef3 + dd");
     expect(ref).toBeTruthy();
-    expect(ref.textContent).toMatch(/Publisher Here,/);
-    expect(ref.textContent).toMatch(/"Third test\."\s/);
-    ref = null;
-    // title,url,author
-    ref = docMLA.querySelector("#bib-TestRef4 + dd");
-    expect(ref).toBeTruthy();
-    expect(ref.textContent).toMatch(/"Test ref title\."\s/);
-    expect(ref.textContent).toMatch("http://test.com");
-    expect(ref.textContent).toMatch(/William Shakespeare\.\s/);
-    ref = null;
-    // title,author
-    ref = docMLA.querySelector("#bib-TestRef5 + dd");
-    expect(ref).toBeTruthy();
-    expect(ref.textContent).toMatch(/"Test ref title\."\s/);
-    expect(ref.textContent).toMatch(/William Shakespeare\.\s/);
-    ref = null;
-    // publisher,author
-    ref = docMLA.querySelector("#bib-TestRef6 + dd");
-    expect(ref).toBeTruthy();
-    expect(ref.textContent).toMatch(/Publishers Inc\.\s/);
-    expect(ref.textContent).toMatch(/William Shakespeare\.\s/);
-    ref = null;
+    finalString = "\"Third test.\" Publisher Here, 2013-12-17, http://test.com/";
+    expect(ref.textContent.trim()).toEqual(finalString); 
+    //Make sure that the right things are hyperlinked
+    anchors = ref.querySelectorAll("a");
+    expect(anchors.length).toEqual(2);
+    [title, retrievedFrom] = [...anchors];
+    expect(title.href).toEqual("http://test.com/");
+    expect(title.firstElementChild.localName).toEqual("cite");
+    expect(title.firstElementChild.textContent).toEqual("\"Third test.\"");
+    expect(retrievedFrom.href).toEqual("http://test.com/");
+    ref = finalString = null;
   });
+
+  //For both MLA and APA
+  it("Reference with only url", ()=>{
+    let ref = docAPA.querySelector("#bib-RefWithOnlyHref + dd");
+    expect(ref).toBeTruthy();
+    let finalString = "(2013-12-17). Retrieved from URL: http://test.com/";
+    expect(ref.textContent.trim()).toEqual(finalString); 
+    //Make sure that the right things are hyperlinked
+    let anchors = ref.querySelectorAll("a");
+    expect(anchors.length).toEqual(1);
+    [retrievedFrom] = [...anchors];
+    expect(retrievedFrom.href).toEqual("http://test.com/");
+    ref = finalString = null;
+
+    ref = docMLA.querySelector("#bib-RefWithOnlyHref + dd");
+    expect(ref).toBeTruthy();
+    finalString = "2013-12-17, http://test.com/";
+    expect(ref.textContent.trim()).toEqual(finalString); 
+    expect(ref.textContent.trim()).toEqual(finalString); 
+    //Make sure that the right things are hyperlinked
+    anchors = ref.querySelectorAll("a");
+    expect(anchors.length).toEqual(1);
+    [retrievedFrom] = [...anchors];
+    expect(retrievedFrom.href).toEqual("http://test.com/");
+  }); 
+
+  //For both MLA and APA
+  it("Reference with only url", ()=>{
+    let ref = docAPA.querySelector("#bib-RefWithOnlyHrefAndAuthor + dd");
+    expect(ref).toBeTruthy();
+    finalString = "William Shakespeare. (2013-12-17). Retrieved from URL: http://test.com/";
+    expect(ref.textContent.trim()).toEqual(finalString); 
+    //Make sure that the right things are hyperlinked
+    anchors = ref.querySelectorAll("a");
+    expect(anchors.length).toEqual(1);
+    [retrievedFrom] = [...anchors];
+    expect(retrievedFrom.href).toEqual("http://test.com/");
+    ref = finalString = null;
+
+    ref = docMLA.querySelector("#bib-RefWithOnlyHrefAndAuthor + dd");
+    expect(ref).toBeTruthy();
+    finalString = "William Shakespeare. 2013-12-17, http://test.com/";
+    expect(ref.textContent.trim()).toEqual(finalString); 
+    //Make sure that the right things are hyperlinked
+    anchors = ref.querySelectorAll("a");
+    expect(anchors.length).toEqual(1);
+    [retrievedFrom] = [...anchors];
+    expect(retrievedFrom.href).toEqual("http://test.com/");
+  }); 
 
   it("resolves a localy-aliased spec", () => {
     const ref = docDefault.querySelector("#bib-FOOBARGLOP + dd");

--- a/tests/spec/core/biblio-spec.js
+++ b/tests/spec/core/biblio-spec.js
@@ -4,8 +4,8 @@ describe("W3C — Bibliographic References", () => {
   const confDefault = {
     editors: [
       {
-        name: "Robin Berjon"
-      }
+        name: "Robin Berjon",
+      },
     ],
     edDraftURI: "https://foo",
     shortName: "Foo",
@@ -15,42 +15,42 @@ describe("W3C — Bibliographic References", () => {
     previousPublishDate: "2013-12-17",
     localBiblio: {
       Zzz: {
-        title: "Last Reference"
+        title: "Last Reference",
       },
       aaa: {
-        title: "First Reference"
+        title: "First Reference",
       },
       TestRef1: {
         title: "Test ref title",
         href: "http://test.com",
         authors: ["William Shakespeare"],
-        publisher: "Publishers Inc."
+        publisher: "Publishers Inc.",
       },
       TestRef2: {
         title: "Second test",
         href: "http://test.com",
         authors: ["Another author"],
-        publisher: "Testing 123"
+        publisher: "Testing 123",
       },
       TestRef3: {
         title: "Third test",
         href: "http://test.com",
-        publisher: "Publisher Here"
+        publisher: "Publisher Here",
       },
       TestRef5: {
-        href: "http://test.com"
+        href: "http://test.com",
       },
       TestRef6: {
         href: "http://test.com",
-        authors: ["William Shakespeare"]
+        authors: ["William Shakespeare"],
       },
       FOOBARGLOP: {
-        aliasOf: "BARBAR"
+        aliasOf: "BARBAR",
       },
       BARBAR: {
-        title: "The BARBAR Spec"
-      }
-    }
+        title: "The BARBAR Spec",
+      },
+    },
   };
 
   //Configuration for APA citation
@@ -97,7 +97,9 @@ describe("W3C — Bibliographic References", () => {
 
   it("includes a dns-prefetch to bibref server", () => {
     const host = bibRefsURL.host;
-    const link = docDefault.querySelector(`link[rel='dns-prefetch'][href*='${host}']`);
+    const link = docDefault.querySelector(
+      `link[rel='dns-prefetch'][href*='${host}']`
+    );
     expect(link).toBeTruthy();
     expect(link.classList.contains("removeOnSave")).toBeTruthy();
   });

--- a/tests/spec/core/biblio-spec.js
+++ b/tests/spec/core/biblio-spec.js
@@ -200,7 +200,7 @@ describe("W3C — Bibliographic References", () => {
   afterAll(flushIframes);
   const bibRefsURL = new URL("https://specref.herokuapp.com/bibrefs");
 
-  const doc1, doc2, doc3;
+  let doc1, doc2, doc3;
   let specRefOk;
   beforeAll(async () => {
     doc1 = await makeRSDoc({ conf1, body1 });

--- a/tests/spec/core/biblio-spec.js
+++ b/tests/spec/core/biblio-spec.js
@@ -226,7 +226,7 @@ describe("W3C — Bibliographic References", () => {
   }); 
 
   //For both MLA and APA
-  it("Reference with only url", ()=>{
+  it("Reference with author and url", ()=>{
     let ref = docAPA.querySelector("#bib-RefWithOnlyHrefAndAuthor + dd");
     expect(ref).toBeTruthy();
     finalString = "William Shakespeare. (2013-12-17). Retrieved from URL: http://test.com/";

--- a/tests/spec/core/biblio-spec.js
+++ b/tests/spec/core/biblio-spec.js
@@ -82,7 +82,7 @@ describe("W3C — Bibliographic References", () => {
   afterAll(flushIframes);
   const bibRefsURL = new URL("https://specref.herokuapp.com/bibrefs");
 
-  let docDefault, docAPA, docMLA;
+  const docDefault, docAPA, docMLA;
   let specRefOk;
   beforeAll(async () => {
     docDefault = await makeRSDoc({ confDefault, body });
@@ -106,7 +106,7 @@ describe("W3C — Bibliographic References", () => {
 
   it("displays the publisher when present", () => {
     // Make sure the reference is added.
-    let ref = docDefault.querySelector("#bib-TestRef1 + dd");
+    const ref = docDefault.querySelector("#bib-TestRef1 + dd");
     expect(ref).toBeTruthy();
     // This prevents Jasmine from taking down the whole test suite if SpecRef is down.
     if (!specRefOk) {
@@ -115,46 +115,49 @@ describe("W3C — Bibliographic References", () => {
       );
     }
     expect(ref.textContent).toMatch(/Publishers Inc\.\s/);
-    ref = null;
-    // Make sure the ". " is automatically added to publisher.
-    ref = docDefault.querySelector("#bib-TestRef2 + dd");
-    expect(ref).toBeTruthy();
-    expect(ref.textContent).toMatch(/Testing 123\.\s/);
-    ref = null;
-    // Make sure publisher is shown even when there is no author
-    ref = docDefault.querySelector("#bib-TestRef3 + dd");
-    expect(ref).toBeTruthy();
-    expect(ref.textContent).toMatch(/Publisher Here\.\s/);
   });
 
-  it("displays the reference for APA citation", () => {
-    let ref = docAPA.querySelector("#bib-TestRef1 + dd");
+  it("makes sure the . is automatically added to publisher", () => {
+    const ref = docDefault.querySelector("#bib-TestRef2 + dd");
     expect(ref).toBeTruthy();
-    let finalString = "William Shakespeare. (2013-12-17). Test ref title. Retrieved from URL: http://test.com/";
+    expect(ref.textContent).toMatch(/Testing 123\.\s/);
+  });  
+
+  it("makes sure publisher is shown even when there is no author", () => {
+    const ref = docDefault.querySelector("#bib-TestRef3 + dd");
+    expect(ref).toBeTruthy();
+    expect(ref.textContent).toMatch(/Publisher Here\.\s/);
+  }); 
+
+  it("displays the APA citation even when unnecessary publisher is given", () => {
+    const ref = docAPA.querySelector("#bib-TestRef1 + dd");
+    expect(ref).toBeTruthy();
+    const finalString = "William Shakespeare. (2013-12-17). Test ref title. Retrieved from URL: http://test.com/";
     expect(ref.textContent.trim()).toEqual(finalString); 
     //Make sure that the right things are hyperlinked
-    let anchors = ref.querySelectorAll("a");
+    const anchors = ref.querySelectorAll("a");
     expect(anchors.length).toEqual(2);
-    let [title, retrievedFrom] = [...anchors];
+    const [title, retrievedFrom] = [...anchors];
     expect(title.href).toEqual("http://test.com/");
     expect(title.firstElementChild.localName).toEqual("cite");
     expect(title.firstElementChild.textContent).toEqual("Test ref title");
-    expect(retrievedFrom.href).toEqual("http://test.com/");
-    ref = finalString = null;
+    expect(retrievedFrom.href).toEqual("http://test.com/");    
+  });
 
-    ref = docAPA.querySelector("#bib-TestRef3 + dd");
+  it("displays the APA citation even when there is no author", () => {
+    const ref = docAPA.querySelector("#bib-TestRef3 + dd");
     expect(ref).toBeTruthy();
-    finalString = "(2013-12-17). Third test. Retrieved from URL: http://test.com/";
+    const finalString = "(2013-12-17). Third test. Retrieved from URL: http://test.com/";
     expect(ref.textContent.trim()).toEqual(finalString); 
     //Make sure that the right things are hyperlinked
-    anchors = ref.querySelectorAll("a");
+    const anchors = ref.querySelectorAll("a");
     expect(anchors.length).toEqual(2);
-    [title, retrievedFrom] = [...anchors];
+    const [title, retrievedFrom] = [...anchors];
     expect(title.href).toEqual("http://test.com/");
     expect(title.firstElementChild.localName).toEqual("cite");
     expect(title.firstElementChild.textContent).toEqual("Third test");
     expect(retrievedFrom.href).toEqual("http://test.com/");
-  });
+  }); 
 
   it("displays the reference for MLA citation", () => {
     let ref = docMLA.querySelector("#bib-TestRef1 + dd");
@@ -183,69 +186,69 @@ describe("W3C — Bibliographic References", () => {
     expect(title.firstElementChild.localName).toEqual("cite");
     expect(title.firstElementChild.textContent).toEqual("\"Second test.\"");
     expect(retrievedFrom.href).toEqual("http://test.com/");
-    ref = finalString = null;
+  });
 
-    ref = docMLA.querySelector("#bib-TestRef3 + dd");
+  it("displays the MLA citation even when there is no author", () => {
+    const ref = docMLA.querySelector("#bib-TestRef3 + dd");
     expect(ref).toBeTruthy();
-    finalString = "\"Third test.\" Publisher Here, 2013-12-17, http://test.com/";
+    const finalString = "\"Third test.\" Publisher Here, 2013-12-17, http://test.com/";
     expect(ref.textContent.trim()).toEqual(finalString); 
     //Make sure that the right things are hyperlinked
-    anchors = ref.querySelectorAll("a");
+    const anchors = ref.querySelectorAll("a");
     expect(anchors.length).toEqual(2);
-    [title, retrievedFrom] = [...anchors];
+    const [title, retrievedFrom] = [...anchors];
     expect(title.href).toEqual("http://test.com/");
     expect(title.firstElementChild.localName).toEqual("cite");
     expect(title.firstElementChild.textContent).toEqual("\"Third test.\"");
     expect(retrievedFrom.href).toEqual("http://test.com/");
-    ref = finalString = null;
-  });
+  }); 
 
-  //For both MLA and APA
-  it("Reference with only url", ()=>{
-    let ref = docAPA.querySelector("#bib-RefWithOnlyHref + dd");
+  it("displays APA citation for reference with only url", ()=>{
+    const ref = docAPA.querySelector("#bib-RefWithOnlyHref + dd");
     expect(ref).toBeTruthy();
-    let finalString = "(2013-12-17). Retrieved from URL: http://test.com/";
+    const finalString = "(2013-12-17). Retrieved from URL: http://test.com/";
     expect(ref.textContent.trim()).toEqual(finalString); 
     //Make sure that the right things are hyperlinked
-    let anchors = ref.querySelectorAll("a");
+    const anchors = ref.querySelectorAll("a");
     expect(anchors.length).toEqual(1);
-    [retrievedFrom] = [...anchors];
-    expect(retrievedFrom.href).toEqual("http://test.com/");
-    ref = finalString = null;
-
-    ref = docMLA.querySelector("#bib-RefWithOnlyHref + dd");
-    expect(ref).toBeTruthy();
-    finalString = "2013-12-17, http://test.com/";
-    expect(ref.textContent.trim()).toEqual(finalString); 
-    expect(ref.textContent.trim()).toEqual(finalString); 
-    //Make sure that the right things are hyperlinked
-    anchors = ref.querySelectorAll("a");
-    expect(anchors.length).toEqual(1);
-    [retrievedFrom] = [...anchors];
+    const [retrievedFrom] = [...anchors];
     expect(retrievedFrom.href).toEqual("http://test.com/");
   }); 
 
-  //For both MLA and APA
-  it("Reference with author and url", ()=>{
-    let ref = docAPA.querySelector("#bib-RefWithOnlyHrefAndAuthor + dd");
+  it("displays MLA citation for reference with only url", ()=>{
+    const ref = docMLA.querySelector("#bib-RefWithOnlyHref + dd");
     expect(ref).toBeTruthy();
-    finalString = "William Shakespeare. (2013-12-17). Retrieved from URL: http://test.com/";
+    const finalString = "2013-12-17, http://test.com/";
+    expect(ref.textContent.trim()).toEqual(finalString); 
     expect(ref.textContent.trim()).toEqual(finalString); 
     //Make sure that the right things are hyperlinked
-    anchors = ref.querySelectorAll("a");
+    const anchors = ref.querySelectorAll("a");
     expect(anchors.length).toEqual(1);
-    [retrievedFrom] = [...anchors];
+    const [retrievedFrom] = [...anchors];
     expect(retrievedFrom.href).toEqual("http://test.com/");
-    ref = finalString = null;
+  }); 
 
-    ref = docMLA.querySelector("#bib-RefWithOnlyHrefAndAuthor + dd");
+  it("displays APA citation for reference with author and url", ()=>{
+    const ref = docAPA.querySelector("#bib-RefWithOnlyHrefAndAuthor + dd");
     expect(ref).toBeTruthy();
-    finalString = "William Shakespeare. 2013-12-17, http://test.com/";
+    const finalString = "William Shakespeare. (2013-12-17). Retrieved from URL: http://test.com/";
     expect(ref.textContent.trim()).toEqual(finalString); 
     //Make sure that the right things are hyperlinked
-    anchors = ref.querySelectorAll("a");
+    const anchors = ref.querySelectorAll("a");
     expect(anchors.length).toEqual(1);
-    [retrievedFrom] = [...anchors];
+    const [retrievedFrom] = [...anchors];
+    expect(retrievedFrom.href).toEqual("http://test.com/");
+  }); 
+
+  it("displays MLA citation for reference with author and url", ()=>{
+    const ref = docMLA.querySelector("#bib-RefWithOnlyHrefAndAuthor + dd");
+    expect(ref).toBeTruthy();
+    const finalString = "William Shakespeare. 2013-12-17, http://test.com/";
+    expect(ref.textContent.trim()).toEqual(finalString); 
+    //Make sure that the right things are hyperlinked
+    const anchors = ref.querySelectorAll("a");
+    expect(anchors.length).toEqual(1);
+    const[retrievedFrom] = [...anchors];
     expect(retrievedFrom.href).toEqual("http://test.com/");
   }); 
 


### PR DESCRIPTION
Fixes #857. 

Adds support for APA, MLA, and retains ReSpec's custom citation style as the default. 