### PR TITLE
fix(package): update command-line-usage to version 5.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   "dependencies": {
     "colors": "^1.1.2",
     "command-line-args": "^5.0.2",
-    "command-line-usage": "^4.1.0",
+    "command-line-usage": "^5.0.2",
     "epipebomb": "^1.0.0",
     "fs-extra": "^5.0.0",
     "highlight.js": "github:marcoscaceres/highlight.js#7b144b3b83ce296d5b29c5e4fc2ea2a65e9d3f32",

--- a/tools/builder.js
+++ b/tools/builder.js
@@ -53,7 +53,7 @@ const usageSections = [
     ],
   },
   {
-    content: "Project home: [underline]{https://github.com/w3c/respec}",
+    content: "Project home: {underline https://github.com/w3c/respec}",
     raw: true,
   },
 ];

--- a/tools/respec2html.js
+++ b/tools/respec2html.js
@@ -97,7 +97,7 @@ const usageSections = [
     ],
   },
   {
-    content: "Project home: [underline]{https://github.com/w3c/respec}",
+    content: "Project home: {underline https://github.com/w3c/respec}",
     raw: true,
   },
 ];


### PR DESCRIPTION
Closes #1565.

I don't think we have anything to change.