### PR TITLE
Remove IDL legacy things

### DIFF
--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -224,7 +224,6 @@ const extenedAttributesLinks = new Map([
   ["Exposed", "WEBIDL#Exposed"],
   ["Global", "WEBIDL#Global"],
   ["HTMLConstructor", "HTML#htmlconstructor"],
-  ["LegacyArrayClass", "WEBIDL#LegacyArrayClass"],
   [
     "LegacyUnenumerableNamedProperties",
     "WEBIDL#LegacyUnenumerableNamedProperties",
@@ -337,8 +336,6 @@ const idlKeywords = new Set([
   "inherit",
   "interface",
   "iterable",
-  "legacycaller",
-  "legacyiterable",
   "long",
   "maplike",
   "NaN",
@@ -377,8 +374,6 @@ const argumentNameKeyword = new Set([
   "inherit",
   "interface",
   "iterable",
-  "legacycaller",
-  "legacyiterable",
   "maplike",
   "partial",
   "required",
@@ -868,7 +863,6 @@ function linkDefinitions(parse, definitionMap, parent, idlElem) {
             defn.getter ||
             defn.setter ||
             defn.deleter ||
-            defn.legacycaller ||
             defn.stringifier
           ) {
             name = "";

--- a/tests/spec/core/webidl.html
+++ b/tests/spec/core/webidl.html
@@ -328,7 +328,7 @@
         Basic operations testing.
       </p>
       <!--
-      getter, setter, creator, deleter, legacycaller, stringifier, serilizer
+      getter, setter, creator, deleter, stringifier, serilizer
       static
       specials don't necessarily have an indentifier
        -->


### PR DESCRIPTION
Based on https://github.com/heycam/webidl/pull/550 removes LegacyArrayClass. 

Also noticed the following had been removed from WebIDL:

-  legacycaller
-  legacyiterable