### PR TITLE
feat(core/images): add natural width and height to images(#923)

### DIFF
--- a/src/core/figures.js
+++ b/src/core/figures.js
@@ -60,7 +60,10 @@ export function run(conf, doc, cb) {
       .prepend(doc.createTextNode(conf.l10n.fig));
     figMap[id] = $cap.contents();
     var $tofCap = $cap.clone();
-    $tofCap.find("a").renameElement("span").removeAttr("href");
+    $tofCap
+      .find("a")
+      .renameElement("span")
+      .removeAttr("href");
     tof.push(
       $("<li class='tofline'><a class='tocxref' href='#" + id + "'></a></li>")
         .find(".tocxref")
@@ -79,8 +82,11 @@ export function run(conf, doc, cb) {
       $a.addClass("fig-ref");
       if ($a.html() === "") {
         const $shortFigDescriptor = figMap[id].slice(0, 2).clone();
-        if(!$a[0].hasAttribute("title")) {
-          const longFigDescriptor = figMap[id].slice(2).clone().text();
+        if (!$a[0].hasAttribute("title")) {
+          const longFigDescriptor = figMap[id]
+            .slice(2)
+            .clone()
+            .text();
           $a.attr("title", longFigDescriptor.trim());
         }
         $a.append($shortFigDescriptor);
@@ -118,9 +124,12 @@ export function run(conf, doc, cb) {
 }
 
 function normalizeImages(doc) {
-  [...doc.querySelectorAll(":not(picture)>img:not([width]):not([height]):not([srcset])")]
-    .forEach(img => {
-      img.height = img.naturalHeight;
-      img.width = img.naturalWidth;
-    });
+  [
+    ...doc.querySelectorAll(
+      ":not(picture)>img:not([width]):not([height]):not([srcset])"
+    ),
+  ].forEach(img => {
+    img.height = img.naturalHeight;
+    img.width = img.naturalWidth;
+  });
 }

--- a/src/core/figures.js
+++ b/src/core/figures.js
@@ -10,6 +10,7 @@ import { pub } from "core/pubsubhub";
 export const name = "core/figures";
 
 export function run(conf, doc, cb) {
+  normalizeImages(doc);
   // Move old syntax to new syntax
   $(".figure", doc).each(function(i, figure) {
     var $figure = $(figure),
@@ -114,4 +115,12 @@ export function run(conf, doc, cb) {
     while (tof.length) $ul.append(tof.shift());
   }
   cb();
+}
+
+function normalizeImages(doc) {
+  [...doc.querySelectorAll(":not(picture)>img:not([width]):not([height]):not([srcset])")]
+    .forEach(img => {
+      img.height = img.naturalHeight;
+      img.width = img.naturalWidth;
+    });
 }

--- a/tests/spec/core/figures-spec.js
+++ b/tests/spec/core/figures-spec.js
@@ -81,4 +81,73 @@ describe("Core - Figures", function() {
     expect(figLinks.item(0).textContent).toEqual("Figure 1 PREFIG");
     expect(figLinks.item(1).textContent).toEqual("Figure 2 IMGTIT");
   });
+
+
+  describe("normalize images", () => {
+    const imgDataURL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAADCAIAAADUVFKvAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4gQKACEWdS72PwAAABl0RVh0Q29tbWVudABDcmVhdGVkIHdpdGggR0lNUFeBDhcAAAAMSURBVAjXY2AgDQAAADAAAceqhY4AAAAASUVORK5CYII=";
+    const ops = {
+      config: makeBasicConfig(),
+      body:
+        `<section>
+         <img id="image-with-no-dimensions" src="${imgDataURL}">
+         <img id="image-with-dimensions" height=100 width=200 src="${imgDataURL}">
+         <img id="image-with-height-only" height=100 src="${imgDataURL}">
+         <img id="image-with-width-only" width=200 src="${imgDataURL}">
+         <img id="image-with-srcset" srcset="${imgDataURL}">
+         <picture>
+          <img id="image-inside-picture" src="${imgDataURL}">
+         </picture>
+      </section>`
+    };
+
+    let doc;
+    beforeAll(async () => {
+      doc = await makeRSDoc(ops);
+    });
+
+    it("sets height and width for images with no height and width", async () => {
+      const image = doc.getElementById("image-with-no-dimensions");
+      expect(image).toBeTruthy();
+      expect(image.hasAttribute("height")).toBeTruthy();
+      expect(image.hasAttribute("width")).toBeTruthy();
+      expect(image.height).toBe(3);
+      expect(image.width).toBe(5);
+    });
+    it("doesn't change height and width for images with both height and width", async () => {
+      const image = doc.getElementById("image-with-dimensions");
+      expect(image).toBeTruthy();
+      expect(image.hasAttribute("height")).toBeTruthy();
+      expect(image.hasAttribute("width")).toBeTruthy();
+      expect(image.height).toBe(100);
+      expect(image.width).toBe(200);
+    });
+    it("doesn't change height and width for images with height only", async () => {
+      const image = doc.getElementById("image-with-height-only");
+      expect(image).toBeTruthy();
+      expect(image.hasAttribute("height")).toBeTruthy();
+      expect(image.hasAttribute("width")).toBeFalsy();
+      expect(image.height).toBe(100);
+    });
+    it("doesn't change height and width for images with width only", async () => {
+      const image = doc.getElementById("image-with-width-only");
+      expect(image).toBeTruthy();
+      expect(image.hasAttribute("height")).toBeFalsy();
+      expect(image.hasAttribute("width")).toBeTruthy();
+      expect(image.width).toBe(200);
+    });
+    it("doesn't change height and width for images with srcset", async () => {
+      const image = doc.getElementById("image-with-srcset");
+      expect(image).toBeTruthy();
+      expect(image.hasAttribute("srcset")).toBeTruthy();
+      expect(image.hasAttribute("height")).toBeFalsy();
+      expect(image.hasAttribute("width")).toBeFalsy();
+      expect(image.srcset).toBe(imgDataURL);
+    });
+    it("doesn't change height and width for images inside picture", async () => {
+      const image = doc.getElementById("image-inside-picture");
+      expect(image).toBeTruthy();
+      expect(image.hasAttribute("height")).toBeFalsy();
+      expect(image.hasAttribute("width")).toBeFalsy();
+    });
+  });
 });

--- a/tests/spec/core/figures-spec.js
+++ b/tests/spec/core/figures-spec.js
@@ -27,13 +27,13 @@ describe("Core - Figures", function() {
     const ops = {
       config: makeBasicConfig(),
       body:
-      makeDefaultBody() +
-      `<figure id='fig'> <img src='img' alt=''>
+        makeDefaultBody() +
+        `<figure id='fig'> <img src='img' alt=''>
         <figcaption>test figure caption</figcaption>
        </figure>
        <a id='anchor-fig-title-empty' title='' href='#fig'></a>
        <a id='anchor-fig-title-set' title='pass' href='#fig'></a>
-       <a id='anchor-fig' href='#fig'></a>`
+       <a id='anchor-fig' href='#fig'></a>`,
     };
     const doc = await makeRSDoc(ops);
     const anchorFig = doc.getElementById("anchor-fig");
@@ -57,11 +57,11 @@ describe("Core - Figures", function() {
         lang: "ja",
       },
       body:
-      makeDefaultBody() +
-      `<figure id='fig'> <img src='img' alt=''>
+        makeDefaultBody() +
+        `<figure id='fig'> <img src='img' alt=''>
         <figcaption>漢字と仮名のサイズの示し方</figcaption>
        </figure>
-       <a id='anchor-fig' href='#fig'></a>`
+       <a id='anchor-fig' href='#fig'></a>`,
     };
     const doc = await makeRSDoc(ops);
     const anchorFig = doc.getElementById("anchor-fig");
@@ -82,13 +82,12 @@ describe("Core - Figures", function() {
     expect(figLinks.item(1).textContent).toEqual("Figure 2 IMGTIT");
   });
 
-
   describe("normalize images", () => {
-    const imgDataURL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAADCAIAAADUVFKvAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4gQKACEWdS72PwAAABl0RVh0Q29tbWVudABDcmVhdGVkIHdpdGggR0lNUFeBDhcAAAAMSURBVAjXY2AgDQAAADAAAceqhY4AAAAASUVORK5CYII=";
+    const imgDataURL =
+      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAADCAIAAADUVFKvAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4gQKACEWdS72PwAAABl0RVh0Q29tbWVudABDcmVhdGVkIHdpdGggR0lNUFeBDhcAAAAMSURBVAjXY2AgDQAAADAAAceqhY4AAAAASUVORK5CYII=";
     const ops = {
       config: makeBasicConfig(),
-      body:
-        `<section>
+      body: `<section>
          <img id="image-with-no-dimensions" src="${imgDataURL}">
          <img id="image-with-dimensions" height=100 width=200 src="${imgDataURL}">
          <img id="image-with-height-only" height=100 src="${imgDataURL}">
@@ -97,7 +96,7 @@ describe("Core - Figures", function() {
          <picture>
           <img id="image-inside-picture" src="${imgDataURL}">
          </picture>
-      </section>`
+      </section>`,
     };
 
     let doc;


### PR DESCRIPTION
fixes: #923 

@marcoscaceres, I decided to create a new module name `core/images` as I think the code fits into no other existing modules. I may be wrong though