### PR TITLE
fix(w3c/templates/headers): doc.title must match conf.title

### DIFF
--- a/src/w3c/templates/headers.js
+++ b/src/w3c/templates/headers.js
@@ -11,13 +11,15 @@ function getSpecTitleElem (conf) {
     specTitleElem.remove();
     conf.title = specTitleElem.textContent.trim();
   } else {
-    if (document.title !== conf.title) {
-      pub("warn", "The document's title and the `<title>` element differ.");
-    }
     specTitleElem.textContent = conf.title;
     specTitleElem.id = "title";
   }
   specTitleElem.classList.add("title", "p-name");
+  if (document.querySelector("title") === null) {
+    document.title = conf.title;
+  } else if (document.title !== conf.title) {
+    pub("warn", "The document's title and the `<title>` element differ.");
+  }
   return specTitleElem;
 }
 

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -329,6 +329,9 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps({}, body);
       const doc = await makeRSDoc(ops);
       expect(doc.title).toEqual("This should be pass.");
+      const titleElem = doc.querySelector("title");
+      expect(titleElem).toBeTruthy();
+      expect(titleElem.textContent).toEqual("This should be pass.");
     });
 
     it("uses <h1> if already present", async () => {

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -321,6 +321,16 @@ describe("W3C — Headers", function() {
   });
 
   describe("use existing h1 element", () => {
+    it("uses the <h1>'s value as the document's title", async () => {
+      const body = `
+        <h1 id='title'>
+          This should be <code>pass</code>.
+         </h1>` + makeDefaultBody();
+      const ops = makeStandardOps({}, body);
+      const doc = await makeRSDoc(ops);
+      expect(doc.title).toEqual("This should be pass.");
+    });
+
     it("uses <h1> if already present", async () => {
       const ops = makeStandardOps();
       ops.body = "<h1 id='title'><code>pass</code></h1>" + makeDefaultBody();


### PR DESCRIPTION
This now sets the document title based on the `h1`, so it avoid having to declare the title of the spec twice. ReSpec gets upset when they are different.  