### PR TITLE
feat: support personal github tokens for testing

### DIFF
--- a/src/core/contrib.js
+++ b/src/core/contrib.js
@@ -4,93 +4,80 @@
 // #gh-commenters: people having contributed comments to issues.
 // #gh-contributors: people whose PR have been merged.
 // Spec editors get filtered out automatically.
-
-import { fetch as ghFetch, fetchIndex } from "core/github";
+import { fetchIndex } from "core/github";
 import { pub } from "core/pubsubhub";
+import { joinAnd } from "core/utils";
 export const name = "core/contrib";
 
 function prop(prop) {
   return o => o[prop];
 }
+const nameProp = prop("name");
+const urlProp = prop("url");
 
-function findUsers(...thingsToFind) {
-  const users = new Set();
-  for (const things of thingsToFind) {
-    for (const thing of things) {
-      if (thing.user) {
-        users.add(thing.user.url);
-      }
-    }
-  }
-  return [...users];
-}
-
-function join(things) {
-  if (!things.length) {
-    return "";
-  }
-  const { length } = things;
-  const last = things[length - 1];
-  switch (length) {
-    case 1:
-      return last;
-    case 2:
-      return `${things[0]} and ${last}`;
-    default:
-      return `${things.join(", ")}, and ${last}`;
-  }
+function findUserURLs(...thingsWithUsers) {
+  const usersURLs = thingsWithUsers
+    .reduce((arr, things) => arr.concat(...things), [])
+    .filter(thing => thing && thing.user)
+    .map(({ user }) => user.url);
+  return [...new Set(usersURLs)];
 }
 
 async function toHTML(urls, editors, element) {
-  const args = await Promise.all(urls.map(ghFetch));
+  const args = await Promise.all(urls.map(fetch));
   const names = args
     .map(([user]) => user.name || user.login)
     .filter(name => !editors.includes(name))
     .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
-  element.textContent = join(names);
+  element.textContent = joinAnd(names);
   element.id = null;
 }
 
 export async function run(conf) {
   const ghCommenters = document.getElementById("gh-commenters");
   const ghContributors = document.getElementById("gh-contributors");
-
   if (!ghCommenters && !ghContributors) {
     return;
   }
-
-  if (!conf.githubAPI) {
-    const elements = [];
-    if (ghCommenters) elements.push("#" + ghCommenters.id);
-    if (ghContributors) elements.push("#" + ghContributors.id);
-    pub(
-      "error",
-      `Requested list of contributors and/or commenters from GitHub (${
-        elements.join(" and ")
-      }) but config.githubAPI is not set.`
-    );
+  const headers = {};
+  const { githubAPI, githubUser, githubToken } = conf;
+  if (githubUser && githubToken) {
+    const credentials = btoa(`${githubUser}:${githubToken}`);
+    const Authorization = `Basic ${credentials}`;
+    Object.assign(headers, { Authorization });
+  }
+  if (!githubAPI) {
+    const msg =
+      "Requested list of contributors and/or commenters from GitHub, but " +
+      "[`githubAPI`](https://github.com/w3c/respec/wiki/githubAPI) is not set.";
+    pub("error", msg);
     return;
   }
+  const response = await fetch(githubAPI, { headers });
+  if (!response.ok) {
+    const msg =
+      "Error fetching repository information from GitHub. " +
+      `(HTTP Status ${response.status}).`;
+    pub("error", msg);
+    return;
+  }
+  const indexes = await response.json();
+  const { issues_url, issue_comment_url, contributors_url } = indexes;
 
-  const json = await ghFetch(conf.githubAPI);
   const [issues, comments, contributors] = await Promise.all([
-    fetchIndex(json.issues_url),
-    fetchIndex(json.issue_comment_url),
-    fetchIndex(json.contributors_url)
+    fetchIndex(issues_url, headers),
+    fetchIndex(issue_comment_url, headers),
+    fetchIndex(contributors_url, headers),
   ]);
-  const editors = respecConfig.editors.map(prop("name"));
-  const commenterUrls = findUsers(issues, comments);
-  const contributorUrls = contributors.map(prop("url"));
+  const editors = conf.editors.map(nameProp);
+  const commenterUrls = findUserURLs(issues, comments);
+  const contributorUrls = contributors.map(urlProp);
   try {
     await Promise.all(
       toHTML(commenterUrls, editors, ghCommenters),
       toHTML(contributorUrls, editors, ghContributors)
     );
-  }
-  catch (error) {
-    pub(
-      "error",
-      "Error loading contributors and/or commenters from  Error: " + error
-    );
+  } catch (error) {
+    pub("error", "Error loading contributors and/or commenters from Github.");
   }
 }

--- a/src/core/github.js
+++ b/src/core/github.js
@@ -36,14 +36,6 @@ export async function fetchAll(url, headers = {}, output = []) {
   return next ? fetchAll(next, headers, output) : output;
 }
 
-export async function fetch(url) {
-  let response = await window.fetch(url);
-  if (!response.ok) {
-    throw new Error("GitHub Response not OK. Probably exceeded request limit.");
-  }
-  return await response.json();
-}
-
 export function fetchIndex(url, headers) {
   // converts URLs of the form:
   // https://api.github.com/repos/user/repo/comments{/number}
@@ -62,45 +54,41 @@ export async function run(conf) {
     typeof conf.github === "object" &&
     !conf.github.hasOwnProperty("repoURL")
   ) {
-    pub(
-      "error",
-      "`respecConf.github` missing property `repoURL`. See https://github.com/w3c/respec/wiki/github"
-    );
+    const msg =
+      "Config option `[github](https://github.com/w3c/respec/wiki/github)` " +
+      "is missing property `repoURL`.";
+    pub("error", msg);
     return;
   }
   let ghURL;
   try {
-    ghURL = new URL(conf.github.repoURL || conf.github);
+    ghURL = new URL(conf.github.repoURL || conf.github, "https://github.com");
   } catch (err) {
     pub("error", `\`respecConf.github\` is not a valid URL? (${ghURL})`);
     return;
   }
   if (ghURL.origin !== "https://github.com") {
-    pub(
-      "error",
-      `\`respecConf.github\` must be HTTPS and pointing to GitHub. (${ghURL})`
-    );
+    const msg = `\`respecConf.github\` must be HTTPS and pointing to GitHub. (${ghURL})`;
+    pub("error", msg);
     return;
   }
   const [org, repo] = ghURL.pathname.split("/").filter(item => item);
   if (!org || !repo) {
-    pub(
-      "error",
-      `\`respecConf.github\` URL needs a path with, for example, w3c/my-spec`
-    );
+    const msg = `\`respecConf.github\` URL needs a path with, for example, w3c/my-spec`;
+    pub("error", msg);
+    return;
   }
   const branch = conf.github.branch || "gh-pages";
   const newProps = {
-    otherLinks: [],
-    shortName: repo,
     edDraftURI: `https://${org.toLowerCase()}.github.io/${repo}/`,
+    githubToken: undefined,
+    githubUser: undefined,
     githubAPI: `https://api.github.com/repos/${org}/${repo}`,
-    issueBase: `${ghURL.href}${ghURL.pathname.endsWith("/") ? "" : "/"}issues/`,
-    pullBase: `${ghURL.href}${ghURL.pathname.endsWith("/") ? "" : "/"}pulls/`,
+    issueBase: new URL("./issues/", ghURL).href,
+    otherLinks: [],
+    pullBase: new URL("./pulls/", ghURL).href,
+    shortName: repo,
   };
-  const commitsHref = `${ghURL.href}${
-    ghURL.pathname.endsWith("/") ? "" : "/"
-  }commits/${branch}`;
   const otherLink = {
     key: conf.l10n.participate,
     data: [
@@ -114,7 +102,7 @@ export async function run(conf) {
       },
       {
         value: conf.l10n.commit_history,
-        href: commitsHref,
+        href: new URL(`./commits/${branch}`, ghURL.href).href,
       },
       {
         value: conf.l10n.pull_requests,

--- a/src/core/issues-notes.js
+++ b/src/core/issues-notes.js
@@ -185,8 +185,10 @@ function handleIssues($ins, ghIssues, conf) {
   }
 }
 
-async function fetchAndStoreGithubIssues(githubAPI) {
+async function fetchAndStoreGithubIssues(conf) {
+  const { githubAPI, githubUser, githubToken, github } = conf;
   const specIssues = document.querySelectorAll(".issue[data-number]");
+  let { key, user } = github;
   if (specIssues.length > MAX_GITHUB_REQUESTS) {
     const msg =
       `Your spec contains ${specIssues.length} Github issues, ` +
@@ -198,12 +200,18 @@ async function fetchAndStoreGithubIssues(githubAPI) {
     .filter(issueNumber => issueNumber)
     .map(async issueNumber => {
       const issueURL = `${githubAPI}/issues/${issueNumber}`;
+      const headers = {
+        // Get back HTML content instead of markdown
+        // See: https://developer.github.com/v3/media/
+        Accept: "application/vnd.github.v3.html+json",
+      };
+      if (githubUser && githubToken) {
+        const credentials = btoa(`${githubUser}:${githubToken}`);
+        const Authorization = `Basic ${credentials}`;
+        Object.assign(headers, { Authorization });
+      }
       const request = new Request(issueURL, {
-        headers: {
-          // Get back HTML content instead of markdown
-          // See: https://developer.github.com/v3/media/
-          Accept: "application/vnd.github.v3.html+json",
-        },
+        headers,
       });
       const response = await fetchAndCache(request);
       return processResponse(response, issueNumber);
@@ -256,7 +264,7 @@ export async function run(conf) {
     return; // nothing to do.
   }
   const ghIssues = conf.githubAPI
-    ? await fetchAndStoreGithubIssues(conf.githubAPI)
+    ? await fetchAndStoreGithubIssues(conf)
     : new Map();
   const { head: headElem } = document;
   headElem.insertBefore(


### PR DESCRIPTION
One can now use `githubUser` and `githubToken` for testing. This is intended to solve the issue of trying to run ReSpec on TravisCI, whose IP ranges are shared with other projects. As such, ReSpec's tests can fail from hitting the github API request limit.  