### PR TITLE
fix(core/base-runner): extend plugin life

### DIFF
--- a/src/core/base-runner.js
+++ b/src/core/base-runner.js
@@ -22,7 +22,7 @@ function toRunnable(plug) {
         const msg = `Plugin ${name} took too long.`;
         console.error(msg, plug);
         reject(new Error(msg));
-      }, 5000);
+      }, 15000);
       if (canMeasure) {
         performance.mark(name + "-start");
       }


### PR DESCRIPTION
wpub loads a lot of stuff, so the issues and notes plugin can time out. 