### PR TITLE
Allow makeStandardOps() to take overrides: Fixes #1576

### DIFF
--- a/tests/spec/SpecHelper.js
+++ b/tests/spec/SpecHelper.js
@@ -149,6 +149,7 @@ function pickRandomsFromList(list, howMany) {
 }
 
 function makeBasicConfig() {
+ 
   return {
     editors: [
       {
@@ -171,9 +172,9 @@ function makeDefaultBody() {
   return "<section id='sotd'><p>foo</p></section><section id='toc'></section>";
 }
 
-function makeStandardOps() {
+function makeStandardOps(configParams) {
   return {
-    config: makeBasicConfig(),
+    config: Object.assign(makeBasicConfig(),configParams),
     body: makeDefaultBody(),
   };
 }

--- a/tests/spec/SpecHelper.js
+++ b/tests/spec/SpecHelper.js
@@ -172,9 +172,16 @@ function makeDefaultBody() {
   return "<section id='sotd'><p>foo</p></section><section id='toc'></section>";
 }
 
-function makeStandardOps(configParams) {
+/**
+ *
+ * @param configParams
+ * @param bodyParams
+ * @returns {{config: {editors, specStatus, edDraftURI, shortName, previousMaturity, previousPublishDate, errata, implementationReportURI, perEnd, lint} & any, body: string}}
+ */
+
+function makeStandardOps(configParams, bodyParams = makeDefaultBody()) {
   return {
     config: Object.assign(makeBasicConfig(),configParams),
-    body: makeDefaultBody(),
+    body: bodyParams,
   };
 }

--- a/tests/spec/SpecHelper.js
+++ b/tests/spec/SpecHelper.js
@@ -179,9 +179,9 @@ function makeDefaultBody() {
  * @returns {{config: {editors, specStatus, edDraftURI, shortName, previousMaturity, previousPublishDate, errata, implementationReportURI, perEnd, lint} & any, body: string}}
  */
 
-function makeStandardOps(configParams, bodyParams = makeDefaultBody()) {
+function makeStandardOps(config = {}, body = makeDefaultBody()) {
   return {
-    config: Object.assign(makeBasicConfig(),configParams),
-    body: bodyParams,
+    body,
+    config: {...makeBasicConfig(), ...config}
   };
 }

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -231,7 +231,7 @@ describe("W3C — Headers", function() {
       const doc = await makeRSDoc(ops);
       expect($("#subtitle", doc).length).toEqual(0);
     });
-    
+
     it("takes subtitle into account", async () => {
       const ops = makeStandardOps();
       const newProps = {

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -387,12 +387,16 @@ describe("W3C — Headers", function() {
 
   describe("edDraftURI", () => {
     it("takes edDraftURI into account", async () => {
-      const ops = makeStandardOps();
-      const newProps = {
+      const ops = makeStandardOps({
+        specStatus: "WD",
+        edDraftURI: "URI",
+      });
+      /*const newProps = {
         specStatus: "WD",
         edDraftURI: "URI",
       };
-      Object.assign(ops.config, newProps);
+      console.log(ops.config)
+      Object.assign(ops.config, newProps);*/
       const doc = await makeRSDoc(ops);
       expect(
         $("dt:contains('Latest editor\\'s draft:')", doc)
@@ -443,12 +447,15 @@ describe("W3C — Headers", function() {
     });
 
     it("handles additionalCopyrightHolders when text is markup", async () => {
-      const ops = makeStandardOps();
-      const newProps = {
+      const ops = makeStandardOps({
+        specStatus: "REC",
+        additionalCopyrightHolders: "<span class='test'>XXX</span>",
+      });
+      /*const newProps = {
         specStatus: "REC",
         additionalCopyrightHolders: "<span class='test'>XXX</span>",
       };
-      Object.assign(ops.config, newProps);
+      Object.assign(ops.config, newProps);*/
       const doc = await makeRSDoc(ops);
       expect($(".head .copyright .test", doc).text()).toEqual("XXX");
     });

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -391,12 +391,7 @@ describe("W3C — Headers", function() {
         specStatus: "WD",
         edDraftURI: "URI",
       });
-      /*const newProps = {
-        specStatus: "WD",
-        edDraftURI: "URI",
-      };
-      console.log(ops.config)
-      Object.assign(ops.config, newProps);*/
+      
       const doc = await makeRSDoc(ops);
       expect(
         $("dt:contains('Latest editor\\'s draft:')", doc)
@@ -451,11 +446,7 @@ describe("W3C — Headers", function() {
         specStatus: "REC",
         additionalCopyrightHolders: "<span class='test'>XXX</span>",
       });
-      /*const newProps = {
-        specStatus: "REC",
-        additionalCopyrightHolders: "<span class='test'>XXX</span>",
-      };
-      Object.assign(ops.config, newProps);*/
+      
       const doc = await makeRSDoc(ops);
       expect($(".head .copyright .test", doc).text()).toEqual("XXX");
     });

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -231,7 +231,7 @@ describe("W3C — Headers", function() {
       const doc = await makeRSDoc(ops);
       expect($("#subtitle", doc).length).toEqual(0);
     });
-
+    
     it("takes subtitle into account", async () => {
       const ops = makeStandardOps();
       const newProps = {


### PR DESCRIPTION
As suggested by @marcoscaceres, at #1576  the changes have been made. There can be multiple ways to incorporate the same. This is just one of them. 

Currently, the new format has been tried at a couple of places (visible [here](https://github.com/w3c/respec/pull/1576/files)). Please review. :smile: 