### PR TITLE
Remove @@@ from sotd

### DIFF
--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -22,11 +22,8 @@ ${conf.isPreview
 ${conf.isUnofficial
     ? html`
   <p>
-    Do not attempt to implement this version of the specification. Do not reference this version as authoritative in any way.
-    ${conf.edDraftURI
-      ? html` Instead, see
-    <a href="${conf.edDraftURI}">${conf.edDraftURI}</a> for the Editor's draft. `
-      : ""}
+    This document is draft of a potential specification. It has no official standing of
+    any kind and does not represent the support or consensus of any standards organisation.
   </p>
   ${[conf.additionalContent]}
 `
@@ -55,8 +52,7 @@ ${conf.isUnofficial
         ${conf.isMemberSubmission
           ? html`
           <p>
-            By publishing this document, W3C acknowledges that <a href="${conf.thisVersion}">
-            the Submitting Members</a>
+            By publishing this document, W3C acknowledges that the <a href="${conf.thisVersion}">Submitting Members</a>
             have made a formal Submission request to W3C for discussion. Publication of this document
             by W3C indicates no endorsement of its content by W3C, nor that W3C has, is, or will be
             allocating any resources to the issues addressed by it. This document is not the product
@@ -71,7 +67,23 @@ ${conf.isUnofficial
             of acknowledged W3C Member Submissions</a>.
           </p>
         `
-          : ""}
+          : html`
+          ${conf.isTeamSubmission
+            ? html`
+            <p>If you wish to make comments regarding this document, please send them to
+            <a href='${`mailto:${conf.wgPublicList}@w3.org${conf.subjectPrefix
+              ? `?subject=${conf.subjectPrefixEnc}`
+              : [""]}`}'>${conf.wgPublicList}@w3.org</a>
+            (<a href='${`mailto:${conf.wgPublicList}-request@w3.org?subject=subscribe`}'>subscribe</a>,
+            <a
+              href='${`https://lists.w3.org/Archives/Public/${conf.wgPublicList}/`}'>archives</a>)${conf.subjectPrefix
+                ? html`
+              with <code>${conf.subjectPrefix}</code> at the start of your email's subject`
+                : ""}.</p>
+            <p>Please consult the complete <a href="https://www.w3.org/TeamSubmission/">list of Team Submissions</a>.</p>
+          `
+            : ""}
+        `}
       `
         : html`
         ${!conf.sotdAfterWGinfo ? [conf.additionalContent] : ""}

--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -74,7 +74,7 @@ ${
             the <a href="https://www.w3.org/Consortium/Process">W3C Process</a>.
             A <a href="${`https://www.w3.org/Submission/${conf.publishDate.getUTCFullYear()}/${
               conf.submissionCommentNumber
-            }/Comment/`}">W3C Team Comment</a> has been
+            }/Comment/`}" id="comment">W3C Team Comment</a> has been
             published in conjunction with this Member Submission. Publication of acknowledged Member Submissions
             at the W3C site is one of the benefits of <a href="https://www.w3.org/Consortium/Prospectus/Joining">
             W3C Membership</a>. Please consult the requirements associated with Member Submissions of

--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -3,40 +3,65 @@ import "deps/hyperhtml";
 export default conf => {
   const html = hyperHTML;
   return html`<h2>${conf.l10n.sotd}</h2>
-${conf.isPreview ? html`
+${
+    conf.isPreview
+      ? html`
   <details class="annoying-warning" open="">
     <summary>This is a preview</summary>
     <p>
       Do not attempt to implement this version of the specification. Do not reference this
       version as authoritative in any way.
-      ${conf.edDraftURI ? html`
-        Instead, see <a href="${conf.edDraftURI}">${conf.edDraftURI}</a> for the Editor's draft.
-      ` : ""}
+      ${
+        conf.edDraftURI
+          ? html`
+        Instead, see <a href="${conf.edDraftURI}">${
+              conf.edDraftURI
+            }</a> for the Editor's draft.
+      `
+          : ""
+      }
     </p>
   </details>
-` : ""}
-${conf.isUnofficial ? html`
+`
+      : ""
+  }
+${
+    conf.isUnofficial
+      ? html`
   <p>
     This document is draft of a potential specification. It has no official standing of
     any kind and does not represent the support or consensus of any standards organisation.
   </p>
   ${[conf.additionalContent]}
-` : html`
-  ${conf.isTagFinding ? [conf.additionalContent] : html`
-    ${conf.isNoTrack ? html`
+`
+      : html`
+  ${
+    conf.isTagFinding
+      ? [conf.additionalContent]
+      : html`
+    ${
+      conf.isNoTrack
+        ? html`
       <p>
-        This document is merely a W3C-internal ${conf.isMO ? "member-confidential" : ""} document. It
+        This document is merely a W3C-internal ${
+          conf.isMO ? "member-confidential" : ""
+        } document. It
         has no official standing of any kind and does not represent consensus of the W3C
         Membership.
       </p>
       ${[conf.additionalContent]}
-    ` : html`
+    `
+        : html`
       <p>
         <em>${[conf.l10n.status_at_publication]}</em>
       </p>
-      ${conf.isSubmission ? html`
+      ${
+        conf.isSubmission
+          ? html`
         ${[conf.additionalContent]}
-        ${conf.isMemberSubmission ? html`
+        ${
+          conf.isMemberSubmission
+            ? html`
           <p>
             By publishing this document, W3C acknowledges that
             the <a href="https://www.w3.org/Submission/@@@submissiondoc@@@">Submitting Members</a>
@@ -53,38 +78,61 @@ ${conf.isUnofficial ? html`
             W3C Patent Policy</a>. Please consult the complete <a href="https://www.w3.org/Submission">list
             of acknowledged W3C Member Submissions</a>.
           </p>
-        ` : html`
-          ${conf.isTeamSubmission ? html`
-            <p>If you wish to make comments regarding this document, please send them to
-            <a href='${`mailto:${conf.wgPublicList}@w3.org${conf.subjectPrefix ? `?subject=${conf.subjectPrefixEnc}` : [""]}`}'>${conf.wgPublicList}@w3.org</a>
-            (<a href='${`mailto:${conf.wgPublicList}-request@w3.org?subject=subscribe`}'>subscribe</a>,
-            <a
-              href='${`https://lists.w3.org/Archives/Public/${conf.wgPublicList}/`}'>archives</a>)${conf.subjectPrefix ? html`
-              with <code>${conf.subjectPrefix}</code> at the start of your email's subject` : ""}.</p>
-            <p>Please consult the complete <a href="https://www.w3.org/TeamSubmission/">list of Team Submissions</a>.</p>
-          ` : ""}
-        `}
-      ` : html`
+        `
+            : ""
+        }
+      `
+          : html`
         ${!conf.sotdAfterWGinfo ? [conf.additionalContent] : ""}
-        ${!conf.overrideStatus ? html`
+        ${
+          !conf.overrideStatus
+            ? html`
         <p>
-          This document was published by ${[conf.wgHTML]} as ${conf.anOrA} ${conf.longStatus}.
-          ${conf.notYetRec ? "This document is intended to become a W3C Recommendation." : ""}
-          ${conf.wgPublicList ? html`
+          This document was published by ${[conf.wgHTML]} as ${conf.anOrA} ${
+                conf.longStatus
+              }.
+          ${
+            conf.notYetRec
+              ? "This document is intended to become a W3C Recommendation."
+              : ""
+          }
+          ${
+            conf.wgPublicList
+              ? html`
             Comments regarding this document are welcome. Please send them to
-            <a href='${`mailto:${conf.wgPublicList}@w3.org${conf.subjectPrefix ? `?subject=${conf.subjectPrefixEnc}` : [""]}`}'>${conf.wgPublicList}@w3.org</a>
-            (<a href='${`mailto:${conf.wgPublicList}-request@w3.org?subject=subscribe`}'>subscribe</a>,
+            <a href='${`mailto:${conf.wgPublicList}@w3.org${
+              conf.subjectPrefix ? `?subject=${conf.subjectPrefixEnc}` : [""]
+            }`}'>${conf.wgPublicList}@w3.org</a>
+            (<a href='${`mailto:${
+              conf.wgPublicList
+            }-request@w3.org?subject=subscribe`}'>subscribe</a>,
             <a
-              href='${`https://lists.w3.org/Archives/Public/${conf.wgPublicList}/`}'>archives</a>)${conf.subjectPrefix ? html`
-              with <code>${conf.subjectPrefix}</code> at the start of your email's subject` : ""}.
-          ` : ""}
-          ${conf.isCR ? `
+              href='${`https://lists.w3.org/Archives/Public/${
+                conf.wgPublicList
+              }/`}'>archives</a>)${
+                  conf.subjectPrefix
+                    ? html`
+              with <code>${
+                conf.subjectPrefix
+              }</code> at the start of your email's subject`
+                    : ""
+                }.
+          `
+              : ""
+          }
+          ${
+            conf.isCR
+              ? `
             W3C publishes a Candidate Recommendation to indicate that the document is believed to be
             stable and to encourage implementation by the developer community. This Candidate
             Recommendation is expected to advance to Proposed Recommendation no earlier than
             ${conf.humanCREnd}.
-          ` : ""}
-          ${conf.isPER ? html`
+          `
+              : ""
+          }
+          ${
+            conf.isPER
+              ? html`
               W3C Advisory Committee Members are invited to
               send formal review comments on this Proposed
               Edited Recommendation to the W3C Team until
@@ -93,36 +141,66 @@ ${conf.isUnofficial ? html`
               appropriate review form for this document by
               consulting their list of current
               <a href='https://www.w3.org/2002/09/wbs/myQuestionnaires'>WBS questionnaires</a>.
-          ` : ""}
-          ${conf.isPR ? html`
+          `
+              : ""
+          }
+          ${
+            conf.isPR
+              ? html`
               The W3C Membership and other interested parties are invited to review the document and
               send comments to
-              <a rel='discussion' href='${`mailto:${conf.wgPublicList}@w3.org`}'>${conf.wgPublicList}@w3.org</a>
-              (<a href='${`mailto:${conf.wgPublicList}-request@w3.org?subject=subscribe`}'>subscribe</a>,
-              <a href='${`https://lists.w3.org/Archives/Public/${conf.wgPublicList}/`}'>archives</a>)
-              through ${conf.humanPREnd}. Advisory Committee Representatives should consult their
+              <a rel='discussion' href='${`mailto:${
+                conf.wgPublicList
+              }@w3.org`}'>${conf.wgPublicList}@w3.org</a>
+              (<a href='${`mailto:${
+                conf.wgPublicList
+              }-request@w3.org?subject=subscribe`}'>subscribe</a>,
+              <a href='${`https://lists.w3.org/Archives/Public/${
+                conf.wgPublicList
+              }/`}'>archives</a>)
+              through ${
+                conf.humanPREnd
+              }. Advisory Committee Representatives should consult their
               <a href='https://www.w3.org/2002/09/wbs/myQuestionnaires'>WBS questionnaires</a>.
               Note that substantive technical comments were expected during the Candidate Recommendation
               review period that ended ${conf.humanCREnd}.
-          ` : ""}
+          `
+              : ""
+          }
         </p>
-        ` : ""}
-        ${conf.implementationReportURI ? html`
+        `
+            : ""
+        }
+        ${
+          conf.implementationReportURI
+            ? html`
           <p>
-            Please see the Working Group's  <a href='${conf.implementationReportURI}'>implementation
+            Please see the Working Group's  <a href='${
+              conf.implementationReportURI
+            }'>implementation
             report</a>.
           </p>
-        ` : ""}
+        `
+            : ""
+        }
         ${conf.sotdAfterWGinfo ? [conf.additionalContent] : ""}
-        ${conf.notRec ? html`
+        ${
+          conf.notRec
+            ? html`
           <p>
-            Publication as ${conf.anOrA} ${conf.textStatus} does not imply endorsement by the W3C
+            Publication as ${conf.anOrA} ${
+                conf.textStatus
+              } does not imply endorsement by the W3C
             Membership. This is a draft document and may be updated, replaced or obsoleted by other
             documents at any time. It is inappropriate to cite this document as other than work in
             progress.
           </p>
-        ` : ""}
-        ${conf.isRec ? html`
+        `
+            : ""
+        }
+        ${
+          conf.isRec
+            ? html`
           <p>
             This document has been reviewed by W3C Members, by software developers, and by other W3C
             groups and interested parties, and is endorsed by the Director as a W3C Recommendation.
@@ -131,41 +209,73 @@ ${conf.isUnofficial ? html`
             specification and to promote its widespread deployment. This enhances the functionality
             and interoperability of the Web.
           </p>
-        ` : ""}
+        `
+            : ""
+        }
         <p data-deliverer="${conf.isNote ? conf.wgId : null}">
-          ${!conf.isIGNote ? html`
+          ${
+            !conf.isIGNote
+              ? html`
             This document was produced by
             ${conf.multipleWGs ? "groups" : "a group"}
             operating under the
             <a href='https://www.w3.org/Consortium/Patent-Policy/'>W3C Patent Policy</a>.
-          ` : ""}
-          ${conf.recNotExpected ? "The group does not expect this document to become a W3C Recommendation." : ""}
-          ${!conf.isIGNote ? html`
-            ${conf.multipleWGs ? html`W3C maintains ${[conf.wgPatentHTML]}` : html`
-              W3C maintains a <a href='${[conf.wgPatentURI]}' rel='disclosure'>public list of any patent
+          `
+              : ""
+          }
+          ${
+            conf.recNotExpected
+              ? "The group does not expect this document to become a W3C Recommendation."
+              : ""
+          }
+          ${
+            !conf.isIGNote
+              ? html`
+            ${
+              conf.multipleWGs
+                ? html`W3C maintains ${[conf.wgPatentHTML]}`
+                : html`
+              W3C maintains a <a href='${[
+                conf.wgPatentURI
+              ]}' rel='disclosure'>public list of any patent
               disclosures</a>
-            `}
+            `
+            }
             made in connection with the deliverables of
-            ${conf.multipleWGs ? "each group; these pages also include" : "the group; that page also includes"}
+            ${
+              conf.multipleWGs
+                ? "each group; these pages also include"
+                : "the group; that page also includes"
+            }
             instructions for disclosing a patent. An individual who has actual knowledge of a patent
             which the individual believes contains
             <a href='https://www.w3.org/Consortium/Patent-Policy/#def-essential'>Essential
             Claim(s)</a> must disclose the information in accordance with
             <a href='https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure'>section
             6 of the W3C Patent Policy</a>.
-          ` : ""}
-          ${conf.isIGNote ? html`
+          `
+              : ""
+          }
+          ${
+            conf.isIGNote
+              ? html`
             The disclosure obligations of the Participants of this group are described in the
             <a href='${conf.charterDisclosureURI}'>charter</a>.
-          ` : ""}
+          `
+              : ""
+          }
         </p>
         <p>This document is governed by the <a id="w3c_process_revision"
           href="https://www.w3.org/2018/Process-20180201/">1 February 2018 W3C Process Document</a>.
         </p>
         ${conf.addPatentNote ? html`<p>${[conf.addPatentNote]}</p>` : ""}
-      `}
-    `}
-  `}
-`}
+      `
+      }
+    `
+    }
+  `
+  }
+`
+  }
 ${[conf.additionalSections]}`;
-}
+};

--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -64,13 +64,13 @@ ${
             ? html`
           <p>
             By publishing this document, W3C acknowledges that
-            the <a href="https://www.w3.org/Submission/@@@submissiondoc@@@">Submitting Members</a>
+            the <a href="https://www.w3.org/Submission/${conf.processVersion}/SUBM-${conf.shortName}-${conf.publishHumanDate.getFullYear()}${conf.publishHumanDate.getMonth()}${conf.publishHumanDate.getDate()}/">Submitting Members</a>
             have made a formal Submission request to W3C for discussion. Publication of this document
             by W3C indicates no endorsement of its content by W3C, nor that W3C has, is, or will be
             allocating any resources to the issues addressed by it. This document is not the product
             of a chartered W3C group, but is published as potential input to
             the <a href="https://www.w3.org/Consortium/Process">W3C Process</a>.
-            A <a href="https://www.w3.org/Submission/@@@teamcomment@@@">W3C Team Comment</a> has been
+            A <a href="https://www.w3.org/Submission/${conf.processVersion}/<comment_no>/Comment/">W3C Team Comment</a> has been
             published in conjunction with this Member Submission. Publication of acknowledged Member Submissions
             at the W3C site is one of the benefits of <a href="https://www.w3.org/Consortium/Prospectus/Joining">
             W3C Membership</a>. Please consult the requirements associated with Member Submissions of

--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -50,7 +50,7 @@ ${conf.isUnofficial ? html`
             allocating any resources to the issues addressed by it. This document is not the product
             of a chartered W3C group, but is published as potential input to
             the <a href="https://www.w3.org/Consortium/Process">W3C Process</a>.
-            A <a href="https://www.w3.org/Submission/${conf.processVersion}/<comment_no>/Comment/">W3C Team Comment</a> has been
+            A <a href="https://www.w3.org/Submission/${conf.previousPublishDate.substr(0, 4)}/<comment_no>/Comment/">W3C Team Comment</a> has been
             published in conjunction with this Member Submission. Publication of acknowledged Member Submissions
             at the W3C site is one of the benefits of <a href="https://www.w3.org/Consortium/Prospectus/Joining">
             W3C Membership</a>. Please consult the requirements associated with Member Submissions of

--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -1,8 +1,13 @@
-import "deps/hyperhtml";
+define(["exports", "deps/hyperhtml"], function (exports) {
+  "use strict";
 
-export default conf => {
-  const html = hyperHTML;
-  return html`<h2>${conf.l10n.sotd}</h2>
+  Object.defineProperty(exports, "__esModule", {
+    value: true
+  });
+
+  exports.default = conf => {
+    const html = hyperHTML;
+    return html`<h2>${conf.l10n.sotd}</h2>
 ${conf.isPreview ? html`
   <details class="annoying-warning" open="">
     <summary>This is a preview</summary>
@@ -39,13 +44,13 @@ ${conf.isUnofficial ? html`
         ${conf.isMemberSubmission ? html`
           <p>
             By publishing this document, W3C acknowledges that
-            the <a href="https://www.w3.org/Submission/@@@submissiondoc@@@">Submitting Members</a>
+            the <a href="https://www.w3.org/Submission/">Submitting Members</a>
             have made a formal Submission request to W3C for discussion. Publication of this document
             by W3C indicates no endorsement of its content by W3C, nor that W3C has, is, or will be
             allocating any resources to the issues addressed by it. This document is not the product
             of a chartered W3C group, but is published as potential input to
             the <a href="https://www.w3.org/Consortium/Process">W3C Process</a>.
-            A <a href="https://www.w3.org/Submission/@@@teamcomment@@@">W3C Team Comment</a> has been
+            A <a href="https://www.w3.org/Submission/${conf.processVersion}/<comment_no>/Comment/">W3C Team Comment</a> has been
             published in conjunction with this Member Submission. Publication of acknowledged Member Submissions
             at the W3C site is one of the benefits of <a href="https://www.w3.org/Consortium/Prospectus/Joining">
             W3C Membership</a>. Please consult the requirements associated with Member Submissions of
@@ -53,17 +58,7 @@ ${conf.isUnofficial ? html`
             W3C Patent Policy</a>. Please consult the complete <a href="https://www.w3.org/Submission">list
             of acknowledged W3C Member Submissions</a>.
           </p>
-        ` : html`
-          ${conf.isTeamSubmission ? html`
-            <p>If you wish to make comments regarding this document, please send them to
-            <a href='${`mailto:${conf.wgPublicList}@w3.org${conf.subjectPrefix ? `?subject=${conf.subjectPrefixEnc}` : [""]}`}'>${conf.wgPublicList}@w3.org</a>
-            (<a href='${`mailto:${conf.wgPublicList}-request@w3.org?subject=subscribe`}'>subscribe</a>,
-            <a
-              href='${`https://lists.w3.org/Archives/Public/${conf.wgPublicList}/`}'>archives</a>)${conf.subjectPrefix ? html`
-              with <code>${conf.subjectPrefix}</code> at the start of your email's subject` : ""}.</p>
-            <p>Please consult the complete <a href="https://www.w3.org/TeamSubmission/">list of Team Submissions</a>.</p>
-          ` : ""}
-        `}
+        ` : ""}
       ` : html`
         ${!conf.sotdAfterWGinfo ? [conf.additionalContent] : ""}
         ${!conf.overrideStatus ? html`
@@ -168,4 +163,6 @@ ${conf.isUnofficial ? html`
   `}
 `}
 ${[conf.additionalSections]}`;
-}
+  };
+});
+//# sourceMappingURL=sotd.js.map

--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -74,7 +74,7 @@ ${
             the <a href="https://www.w3.org/Consortium/Process">W3C Process</a>.
             A <a href="${`https://www.w3.org/Submission/${conf.publishDate.getUTCFullYear()}/${
               conf.submissionCommentNumber
-            }/Comment/`}" id="comment">W3C Team Comment</a> has been
+            }/Comment/`}">W3C Team Comment</a> has been
             published in conjunction with this Member Submission. Publication of acknowledged Member Submissions
             at the W3C site is one of the benefits of <a href="https://www.w3.org/Consortium/Prospectus/Joining">
             W3C Membership</a>. Please consult the requirements associated with Member Submissions of

--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -240,7 +240,7 @@ ${
                 ? html`W3C maintains ${[conf.wgPatentHTML]}`
                 : html`
               W3C maintains a <a href='${[
-                conf.wgPatentURI
+                conf.wgPatentURI,
               ]}' rel='disclosure'>public list of any patent
               disclosures</a>
             `

--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -1,13 +1,8 @@
-define(["exports", "deps/hyperhtml"], function (exports) {
-  "use strict";
+import "deps/hyperhtml";
 
-  Object.defineProperty(exports, "__esModule", {
-    value: true
-  });
-
-  exports.default = conf => {
-    const html = hyperHTML;
-    return html`<h2>${conf.l10n.sotd}</h2>
+export default conf => {
+  const html = hyperHTML;
+  return html`<h2>${conf.l10n.sotd}</h2>
 ${conf.isPreview ? html`
   <details class="annoying-warning" open="">
     <summary>This is a preview</summary>
@@ -44,13 +39,13 @@ ${conf.isUnofficial ? html`
         ${conf.isMemberSubmission ? html`
           <p>
             By publishing this document, W3C acknowledges that
-            the <a href="https://www.w3.org/Submission/">Submitting Members</a>
+            the <a href="https://www.w3.org/Submission/@@@submissiondoc@@@">Submitting Members</a>
             have made a formal Submission request to W3C for discussion. Publication of this document
             by W3C indicates no endorsement of its content by W3C, nor that W3C has, is, or will be
             allocating any resources to the issues addressed by it. This document is not the product
             of a chartered W3C group, but is published as potential input to
             the <a href="https://www.w3.org/Consortium/Process">W3C Process</a>.
-            A <a href="https://www.w3.org/Submission/${conf.previousPublishDate.substr(0, 4)}/<comment_no>/Comment/">W3C Team Comment</a> has been
+            A <a href="https://www.w3.org/Submission/@@@teamcomment@@@">W3C Team Comment</a> has been
             published in conjunction with this Member Submission. Publication of acknowledged Member Submissions
             at the W3C site is one of the benefits of <a href="https://www.w3.org/Consortium/Prospectus/Joining">
             W3C Membership</a>. Please consult the requirements associated with Member Submissions of
@@ -58,7 +53,17 @@ ${conf.isUnofficial ? html`
             W3C Patent Policy</a>. Please consult the complete <a href="https://www.w3.org/Submission">list
             of acknowledged W3C Member Submissions</a>.
           </p>
-        ` : ""}
+        ` : html`
+          ${conf.isTeamSubmission ? html`
+            <p>If you wish to make comments regarding this document, please send them to
+            <a href='${`mailto:${conf.wgPublicList}@w3.org${conf.subjectPrefix ? `?subject=${conf.subjectPrefixEnc}` : [""]}`}'>${conf.wgPublicList}@w3.org</a>
+            (<a href='${`mailto:${conf.wgPublicList}-request@w3.org?subject=subscribe`}'>subscribe</a>,
+            <a
+              href='${`https://lists.w3.org/Archives/Public/${conf.wgPublicList}/`}'>archives</a>)${conf.subjectPrefix ? html`
+              with <code>${conf.subjectPrefix}</code> at the start of your email's subject` : ""}.</p>
+            <p>Please consult the complete <a href="https://www.w3.org/TeamSubmission/">list of Team Submissions</a>.</p>
+          ` : ""}
+        `}
       ` : html`
         ${!conf.sotdAfterWGinfo ? [conf.additionalContent] : ""}
         ${!conf.overrideStatus ? html`
@@ -163,6 +168,4 @@ ${conf.isUnofficial ? html`
   `}
 `}
 ${[conf.additionalSections]}`;
-  };
-});
-//# sourceMappingURL=sotd.js.map
+}

--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -64,13 +64,15 @@ ${
             ? html`
           <p>
             By publishing this document, W3C acknowledges that
-            the <a href="https://www.w3.org/Submission/${conf.processVersion}/SUBM-${conf.shortName}-${conf.publishHumanDate.getFullYear()}${conf.publishHumanDate.getMonth()}${conf.publishHumanDate.getDate()}/">Submitting Members</a>
+            the <a href="${conf.thisVersion}">Submitting Members</a>
             have made a formal Submission request to W3C for discussion. Publication of this document
             by W3C indicates no endorsement of its content by W3C, nor that W3C has, is, or will be
             allocating any resources to the issues addressed by it. This document is not the product
             of a chartered W3C group, but is published as potential input to
             the <a href="https://www.w3.org/Consortium/Process">W3C Process</a>.
-            A <a href="https://www.w3.org/Submission/${conf.processVersion}/<comment_no>/Comment/">W3C Team Comment</a> has been
+            A <a href="https://www.w3.org/Submission/${
+              conf.processVersion
+            }/<comment_no>/Comment/">W3C Team Comment</a> has been
             published in conjunction with this Member Submission. Publication of acknowledged Member Submissions
             at the W3C site is one of the benefits of <a href="https://www.w3.org/Consortium/Prospectus/Joining">
             W3C Membership</a>. Please consult the requirements associated with Member Submissions of

--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -63,16 +63,18 @@ ${
           conf.isMemberSubmission
             ? html`
           <p>
-            By publishing this document, W3C acknowledges that
-            the <a href="${conf.thisVersion}">Submitting Members</a>
+            By publishing this document, W3C acknowledges that <a href="${
+              conf.thisVersion
+            }">
+            the Submitting Members</a>
             have made a formal Submission request to W3C for discussion. Publication of this document
             by W3C indicates no endorsement of its content by W3C, nor that W3C has, is, or will be
             allocating any resources to the issues addressed by it. This document is not the product
             of a chartered W3C group, but is published as potential input to
             the <a href="https://www.w3.org/Consortium/Process">W3C Process</a>.
-            A <a href="https://www.w3.org/Submission/${
-              conf.processVersion
-            }/<comment_no>/Comment/">W3C Team Comment</a> has been
+            A <a href="${`https://www.w3.org/Submission/${conf.publishDate.getUTCFullYear()}/${
+              conf.submissionCommentNumber
+            }/Comment/`}">W3C Team Comment</a> has been
             published in conjunction with this Member Submission. Publication of acknowledged Member Submissions
             at the W3C site is one of the benefits of <a href="https://www.w3.org/Consortium/Prospectus/Joining">
             W3C Membership</a>. Please consult the requirements associated with Member Submissions of

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -1162,7 +1162,7 @@ describe("W3C — Headers", function() {
           url: "http://hyperlink/"
         },
         {
-          src: 'data:image/svg+xml,<svg%20xmlns="http://www.w3.org/2000/svg"/>',
+          src: "data:image/svg+xml,<svg%20xmlns=\"http://www.w3.org/2000/svg\"/>",
           alt: "this is an svg",
           height: 315,
           width: 961,

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -9,7 +9,7 @@ describe("W3C — Headers", function() {
     it("takes prevRecShortname and prevRecURI into account", async () => {
       const ops = makeStandardOps();
       const newProps = {
-        prevRecURI: "URI"
+        prevRecURI: "URI",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -24,7 +24,7 @@ describe("W3C — Headers", function() {
     it("takes specStatus into account", async () => {
       const ops = makeStandardOps();
       const newProps = {
-        specStatus: "ED"
+        specStatus: "ED",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -37,7 +37,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         specStatus: "REC",
-        shortName: "xxx"
+        shortName: "xxx",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -57,7 +57,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         specStatus: "REC",
-        shortName: "xxx"
+        shortName: "xxx",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -87,9 +87,9 @@ describe("W3C — Headers", function() {
             companyURL: "http://COMPANY",
             mailto: "EMAIL",
             note: "NOTE",
-            w3cid: "1234"
-          }
-        ]
+            w3cid: "1234",
+          },
+        ],
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -112,12 +112,12 @@ describe("W3C — Headers", function() {
         specStatus: "REC",
         editors: [
           {
-            name: "NAME1"
+            name: "NAME1",
           },
           {
-            name: "NAME2"
-          }
-        ]
+            name: "NAME2",
+          },
+        ],
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -139,25 +139,25 @@ describe("W3C — Headers", function() {
               {
                 name: "0000-0003-0782-2704",
                 href: "http://orcid.org/0000-0003-0782-2704",
-                class: "orcid"
+                class: "orcid",
               },
               {
                 name: "@ivan_herman",
                 href: "http://twitter.com/ivan_herman",
-                class: "twitter"
+                class: "twitter",
               },
               {
                 href: "http://not-valid-missing-name",
-                class: "invalid"
+                class: "invalid",
               },
               {
                 name: "\n\t  \n",
                 href: "http://empty-name",
-                class: "invalid"
-              }
-            ]
-          }
-        ]
+                class: "invalid",
+              },
+            ],
+          },
+        ],
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -189,7 +189,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         specStatus: "REC",
-        formerEditors: []
+        formerEditors: [],
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -213,9 +213,9 @@ describe("W3C — Headers", function() {
             company: "COMPANY",
             companyURL: "http://COMPANY",
             mailto: "EMAIL",
-            w3cid: "1234"
-          }
-        ]
+            w3cid: "1234",
+          },
+        ],
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -252,12 +252,12 @@ describe("W3C — Headers", function() {
         specStatus: "REC",
         formerEditors: [
           {
-            name: "NAME1"
+            name: "NAME1",
           },
           {
-            name: "NAME2"
-          }
-        ]
+            name: "NAME2",
+          },
+        ],
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -285,9 +285,9 @@ describe("W3C — Headers", function() {
         specStatus: "REC",
         authors: [
           {
-            name: "NAME1"
-          }
-        ]
+            name: "NAME1",
+          },
+        ],
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -303,12 +303,12 @@ describe("W3C — Headers", function() {
         specStatus: "REC",
         authors: [
           {
-            name: "NAME1"
+            name: "NAME1",
           },
           {
-            name: "NAME2"
-          }
-        ]
+            name: "NAME2",
+          },
+        ],
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -359,7 +359,7 @@ describe("W3C — Headers", function() {
     it("handles missing subtitle", async () => {
       const ops = makeStandardOps();
       const newProps = {
-        specStatus: "REC"
+        specStatus: "REC",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -391,7 +391,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       ops.body = "<h2 id='subtitle'><code>pass</code></h2>" + makeDefaultBody();
       const newProps = {
-        subtitle: "fail - this should have been overridden by the <h2>"
+        subtitle: "fail - this should have been overridden by the <h2>",
       };
       Object.assign(ops.config, newProps);
 
@@ -414,7 +414,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         specStatus: "REC",
-        subtitle: "pass"
+        subtitle: "pass",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -428,7 +428,7 @@ describe("W3C — Headers", function() {
     it("takes publishDate into account", async () => {
       const ops = makeStandardOps();
       const newProps = {
-        publishDate: "1977-03-15"
+        publishDate: "1977-03-15",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -451,7 +451,7 @@ describe("W3C — Headers", function() {
         previousPublishDate: "197-123131-15",
         crEnd: "bad date",
         prEnd: "next wednesday",
-        perEnd: "today"
+        perEnd: "today",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -471,7 +471,7 @@ describe("W3C — Headers", function() {
         specStatus: "REC",
         publishDate: "2017-03-15",
         previousPublishDate: "1977-03-15",
-        previousMaturity: "CR"
+        previousMaturity: "CR",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -488,7 +488,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         specStatus: "REC",
-        errata: "ERR"
+        errata: "ERR",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -501,7 +501,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         specStatus: "FPWD",
-        license: "w3c-software-doc"
+        license: "w3c-software-doc",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -522,9 +522,9 @@ describe("W3C — Headers", function() {
       alternateFormats: [
         {
           uri: "URI",
-          label: "LABEL"
-        }
-      ]
+          label: "LABEL",
+        },
+      ],
     };
     Object.assign(ops.config, newProps);
     const doc = await makeRSDoc(ops);
@@ -536,7 +536,7 @@ describe("W3C — Headers", function() {
     const ops = makeStandardOps();
     const newProps = {
       specStatus: "REC",
-      testSuiteURI: "URI"
+      testSuiteURI: "URI",
     };
     Object.assign(ops.config, newProps);
     const doc = await makeRSDoc(ops);
@@ -552,7 +552,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         specStatus: "REC",
-        implementationReportURI: "URI"
+        implementationReportURI: "URI",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -568,7 +568,7 @@ describe("W3C — Headers", function() {
     it("takes edDraftURI into account", async () => {
       const ops = makeStandardOps({
         specStatus: "WD",
-        edDraftURI: "URI"
+        edDraftURI: "URI",
       });
 
       const doc = await makeRSDoc(ops);
@@ -585,7 +585,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         specStatus: "ED",
-        prevED: "URI"
+        prevED: "URI",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -603,7 +603,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         specStatus: "REC",
-        additionalCopyrightHolders: "XXX"
+        additionalCopyrightHolders: "XXX",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -613,7 +613,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         specStatus: "unofficial",
-        additionalCopyrightHolders: "XXX"
+        additionalCopyrightHolders: "XXX",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -623,7 +623,7 @@ describe("W3C — Headers", function() {
     it("handles additionalCopyrightHolders when text is markup", async () => {
       const ops = makeStandardOps({
         specStatus: "REC",
-        additionalCopyrightHolders: "<span class='test'>XXX</span>"
+        additionalCopyrightHolders: "<span class='test'>XXX</span>",
       });
 
       const doc = await makeRSDoc(ops);
@@ -635,7 +635,7 @@ describe("W3C — Headers", function() {
     it("takes overrideCopyright into account", async () => {
       const ops = makeStandardOps();
       const newProps = {
-        overrideCopyright: "<p class='copyright2'>XXX</p>"
+        overrideCopyright: "<p class='copyright2'>XXX</p>",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -650,7 +650,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         publishDate: "2012-03-15",
-        copyrightStart: "1977"
+        copyrightStart: "1977",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -661,7 +661,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         publishDate: "2012-03-15",
-        copyrightStart: "2012"
+        copyrightStart: "2012",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -674,7 +674,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         wgPatentURI: "https://www.w3.org/pp-impl/123456/status",
-        specStatus: "WG-NOTE"
+        specStatus: "WG-NOTE",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops, () => {}, simpleSpecURL);
@@ -688,7 +688,7 @@ describe("W3C — Headers", function() {
     it("gracefully handles missing wgPatentURI", async () => {
       const ops = makeStandardOps();
       const newProps = {
-        specStatus: "FPWD-NOTE"
+        specStatus: "FPWD-NOTE",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops, () => {}, simpleSpecURL);
@@ -703,7 +703,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         wgPatentURI: "https://www.w3.org/pp-impl/123456/status",
-        specStatus: "WD"
+        specStatus: "WD",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops, () => {}, simpleSpecURL);
@@ -723,7 +723,7 @@ describe("W3C — Headers", function() {
         wgURI: "WGURI",
         wgPatentURI: "WGPATENT",
         wgPublicList: "WGLIST",
-        subjectPrefix: "[The Prefix]"
+        subjectPrefix: "[The Prefix]",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops, () => {}, simpleSpecURL);
@@ -752,7 +752,7 @@ describe("W3C — Headers", function() {
         wg: ["WGNAME1", "WGNAME2"],
         wgURI: ["WGURI1", "WGURI2"],
         wgPatentURI: ["WGPATENT1", "WGPATENT2"],
-        wgPublicList: "WGLIST"
+        wgPublicList: "WGLIST",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -800,7 +800,7 @@ describe("W3C — Headers", function() {
         wg: "WGNAME",
         wgURI: "WGURI",
         wgPublicList: "WGLIST",
-        subjectPrefix: "[The Prefix]"
+        subjectPrefix: "[The Prefix]",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -821,7 +821,7 @@ describe("W3C — Headers", function() {
         wgURI: "WGURI",
         wgPublicList: "WGLIST",
         subjectPrefix: "[The Prefix]",
-        implementationReportURI: ""
+        implementationReportURI: "",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops, () => {}, simpleSpecURL);
@@ -842,7 +842,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         specStatus: "IG-NOTE",
-        charterDisclosureURI: "URI"
+        charterDisclosureURI: "URI",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -854,7 +854,7 @@ describe("W3C — Headers", function() {
     it("takes addPatentNote into account", async () => {
       const ops = makeStandardOps();
       const newProps = {
-        addPatentNote: "<strong>PATENTNOTE</strong>"
+        addPatentNote: "<strong>PATENTNOTE</strong>",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -870,7 +870,7 @@ describe("W3C — Headers", function() {
         wg: "WGNAME",
         wgURI: "http://WG",
         wgPublicList: "WGLIST",
-        subjectPrefix: "[The Prefix]"
+        subjectPrefix: "[The Prefix]",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -909,7 +909,7 @@ describe("W3C — Headers", function() {
         wg: "WGNAME",
         wgURI: "http://WG",
         thisVersion: "http://THIS",
-        latestVersion: "http://LATEST"
+        latestVersion: "http://LATEST",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -991,7 +991,7 @@ describe("W3C — Headers", function() {
         wg: "WGNAME",
         wgURI: "WGURI",
         wgPatentURI: "WGPATENT",
-        wgPublicList: "WGLIST"
+        wgPublicList: "WGLIST",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops, () => {}, simpleSpecURL);
@@ -1081,7 +1081,7 @@ describe("W3C — Headers", function() {
       );
     };
     const cgOpts = Object.assign({}, ops, {
-      config: { specStatus: "CG-DRAFT" }
+      config: { specStatus: "CG-DRAFT" },
     });
     // Test regular spec using "stod.html"
     theTest(await makeRSDoc(ops));
@@ -1092,7 +1092,7 @@ describe("W3C — Headers", function() {
     const ops = makeStandardOps();
     const newProps = {
       specStatus: "REC",
-      shortName: "PASS"
+      shortName: "PASS",
     };
     Object.assign(ops.config, newProps);
     const doc = await makeRSDoc(ops);
@@ -1110,7 +1110,7 @@ describe("W3C — Headers", function() {
     const ops = makeStandardOps();
     const newProps = {
       specStatus: "CR",
-      shortName: "FAIL"
+      shortName: "FAIL",
     };
     Object.assign(ops.config, newProps);
     const doc = await makeRSDoc(ops);
@@ -1124,7 +1124,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         isPreview: true,
-        shortName: "whatever"
+        shortName: "whatever",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -1139,7 +1139,7 @@ describe("W3C — Headers", function() {
     const newProps = {
       noRecTrack: true,
       specStatus: "WD",
-      recNotExpected: true
+      recNotExpected: true,
     };
     Object.assign(ops.config, newProps);
     const doc = await makeRSDoc(ops);
@@ -1159,14 +1159,14 @@ describe("W3C — Headers", function() {
           alt: "this is a small gif",
           height: 765,
           width: 346,
-          url: "http://hyperlink/"
+          url: "http://hyperlink/",
         },
         {
-          src: "data:image/svg+xml,<svg%20xmlns=\"http://www.w3.org/2000/svg\"/>",
+          src: 'data:image/svg+xml,<svg%20xmlns="http://www.w3.org/2000/svg"/>',
           alt: "this is an svg",
           height: 315,
           width: 961,
-          url: "http://prod/"
+          url: "http://prod/",
         },
         {
           src:
@@ -1174,8 +1174,8 @@ describe("W3C — Headers", function() {
           alt: "this is a larger gif",
           height: 876,
           width: 283,
-          url: "http://shiny/"
-        }
+          url: "http://shiny/",
+        },
       ];
       Object.assign(ops.config, { logos });
       const doc = await makeRSDoc(ops);

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -967,32 +967,6 @@ describe("W3C — Headers", function() {
     });
   });
 
-  describe("Team-SUBM", () => {
-    let doc;
-    beforeAll(async () => {
-      const ops = makeStandardOps();
-      const newProps = {
-        specStatus: "Team-SUBM",
-      };
-      Object.assign(ops.config, newProps);
-      doc = await makeRSDoc(ops);
-    });
-    it("shouldn't expose a Previous version link for Team submissions", async () => {
-      expect($("dt:contains('Previous version:')", doc).length).toEqual(0);
-    });
-    it("displays the Team Submission logo for Team submissions", async () => {
-      const img = doc.querySelector(
-        ".head img[src^='https://www.w3.org/Icons/team_subm']"
-      );
-      expect(img).toBeTruthy();
-    });
-    it("uses the right SoTD boilerplate for Team submissions", async () => {
-      const link = doc.querySelector(
-        "#sotd a[href='https://www.w3.org/TeamSubmission/']"
-      );
-      expect(link).toBeTruthy();
-    });
-  });
   describe("statusOverride", () => {
     it("allows status paragraph to be overridden", async () => {
       const ops = makeStandardOps();

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -1162,7 +1162,7 @@ describe("W3C — Headers", function() {
           url: "http://hyperlink/",
         },
         {
-          src: 'data:image/svg+xml,<svg%20xmlns="http://www.w3.org/2000/svg"/>',
+          src: "data:image/svg+xml,<svg%20xmlns=\"http://www.w3.org/2000/svg\"/>",
           alt: "this is an svg",
           height: 315,
           width: 961,

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -9,7 +9,7 @@ describe("W3C — Headers", function() {
     it("takes prevRecShortname and prevRecURI into account", async () => {
       const ops = makeStandardOps();
       const newProps = {
-        prevRecURI: "URI",
+        prevRecURI: "URI"
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -24,7 +24,7 @@ describe("W3C — Headers", function() {
     it("takes specStatus into account", async () => {
       const ops = makeStandardOps();
       const newProps = {
-        specStatus: "ED",
+        specStatus: "ED"
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -37,7 +37,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         specStatus: "REC",
-        shortName: "xxx",
+        shortName: "xxx"
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -57,7 +57,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         specStatus: "REC",
-        shortName: "xxx",
+        shortName: "xxx"
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -87,9 +87,9 @@ describe("W3C — Headers", function() {
             companyURL: "http://COMPANY",
             mailto: "EMAIL",
             note: "NOTE",
-            w3cid: "1234",
-          },
-        ],
+            w3cid: "1234"
+          }
+        ]
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -112,12 +112,12 @@ describe("W3C — Headers", function() {
         specStatus: "REC",
         editors: [
           {
-            name: "NAME1",
+            name: "NAME1"
           },
           {
-            name: "NAME2",
-          },
-        ],
+            name: "NAME2"
+          }
+        ]
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -139,25 +139,25 @@ describe("W3C — Headers", function() {
               {
                 name: "0000-0003-0782-2704",
                 href: "http://orcid.org/0000-0003-0782-2704",
-                class: "orcid",
+                class: "orcid"
               },
               {
                 name: "@ivan_herman",
                 href: "http://twitter.com/ivan_herman",
-                class: "twitter",
+                class: "twitter"
               },
               {
                 href: "http://not-valid-missing-name",
-                class: "invalid",
+                class: "invalid"
               },
               {
                 name: "\n\t  \n",
                 href: "http://empty-name",
-                class: "invalid",
-              },
-            ],
-          },
-        ],
+                class: "invalid"
+              }
+            ]
+          }
+        ]
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -189,7 +189,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         specStatus: "REC",
-        formerEditors: [],
+        formerEditors: []
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -213,9 +213,9 @@ describe("W3C — Headers", function() {
             company: "COMPANY",
             companyURL: "http://COMPANY",
             mailto: "EMAIL",
-            w3cid: "1234",
-          },
-        ],
+            w3cid: "1234"
+          }
+        ]
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -252,12 +252,12 @@ describe("W3C — Headers", function() {
         specStatus: "REC",
         formerEditors: [
           {
-            name: "NAME1",
+            name: "NAME1"
           },
           {
-            name: "NAME2",
-          },
-        ],
+            name: "NAME2"
+          }
+        ]
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -285,9 +285,9 @@ describe("W3C — Headers", function() {
         specStatus: "REC",
         authors: [
           {
-            name: "NAME1",
-          },
-        ],
+            name: "NAME1"
+          }
+        ]
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -303,12 +303,12 @@ describe("W3C — Headers", function() {
         specStatus: "REC",
         authors: [
           {
-            name: "NAME1",
+            name: "NAME1"
           },
           {
-            name: "NAME2",
-          },
-        ],
+            name: "NAME2"
+          }
+        ]
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -322,7 +322,8 @@ describe("W3C — Headers", function() {
 
   describe("use existing h1 element", () => {
     it("uses the <h1>'s value as the document's title", async () => {
-      const body = `
+      const body =
+        `
         <h1 id='title'>
           This should be <code>pass</code>.
          </h1>` + makeDefaultBody();
@@ -358,7 +359,7 @@ describe("W3C — Headers", function() {
     it("handles missing subtitle", async () => {
       const ops = makeStandardOps();
       const newProps = {
-        specStatus: "REC",
+        specStatus: "REC"
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -390,7 +391,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       ops.body = "<h2 id='subtitle'><code>pass</code></h2>" + makeDefaultBody();
       const newProps = {
-        subtitle: "fail - this should have been overridden by the <h2>",
+        subtitle: "fail - this should have been overridden by the <h2>"
       };
       Object.assign(ops.config, newProps);
 
@@ -413,7 +414,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         specStatus: "REC",
-        subtitle: "pass",
+        subtitle: "pass"
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -427,7 +428,7 @@ describe("W3C — Headers", function() {
     it("takes publishDate into account", async () => {
       const ops = makeStandardOps();
       const newProps = {
-        publishDate: "1977-03-15",
+        publishDate: "1977-03-15"
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -450,7 +451,7 @@ describe("W3C — Headers", function() {
         previousPublishDate: "197-123131-15",
         crEnd: "bad date",
         prEnd: "next wednesday",
-        perEnd: "today",
+        perEnd: "today"
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -470,7 +471,7 @@ describe("W3C — Headers", function() {
         specStatus: "REC",
         publishDate: "2017-03-15",
         previousPublishDate: "1977-03-15",
-        previousMaturity: "CR",
+        previousMaturity: "CR"
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -487,7 +488,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         specStatus: "REC",
-        errata: "ERR",
+        errata: "ERR"
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -500,7 +501,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         specStatus: "FPWD",
-        license: "w3c-software-doc",
+        license: "w3c-software-doc"
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -521,9 +522,9 @@ describe("W3C — Headers", function() {
       alternateFormats: [
         {
           uri: "URI",
-          label: "LABEL",
-        },
-      ],
+          label: "LABEL"
+        }
+      ]
     };
     Object.assign(ops.config, newProps);
     const doc = await makeRSDoc(ops);
@@ -535,7 +536,7 @@ describe("W3C — Headers", function() {
     const ops = makeStandardOps();
     const newProps = {
       specStatus: "REC",
-      testSuiteURI: "URI",
+      testSuiteURI: "URI"
     };
     Object.assign(ops.config, newProps);
     const doc = await makeRSDoc(ops);
@@ -551,7 +552,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         specStatus: "REC",
-        implementationReportURI: "URI",
+        implementationReportURI: "URI"
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -567,9 +568,9 @@ describe("W3C — Headers", function() {
     it("takes edDraftURI into account", async () => {
       const ops = makeStandardOps({
         specStatus: "WD",
-        edDraftURI: "URI",
+        edDraftURI: "URI"
       });
-      
+
       const doc = await makeRSDoc(ops);
       expect(
         $("dt:contains('Latest editor\\'s draft:')", doc)
@@ -584,7 +585,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         specStatus: "ED",
-        prevED: "URI",
+        prevED: "URI"
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -602,7 +603,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         specStatus: "REC",
-        additionalCopyrightHolders: "XXX",
+        additionalCopyrightHolders: "XXX"
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -612,7 +613,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         specStatus: "unofficial",
-        additionalCopyrightHolders: "XXX",
+        additionalCopyrightHolders: "XXX"
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -622,9 +623,9 @@ describe("W3C — Headers", function() {
     it("handles additionalCopyrightHolders when text is markup", async () => {
       const ops = makeStandardOps({
         specStatus: "REC",
-        additionalCopyrightHolders: "<span class='test'>XXX</span>",
+        additionalCopyrightHolders: "<span class='test'>XXX</span>"
       });
-      
+
       const doc = await makeRSDoc(ops);
       expect($(".head .copyright .test", doc).text()).toEqual("XXX");
     });
@@ -634,7 +635,7 @@ describe("W3C — Headers", function() {
     it("takes overrideCopyright into account", async () => {
       const ops = makeStandardOps();
       const newProps = {
-        overrideCopyright: "<p class='copyright2'>XXX</p>",
+        overrideCopyright: "<p class='copyright2'>XXX</p>"
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -649,7 +650,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         publishDate: "2012-03-15",
-        copyrightStart: "1977",
+        copyrightStart: "1977"
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -660,7 +661,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         publishDate: "2012-03-15",
-        copyrightStart: "2012",
+        copyrightStart: "2012"
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -673,7 +674,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         wgPatentURI: "https://www.w3.org/pp-impl/123456/status",
-        specStatus: "WG-NOTE",
+        specStatus: "WG-NOTE"
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops, () => {}, simpleSpecURL);
@@ -687,7 +688,7 @@ describe("W3C — Headers", function() {
     it("gracefully handles missing wgPatentURI", async () => {
       const ops = makeStandardOps();
       const newProps = {
-        specStatus: "FPWD-NOTE",
+        specStatus: "FPWD-NOTE"
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops, () => {}, simpleSpecURL);
@@ -702,7 +703,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         wgPatentURI: "https://www.w3.org/pp-impl/123456/status",
-        specStatus: "WD",
+        specStatus: "WD"
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops, () => {}, simpleSpecURL);
@@ -722,7 +723,7 @@ describe("W3C — Headers", function() {
         wgURI: "WGURI",
         wgPatentURI: "WGPATENT",
         wgPublicList: "WGLIST",
-        subjectPrefix: "[The Prefix]",
+        subjectPrefix: "[The Prefix]"
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops, () => {}, simpleSpecURL);
@@ -751,7 +752,7 @@ describe("W3C — Headers", function() {
         wg: ["WGNAME1", "WGNAME2"],
         wgURI: ["WGURI1", "WGURI2"],
         wgPatentURI: ["WGPATENT1", "WGPATENT2"],
-        wgPublicList: "WGLIST",
+        wgPublicList: "WGLIST"
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -799,7 +800,7 @@ describe("W3C — Headers", function() {
         wg: "WGNAME",
         wgURI: "WGURI",
         wgPublicList: "WGLIST",
-        subjectPrefix: "[The Prefix]",
+        subjectPrefix: "[The Prefix]"
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -820,7 +821,7 @@ describe("W3C — Headers", function() {
         wgURI: "WGURI",
         wgPublicList: "WGLIST",
         subjectPrefix: "[The Prefix]",
-        implementationReportURI: "",
+        implementationReportURI: ""
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops, () => {}, simpleSpecURL);
@@ -841,7 +842,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         specStatus: "IG-NOTE",
-        charterDisclosureURI: "URI",
+        charterDisclosureURI: "URI"
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -853,7 +854,7 @@ describe("W3C — Headers", function() {
     it("takes addPatentNote into account", async () => {
       const ops = makeStandardOps();
       const newProps = {
-        addPatentNote: "<strong>PATENTNOTE</strong>",
+        addPatentNote: "<strong>PATENTNOTE</strong>"
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -869,7 +870,7 @@ describe("W3C — Headers", function() {
         wg: "WGNAME",
         wgURI: "http://WG",
         wgPublicList: "WGLIST",
-        subjectPrefix: "[The Prefix]",
+        subjectPrefix: "[The Prefix]"
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -908,7 +909,7 @@ describe("W3C — Headers", function() {
         wg: "WGNAME",
         wgURI: "http://WG",
         thisVersion: "http://THIS",
-        latestVersion: "http://LATEST",
+        latestVersion: "http://LATEST"
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -946,6 +947,9 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         specStatus: "Member-SUBM",
+        submissionCommentNumber: "01",
+        publishDate: "2018-05-25",
+        shortName: "yolo",
       };
       Object.assign(ops.config, newProps);
       doc = await makeRSDoc(ops);
@@ -965,6 +969,18 @@ describe("W3C — Headers", function() {
         "the Submitting Members have made a formal Submission request";
       expect(stod).toMatch(testString);
     });
+    it("links the right submitting members", async () => {
+      const anchor = doc.querySelector(
+        "#sotd a[href='https://www.w3.org/Submission/2018/Member-SUBM-yolo-20180525/']"
+      );
+      expect(anchor).toBeTruthy();
+    });
+    it("shows the correct staff comments", async () => {
+      const anchor = doc.querySelector(
+        "#sotd a[href='https://www.w3.org/Submission/2018/01/Comment/']"
+      );
+      expect(anchor).toBeTruthy();
+    });
   });
 
   describe("statusOverride", () => {
@@ -975,7 +991,7 @@ describe("W3C — Headers", function() {
         wg: "WGNAME",
         wgURI: "WGURI",
         wgPatentURI: "WGPATENT",
-        wgPublicList: "WGLIST",
+        wgPublicList: "WGLIST"
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops, () => {}, simpleSpecURL);
@@ -1065,7 +1081,7 @@ describe("W3C — Headers", function() {
       );
     };
     const cgOpts = Object.assign({}, ops, {
-      config: { specStatus: "CG-DRAFT" },
+      config: { specStatus: "CG-DRAFT" }
     });
     // Test regular spec using "stod.html"
     theTest(await makeRSDoc(ops));
@@ -1076,7 +1092,7 @@ describe("W3C — Headers", function() {
     const ops = makeStandardOps();
     const newProps = {
       specStatus: "REC",
-      shortName: "PASS",
+      shortName: "PASS"
     };
     Object.assign(ops.config, newProps);
     const doc = await makeRSDoc(ops);
@@ -1094,7 +1110,7 @@ describe("W3C — Headers", function() {
     const ops = makeStandardOps();
     const newProps = {
       specStatus: "CR",
-      shortName: "FAIL",
+      shortName: "FAIL"
     };
     Object.assign(ops.config, newProps);
     const doc = await makeRSDoc(ops);
@@ -1108,7 +1124,7 @@ describe("W3C — Headers", function() {
       const ops = makeStandardOps();
       const newProps = {
         isPreview: true,
-        shortName: "whatever",
+        shortName: "whatever"
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -1123,7 +1139,7 @@ describe("W3C — Headers", function() {
     const newProps = {
       noRecTrack: true,
       specStatus: "WD",
-      recNotExpected: true,
+      recNotExpected: true
     };
     Object.assign(ops.config, newProps);
     const doc = await makeRSDoc(ops);
@@ -1143,14 +1159,14 @@ describe("W3C — Headers", function() {
           alt: "this is a small gif",
           height: 765,
           width: 346,
-          url: "http://hyperlink/",
+          url: "http://hyperlink/"
         },
         {
-          src: "data:image/svg+xml,<svg%20xmlns=\"http://www.w3.org/2000/svg\"/>",
+          src: 'data:image/svg+xml,<svg%20xmlns="http://www.w3.org/2000/svg"/>',
           alt: "this is an svg",
           height: 315,
           width: 961,
-          url: "http://prod/",
+          url: "http://prod/"
         },
         {
           src:
@@ -1158,8 +1174,8 @@ describe("W3C — Headers", function() {
           alt: "this is a larger gif",
           height: 876,
           width: 283,
-          url: "http://shiny/",
-        },
+          url: "http://shiny/"
+        }
       ];
       Object.assign(ops.config, { logos });
       const doc = await makeRSDoc(ops);


### PR DESCRIPTION
Fixes #1494 .
The url for team submission comment requires the submission year (not the published year) along with the comment number (serial no of what comment it was in that year).  Idk how to get the comment number.