### PR TITLE
fix(core/webidl): support extended attributes for IDL types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9761,9 +9761,9 @@
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
     },
     "webidl2": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/webidl2/-/webidl2-10.2.1.tgz",
-      "integrity": "sha512-zzVpyPEEZYt8P355+W79Fh/Fm61/GNBkEiQGFkq5hl6UhAro2bg3jzqXeGOog6lWUGjvoFL/tyzpdhveOwubIg==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/webidl2/-/webidl2-10.3.1.tgz",
+      "integrity": "sha512-n6y1kwIWZB8VHgPeTCzp3qVwmz/Wilbquni2t23Sin3xU8tfhjh9EUTwYNpD406EXPVG1oDzmt+12Bu02Hm1aA==",
       "dev": true
     },
     "whatwg-encoding": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "text": "github:requirejs/text#d04de4ffd7bf5ba6cb80cdca2d40d4f6f52a1b1f",
     "uglify-es": "3.3.7",
     "url-search-params": "^0.10.0",
-    "webidl2": "^10.2.1"
+    "webidl2": "^10.3.1"
   },
   "scripts": {
     "babel:build": "babel src -d js --source-maps -q",

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -44,9 +44,6 @@ function registerHelpers() {
   hb.registerHelper("extAttrInline", function(obj) {
     return extAttr(obj.extAttrs, 0, /*singleLine=*/ true);
   });
-  hb.registerHelper("typeExtAttrs", function(obj) {
-    return extAttr(obj.typeExtAttrs, 0, /*singleLine=*/ true);
-  });
   hb.registerHelper("extAttrClassName", function() {
     var extAttr = this;
     if (extAttr.name === "Constructor" || extAttr.name === "NamedConstructor") {
@@ -158,9 +155,10 @@ function idlType2Html(idlType) {
   if (Array.isArray(idlType)) {
     return idlType.map(idlType2Html).join(", ");
   }
+  const extAttrs = extAttr(idlType.extAttrs, 0, /*singleLine=*/ true);
   const nullable = idlType.nullable ? "?" : "";
   if (idlType.union) {
-    return `(${idlType.idlType.map(idlType2Html).join(" or ")})${nullable}`;
+    return `${extAttrs}(${idlType.idlType.map(idlType2Html).join(" or ")})${nullable}`;
   }
   let type = "";
   if (idlType.generic) {
@@ -173,7 +171,7 @@ function idlType2Html(idlType) {
       ? linkStandardType(idlType.idlType)
       : idlType2Html(idlType.idlType);
   }
-  return type + nullable;
+  return extAttrs + type + nullable;
 }
 
 function linkStandardType(type) {

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -1,16 +1,10 @@
 "use strict";
 describe("Core - WebIDL", function() {
   afterAll(flushIframes);
-  var doc;
-  beforeAll(function(done) {
-    var ops = makeStandardOps();
-    makeRSDoc(
-      ops,
-      function(idlDoc) {
-        doc = idlDoc;
-      },
-      "spec/core/webidl.html"
-    ).then(done);
+  let doc;
+  beforeAll(async () => {
+    const ops = makeStandardOps();
+    doc = await makeRSDoc(ops, () => { }, "spec/core/webidl.html");
   });
 
   it("handles record types", done => {
@@ -570,26 +564,33 @@ describe("Core - WebIDL", function() {
     done();
   });
 
-  it("should handle typedefs", function(done) {
-    var $target = $("#td-basic", doc);
-    var text = "typedef DOMString string;";
-    expect($target.text()).toEqual(text);
-    expect($target.find(".idlTypedef").length).toEqual(1);
-    expect($target.find(".idlTypedefID").text()).toEqual("string");
-    expect($target.find(".idlTypedefType").text()).toEqual("DOMString");
+  it("should handle typedefs", () => {
+    let target = doc.getElementById("td-basic");
+    let text = "typedef DOMString string;";
+    expect(target.textContent).toEqual(text);
+    expect(target.querySelectorAll(".idlTypedef").length).toEqual(1);
+    expect(target.querySelector(".idlTypedefID").textContent).toEqual("string");
+    expect(target.querySelector(".idlTypedefType").textContent).toEqual("DOMString");
 
-    $target = $("#td-less-basic", doc);
+    target = doc.getElementById("td-less-basic");
     text = "typedef unsigned long long? tdLessBasic;";
-    expect($target.text()).toEqual(text);
+    expect(target.textContent).toEqual(text);
 
     // Links and IDs.
     expect(
-      $target.find(":contains('tdLessBasic')").filter("a").attr("href")
+      target.querySelector(".idlTypedefID").children[0].getAttribute("href")
     ).toEqual("#dom-tdlessbasic");
     expect(
-      $target.find(".idlTypedef:contains('tdLessBasic')").attr("id")
+      target.querySelector(".idlTypedef").id
     ).toEqual("idl-def-tdlessbasic");
-    done();
+
+    target = doc.getElementById("td-extended-attribute");
+    text = "typedef ([Clamp] unsigned long or ConstrainULongRange) ConstrainULong;";
+    expect(target.textContent).toEqual(text);
+
+    target = doc.getElementById("td-union-extended-attribute");
+    text = "typedef [Clamp] (unsigned long or ConstrainULongRange) ConstrainULong2;";
+    expect(target.textContent).toEqual(text);
   });
 
   it("should handle includes", () => {

--- a/tests/spec/core/webidl.html
+++ b/tests/spec/core/webidl.html
@@ -504,6 +504,18 @@
         typedef unsigned long long? tdLessBasic;
       </pre>
       <p id='td-less-basic-doc'><dfn>tdLessBasic</dfn></p>
+      <p>
+        Typedef with an extended attribute.
+      </p>
+      <pre id='td-extended-attribute' class='idl'>
+        typedef ([Clamp] unsigned long or ConstrainULongRange) ConstrainULong;
+      </pre>
+      <p>
+        Typedef with an extended attribute on union type.
+      </p>
+      <pre id='td-union-extended-attribute' class='idl'>
+        typedef [Clamp] (unsigned long or ConstrainULongRange) ConstrainULong2;
+      </pre>
     </section>
     <section>
       <h2>Implements</h2>


### PR DESCRIPTION
Fixes #1574.

There was no support for TypeWithExtendedAttributes things so this PR adds it.