### PR TITLE
fix: restore whitespace between status and date

### DIFF
--- a/src/w3c/templates/headers.js
+++ b/src/w3c/templates/headers.js
@@ -47,7 +47,7 @@ export default conf => {
   ${conf.logos.map(showLogo)}
   ${getSpecTitleElem(conf)}
   ${getSpecSubTitleElem(conf)}
-  <h2>${conf.prependW3C ? "W3C " : ""}${conf.textStatus}<time class='dt-published' datetime='${conf.dashDate}'>${conf.publishHumanDate}</time></h2>
+  <h2>${conf.prependW3C ? "W3C " : ""}${conf.textStatus} <time class='dt-published' datetime='${conf.dashDate}'>${conf.publishHumanDate}</time></h2>
   <dl>
     ${!conf.isNoTrack ? html`
       <dt>${conf.l10n.this_version}</dt>


### PR DESCRIPTION
That [commit](https://github.com/w3c/respec/commit/a5e552c054d0f4994514b71f7d4ae5e5e6fb311b#diff-ebb1a497c097951bb868645bd73ade4f) broke the expected header.

Fix #1590 