### PR TITLE
Migrating tests from jQuery

### DIFF
--- a/tests/spec/SpecHelper.js
+++ b/tests/spec/SpecHelper.js
@@ -177,3 +177,46 @@ function makeStandardOps() {
     body: makeDefaultBody(),
   };
 }
+
+/**
+ * partial equivalent to jquery's $(selector:contains('text'))
+ * @param {String} selector
+ * @param {String|RegExp} text text to search
+ * @param context
+ * returns: Array of valid selectors
+ * example:
+ *  selectorContains("dt", "Editors:", doc)
+ *    <=>
+ *  $("dt:contains('Editors:'", doc)
+ */
+function selectorContains(selector, text, context = document) {
+  const re = new RegExp(text);
+  return [...context.querySelectorAll(selector)]
+    .filter(element => re.test(element.textContent));
+}
+
+/**
+ * partial equivalent to jquery's `el.next([type])`
+ * @param {Node} element element whose sibling is to be found
+ * @param {String} tagname tagname of sibling.
+ * return: element's sibling which has the tagname as tagName or null
+ * default: return nextSibling (if tagname = "")
+ * example:
+ *   let el = $("dt:contains('Editor:')", doc);
+*    nextSiblingOfType(el, "dd")
+ *    <=>
+ *   el.next("dd");
+ */
+function nextSiblingOfType(element, tagname = "") {
+  if (!tagname) {
+    return element.nextSibling;
+  }
+  let temp = element.nextSibling;
+  while (temp) {
+    if (temp.tagName.toLowerCase() === tagname) {
+      return temp;
+    }
+    temp = temp.nextSibling;
+  }
+  return null;
+}


### PR DESCRIPTION
Add selector helpers to help in migration, so that we won't need either of jQuery or Sizzle. 

We intend to do as much as work without using an extra layer of redirection, so we won't be adding a lot of helpers. Only the helpers which might be too verbose to write in tests should be created.

Based on my observations, I've added following two helpers.
Please give your opinion on name of these helper functions.

# Example Usage

##  `selectorContains`

Partial equivalent of jquery's `:contains(text)`

``` js
selectorContains("dt", "Editors:", doc);
// <=> $("dt:contains('Editors:'", doc);

selectorContains(".head a", "errata", doc)
// or selectorContains("a", "errata", doc.querySelector(".head"))
// <=> $(".head a:contains('errata')", doc)

let $sotd = doc.getElementById("sotd");
selectorContains("a", /^WGNAME$/, $sotd);
// using regex
// if you use "WGNAME", it'll also match "WGNAME1", "blahWGNAMEblah"
// <=> $sotd.find("a:contains('WGNAME')")
```

## `nextSiblingOfType`

Partial equivalent of jquery's `el.next(selector)`
``` js

let el = $("dt:contains('Editor:')", doc);
nextSiblingOfType(el, "dd")
//  <=> el.next("dd");
```
If you don't want to use this function, you may use `el.nextSibling` directly (and then test the type of the selected element if needed)
