### PR TITLE
fix(core/webidl): dont warn about nameless ops

### DIFF
--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -1005,6 +1005,7 @@ function findDfn(parent, name, definitionMap, type, idlElem) {
     const showWarnings =
       type &&
       idlElem &&
+      name &&
       idlElem.classList.contains("no-link-warnings") === false;
     if (showWarnings) {
       var msg = `No \`<dfn>\` for ${type} \`${originalName}\`${originalParent


### PR DESCRIPTION
Some operations in WebIDL can be annoynous (e.g., strigifiers), so we shoulnd't warn about the when they have no name.

For example: 

```
interface Selection {
   stringifier DOMString ();
}
```