### PR TITLE
refactor(core/utils): use value instead of getter

### DIFF
--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -451,7 +451,7 @@ export function runTransforms(content, flist) {
 class NetworkError extends Error {
   constructor(message, response) {
     super(message);
-    Object.defineProperty(this, "response", { get() { return response; } });
+    Object.defineProperty(this, "response", { value: response });
   }
 }
 


### PR DESCRIPTION
It's a constant value so we can use `value` instead.