### PR TITLE
Refactor save html

### DIFF
--- a/src/core/exporter.js
+++ b/src/core/exporter.js
@@ -1,0 +1,101 @@
+// module: exporter
+// used in ui/save-html
+
+import { removeReSpec } from "core/utils";
+import { pub } from "core/pubsubhub";
+
+export function serialize(format = "html") {
+  const cloneDoc = document.cloneNode(true);
+  cleanup(cloneDoc);
+  let result = "";
+  switch (format) {
+    case "xml":
+      result = new XMLSerializer().serializeToString(cloneDoc);
+      break;
+    default: {
+      if (cloneDoc.doctype) {
+        result += new XMLSerializer().serializeToString(cloneDoc.doctype);
+      }
+      result += cloneDoc.documentElement.outerHTML;
+    }
+  }
+  return result;
+}
+
+export async function exportDocument(format, mimeType) {
+  await document.respecIsReady;
+  const dataURL = toDataURL(serialize(format), mimeType);
+  const encodedString = dataURL.replace(/^data:\w+\/\w+;charset=utf-8,/, "");
+  const decodedString = decodeURIComponent(encodedString);
+  return decodedString;
+}
+
+export function toDataURL(data, mimeType = "text/html") {
+  const encodedString = encodeURIComponent(data);
+  return `data:${mimeType};charset=utf-8,${encodedString}`;
+}
+
+// Create and download an EPUB 3 version of the content
+// Using (by default) the EPUB 3 conversion service set up at labs.w3.org/epub-generator
+// For more details on that service, see https://github.com/iherman/respec2epub
+export function makeEPubHref() {
+  const url = new URL(
+    "https://labs.w3.org/epub-generator/cgi-bin/epub-generator.py"
+  );
+  const params = new URLSearchParams({
+    type: "respec",
+    url: document.location.href,
+  });
+  return `${url}?${params}`;
+}
+
+function cleanup(cloneDoc) {
+  const { head, body, documentElement } = cloneDoc;
+  cleanupHyper(documentElement);
+  Array.from(
+    cloneDoc.querySelectorAll(".removeOnSave, #toc-nav")
+  ).forEach(elem => elem.remove());
+  body.classList.remove("toc-sidebar");
+  removeReSpec(documentElement);
+  const insertions = cloneDoc.createDocumentFragment();
+  // Move meta viewport, as it controls the rendering on mobile.
+  const metaViewport = cloneDoc.querySelector("meta[name='viewport']");
+  if (metaViewport && head.firstChild !== metaViewport) {
+    insertions.appendChild(metaViewport);
+  }
+  // Move charset to near top, as it needs to be in the first 512 bytes.
+  let metaCharset = cloneDoc.querySelector(
+    "meta[charset], meta[content*='charset=']"
+  );
+  if (!metaCharset) {
+    metaCharset = cloneDoc.createElement("meta");
+    metaCharset.setAttribute("charset", "utf-8");
+  }
+  insertions.appendChild(metaCharset);
+  // Add meta generator
+  const metaGenerator = cloneDoc.createElement("meta");
+  metaGenerator.name = "generator";
+  metaGenerator.content =
+    "ReSpec " + window.respecVersion || "Developer Channel";
+  insertions.appendChild(metaGenerator);
+  head.insertBefore(insertions, head.firstChild);
+  pub("beforesave", documentElement);
+}
+
+function cleanupHyper(node) {
+  // collect first, or walker will cease too early
+  const comments = [...walkTree(
+    node, NodeFilter.SHOW_COMMENT,
+    comment => comment.textContent.startsWith("_hyper")
+  )];
+  for (const comment of comments) {
+    comment.parentNode.removeChild(comment);
+  }
+}
+
+function* walkTree(...args) {
+  const walker = document.createTreeWalker(...args);
+  while (walker.nextNode()) {
+    yield walker.currentNode;
+  }
+}

--- a/src/core/exporter.js
+++ b/src/core/exporter.js
@@ -4,8 +4,8 @@
 import { removeReSpec } from "core/utils";
 import { pub } from "core/pubsubhub";
 
-export function serialize(format = "html") {
-  const cloneDoc = document.cloneNode(true);
+export function serialize(format = "html", doc = document) {
+  const cloneDoc = doc.cloneNode(true);
   cleanup(cloneDoc);
   let result = "";
   switch (format) {
@@ -22,9 +22,9 @@ export function serialize(format = "html") {
   return result;
 }
 
-export async function exportDocument(format, mimeType) {
-  await document.respecIsReady;
-  const dataURL = toDataURL(serialize(format), mimeType);
+export async function exportDocument(format, mimeType, doc = document) {
+  await doc.respecIsReady;
+  const dataURL = toDataURL(serialize(format, doc), mimeType);
   const encodedString = dataURL.replace(/^data:\w+\/\w+;charset=utf-8,/, "");
   const decodedString = decodeURIComponent(encodedString);
   return decodedString;

--- a/src/core/exporter.js
+++ b/src/core/exporter.js
@@ -42,7 +42,7 @@ export function makeEPubHref() {
   const url = new URL(
     "https://labs.w3.org/epub-generator/cgi-bin/epub-generator.py"
   );
-  url.searchParams.append("type", "respec")
+  url.searchParams.append("type", "respec");
   url.searchParams.append("url", document.location.href);
   return url.href;
 }

--- a/src/core/exporter.js
+++ b/src/core/exporter.js
@@ -19,14 +19,13 @@ const mimeTypes = new Map([["text/html", "html"], ["application/xml", "xml"]]);
  * @param {Document} doc document to export. useful for testing purposes
  * @returns a stringified data-uri of document that can be saved.
  */
-export async function rsDocToDataURL(mimeType) {
+export function rsDocToDataURL(mimeType) {
   const format = mimeTypes.get(mimeType);
   if (!format) {
     const validTypes = [...mimeTypes.values()].join(", ");
-    const msg = `Invalid format: ${mimeType}. Expected one of ${validTypes}.`;
-    throw new TypeError(mimeType);
+    const msg = `Invalid format: ${mimeType}. Expected one of: ${validTypes}.`;
+    throw new TypeError(msg);
   }
-  await document.respecIsReady;
   const data = serialize(format);
   const encodedString = encodeURIComponent(data);
   return `data:${mimeType};charset=utf-8,${encodedString}`;

--- a/src/core/exporter.js
+++ b/src/core/exporter.js
@@ -7,7 +7,7 @@
 
 import { removeReSpec } from "core/utils";
 import { pub } from "core/pubsubhub";
-import "deps/hyperHTML";
+import "deps/hyperhtml";
 
 const mimeTypes = new Map([["text/html", "html"], ["application/xml", "xml"]]);
 
@@ -19,20 +19,20 @@ const mimeTypes = new Map([["text/html", "html"], ["application/xml", "xml"]]);
  * @param {Document} doc document to export. useful for testing purposes
  * @returns a stringified data-uri of document that can be saved.
  */
-export function rsDocToDataURL(mimeType) {
+export function rsDocToDataURL(mimeType, doc = document) {
   const format = mimeTypes.get(mimeType);
   if (!format) {
     const validTypes = [...mimeTypes.values()].join(", ");
     const msg = `Invalid format: ${mimeType}. Expected one of: ${validTypes}.`;
     throw new TypeError(msg);
   }
-  const data = serialize(format);
+  const data = serialize(format, doc);
   const encodedString = encodeURIComponent(data);
   return `data:${mimeType};charset=utf-8,${encodedString}`;
 }
 
-function serialize(format) {
-  const cloneDoc = document.cloneNode(true);
+function serialize(format, doc) {
+  const cloneDoc = doc.cloneNode(true);
   cleanup(cloneDoc);
   let result = "";
   switch (format) {

--- a/src/core/exporter.js
+++ b/src/core/exporter.js
@@ -1,5 +1,5 @@
 /**
- * module: exporter
+ * module: core/exporter
  * Exports a ReSpec document, based on mime type, so it can be saved, etc.
  * Also performs cleanup, removing things that shouldn't be in published documents.
  * That is, elements that have a "removeOnSave" css class.

--- a/src/core/exporter.js
+++ b/src/core/exporter.js
@@ -55,26 +55,29 @@ function cleanup(cloneDoc) {
   ).forEach(elem => elem.remove());
   body.classList.remove("toc-sidebar");
   removeReSpec(documentElement);
+
   const insertions = cloneDoc.createDocumentFragment();
+
   // Move meta viewport, as it controls the rendering on mobile.
   const metaViewport = cloneDoc.querySelector("meta[name='viewport']");
   if (metaViewport && head.firstChild !== metaViewport) {
     insertions.appendChild(metaViewport);
   }
+
   // Move charset to near top, as it needs to be in the first 512 bytes.
   let metaCharset = cloneDoc.querySelector(
     "meta[charset], meta[content*='charset=']"
   );
   if (!metaCharset) {
-    metaCharset = cloneDoc.createElement("meta");
-    metaCharset.setAttribute("charset", "utf-8");
+    metaCharset = hyperHTML`<meta charset="utf-8">`;
   }
   insertions.appendChild(metaCharset);
+
   // Add meta generator
-  const metaGenerator = cloneDoc.createElement("meta");
-  metaGenerator.name = "generator";
-  metaGenerator.content =
-    "ReSpec " + window.respecVersion || "Developer Channel";
+  const respecVersion = window.respecVersion || "Developer Channel";
+  const metaGenerator = hyperHTML`
+    <meta name="generator" content="${"ReSpec " + respecVersion}">`;
+
   insertions.appendChild(metaGenerator);
   head.insertBefore(insertions, head.firstChild);
   pub("beforesave", documentElement);

--- a/src/core/exporter.js
+++ b/src/core/exporter.js
@@ -50,9 +50,10 @@ export function makeEPubHref() {
 function cleanup(cloneDoc) {
   const { head, body, documentElement } = cloneDoc;
   cleanupHyper(cloneDoc);
-  Array.from(
-    cloneDoc.querySelectorAll(".removeOnSave, #toc-nav")
-  ).forEach(elem => elem.remove());
+
+  cloneDoc
+    .querySelectorAll(".removeOnSave, #toc-nav")
+    .forEach(elem => elem.remove());
   body.classList.remove("toc-sidebar");
   removeReSpec(documentElement);
 
@@ -83,10 +84,14 @@ function cleanup(cloneDoc) {
   pub("beforesave", documentElement);
 }
 
-function cleanupHyper({documentElement: node}) {
+function cleanupHyper({ documentElement: node }) {
   // collect first, or walker will cease too early
   const filter = comment => comment.textContent.startsWith("_hyper");
-  const walker = document.createTreeWalker(node, NodeFilter.SHOW_COMMENT, filter);
+  const walker = document.createTreeWalker(
+    node,
+    NodeFilter.SHOW_COMMENT,
+    filter
+  );
   for (const comment of [...walkTree(walker)]) {
     comment.remove();
   }

--- a/src/core/exporter.js
+++ b/src/core/exporter.js
@@ -49,7 +49,7 @@ export function makeEPubHref() {
 
 function cleanup(cloneDoc) {
   const { head, body, documentElement } = cloneDoc;
-  cleanupHyper(documentElement);
+  cleanupHyper(cloneDoc);
   Array.from(
     cloneDoc.querySelectorAll(".removeOnSave, #toc-nav")
   ).forEach(elem => elem.remove());
@@ -80,19 +80,16 @@ function cleanup(cloneDoc) {
   pub("beforesave", documentElement);
 }
 
-function cleanupHyper(node) {
+function cleanupHyper({documentElement: node}) {
   // collect first, or walker will cease too early
-  const comments = [...walkTree(
-    node, NodeFilter.SHOW_COMMENT,
-    comment => comment.textContent.startsWith("_hyper")
-  )];
-  for (const comment of comments) {
-    comment.parentNode.removeChild(comment);
+  const filter = comment => comment.textContent.startsWith("_hyper");
+  const walker = document.createTreeWalker(node, NodeFilter.SHOW_COMMENT, filter);
+  for (const comment of [...walkTree(walker)]) {
+    comment.remove();
   }
 }
 
-function* walkTree(...args) {
-  const walker = document.createTreeWalker(...args);
+function* walkTree(walker) {
   while (walker.nextNode()) {
     yield walker.currentNode;
   }

--- a/src/core/exporter.js
+++ b/src/core/exporter.js
@@ -42,11 +42,9 @@ export function makeEPubHref() {
   const url = new URL(
     "https://labs.w3.org/epub-generator/cgi-bin/epub-generator.py"
   );
-  const params = new URLSearchParams({
-    type: "respec",
-    url: document.location.href,
-  });
-  return `${url}?${params}`;
+  url.searchParams.append("type", "respec")
+  url.searchParams.append("url", document.location.href);
+  return url.href;
 }
 
 function cleanup(cloneDoc) {

--- a/src/ui/save-html.js
+++ b/src/ui/save-html.js
@@ -3,22 +3,19 @@
 import { ui } from "core/ui";
 import { l10n, lang } from "core/l10n";
 import { pub } from "core/pubsubhub";
-import {
-  toDataURL,
-  makeEPubHref,
-  serialize,
-  exportDocument as newExportDoc,
-} from "core/exporter";
+import { exportDocument as newExportDoc } from "core/exporter";
+
 export const name = "ui/save-html";
 
 const downloadLinks = [
   {
     id: "respec-save-as-html",
-    title: "HTML",
-    get href() {
-      return toDataURL(serialize());
-    },
     fileName: "index.html",
+    title: "HTML",
+    type: "text/html",
+    get href() {
+      return newExportDoc(this.type);
+    },
   },
   {
     id: "respec-save-as-xml",
@@ -26,7 +23,7 @@ const downloadLinks = [
     title: "XML",
     type: "application/xml",
     get href() {
-      return toDataURL(serialize("xml"), this.type);
+      return newExportDoc(this.type);
     },
   },
   {
@@ -88,5 +85,17 @@ export function exportDocument(format, mimeType) {
     "Use core/exporter `exportDocument()` instead.";
   pub("warn", msg);
   console.warn(msg);
-  newExportDoc(format, mimeType);
+  newExportDoc(mimeType);
+}
+
+// Create and download an EPUB 3 version of the content
+// Using (by default) the EPUB 3 conversion service set up at labs.w3.org/epub-generator
+// For more details on that service, see https://github.com/iherman/respec2epub
+function makeEPubHref() {
+  const url = new URL(
+    "https://labs.w3.org/epub-generator/cgi-bin/epub-generator.py"
+  );
+  url.searchParams.append("type", "respec");
+  url.searchParams.append("url", document.location.href);
+  return url.href;
 }

--- a/src/ui/save-html.js
+++ b/src/ui/save-html.js
@@ -4,7 +4,7 @@ import { ui } from "core/ui";
 import { l10n, lang } from "core/l10n";
 import { pub } from "core/pubsubhub";
 import { rsDocToDataURL } from "core/exporter";
-
+import "deps/hyperhtml";
 export const name = "ui/save-html";
 // Create and download an EPUB 3 version of the content
 // Using (by default) the EPUB 3 conversion service set up at labs.w3.org/epub-generator

--- a/src/ui/save-html.js
+++ b/src/ui/save-html.js
@@ -1,15 +1,14 @@
 // Module ui/save-html
 // Saves content to HTML when asked to
-import { xmlEscape, removeReSpec } from "core/utils";
-import { pub } from "core/pubsubhub";
 import { ui } from "core/ui";
 import { l10n, lang } from "core/l10n";
+import { toDataURL, makeEPubHref, serialize } from "core/exporter";
 export const name = "ui/save-html";
 
 const downloadLinks = [
   {
     id: "respec-save-as-html",
-    title: `HTML`,
+    title: "HTML",
     get href() {
       return toDataURL(serialize());
     },
@@ -18,7 +17,7 @@ const downloadLinks = [
   {
     id: "respec-save-as-xml",
     fileName: "index.xhtml",
-    title: `XML`,
+    title: "XML",
     type: "application/xml",
     get href() {
       return toDataURL(serialize("xml"), this.type);
@@ -27,11 +26,40 @@ const downloadLinks = [
   {
     id: "respec-save-as-epub",
     fileName: "spec.epub",
-    title: `EPUB 3`,
+    title: "EPUB 3",
     type: "application/epub+zip",
-    href: makeEPubHref(),
+    get href() {
+      return makeEPubHref();
+    },
   },
 ];
+
+function toDownloadLink(
+  { id, href, fileName, title, type = "" } = { type: "" }
+) {
+  return hyperHTML`
+    <a
+      href="${href}"
+      id="${id}"
+      download="${fileName}"
+      type="${type}"
+      class="respec-save-button"
+      onclick=${() => ui.closeModal()}
+    >${title}</a>`;
+}
+
+const saveDialog = {
+  show(button) {
+    document.respecIsReady.then(() => {
+      const div = hyperHTML`
+        <div class="respec-save-buttons">
+          ${downloadLinks.map(toDownloadLink)}
+        </div>`;
+      ui.freshModal(l10n[lang].save_snapshot, div, button);
+    });
+  },
+};
+
 const supportsDownload = "download" in document.createElement("a");
 let button;
 if (supportsDownload) {
@@ -43,139 +71,7 @@ if (supportsDownload) {
   );
 }
 
-function toDataURL(data, mimeType = "text/html") {
-  const encodedString = encodeURIComponent(data);
-  return `data:${mimeType};charset=utf-8,${encodedString}`;
-}
-
-function serialize(format = "html") {
-  const cloneDoc = document.cloneNode(true);
-  cleanup(cloneDoc);
-  let result = "";
-  switch (format) {
-    case "xml":
-      result = new XMLSerializer().serializeToString(cloneDoc);
-      break;
-    default: {
-      if (cloneDoc.doctype) {
-        result += new XMLSerializer().serializeToString(cloneDoc.doctype);
-      }
-      result += cloneDoc.documentElement.outerHTML;
-    }
-  }
-  return result;
-}
-
-// Create and download an EPUB 3 version of the content
-// Using (by default) the EPUB 3 conversion service set up at labs.w3.org/epub-generator
-// For more details on that service, see https://github.com/iherman/respec2epub
-function makeEPubHref() {
-  const url = new URL(
-    "https://labs.w3.org/epub-generator/cgi-bin/epub-generator.py"
-  );
-  const params = new URLSearchParams({
-    type: "respec",
-    url: document.location.href,
-  });
-  return `${url}?${params}`;
-}
-
-function cleanup(cloneDoc) {
-  const { head, body, documentElement } = cloneDoc;
-  cleanupHyper(documentElement);
-  Array.from(
-    cloneDoc.querySelectorAll(".removeOnSave, #toc-nav")
-  ).forEach(elem => elem.remove());
-  body.classList.remove("toc-sidebar");
-  removeReSpec(documentElement);
-  const insertions = cloneDoc.createDocumentFragment();
-  // Move meta viewport, as it controls the rendering on mobile.
-  const metaViewport = cloneDoc.querySelector("meta[name='viewport']");
-  if (metaViewport && head.firstChild !== metaViewport) {
-    insertions.appendChild(metaViewport);
-  }
-  // Move charset to near top, as it needs to be in the first 512 bytes.
-  let metaCharset = cloneDoc.querySelector(
-    "meta[charset], meta[content*='charset=']"
-  );
-  if (!metaCharset) {
-    metaCharset = cloneDoc.createElement("meta");
-    metaCharset.setAttribute("charset", "utf-8");
-  }
-  insertions.appendChild(metaCharset);
-  // Add meta generator
-  const metaGenerator = cloneDoc.createElement("meta");
-  metaGenerator.name = "generator";
-  metaGenerator.content =
-    "ReSpec " + window.respecVersion || "Developer Channel";
-  insertions.appendChild(metaGenerator);
-  head.insertBefore(insertions, head.firstChild);
-  pub("beforesave", documentElement);
-}
-
-function cleanupHyper(node) {
-  // collect first, or walker will cease too early
-  const comments = [...walkTree(
-    node, NodeFilter.SHOW_COMMENT, 
-    comment => comment.textContent.startsWith("_hyper")
-  )];
-  for (const comment of comments) {
-    comment.parentNode.removeChild(comment);
-  }
-}
-
-function* walkTree(...args) {
-  const walker = document.createTreeWalker(...args);
-  while (walker.nextNode()) {
-    yield walker.currentNode;
-  }
-}
-
-function toDownloadLink(
-  { id, href, fileName, title, type = "" } = { type: "" }
-) {
-  const a = document.createElement("a");
-  a.classList.add("respec-save-button");
-  a.id = id;
-  a.href = href;
-  a.download = fileName;
-  a.type = type;
-  a.addEventListener("click", () => {
-    ui.closeModal();
-  });
-  const render = hyperHTML.bind(a);
-  return render`
-    ${title}
-  `;
-}
-
-const div = document.createElement("div");
-div.classList.add("respec-save-buttons");
-const dialogRender = hyperHTML.bind(div);
-const saveDialog = {
-  show(button) {
-    document.respecIsReady.then(() => {
-      dialogRender`
-        ${downloadLinks.map(toDownloadLink)}
-      `;
-      ui.freshModal(l10n[lang].save_snapshot, div, button);
-    });
-  },
-};
-
-export function exportDocument(format, mimeType) {
-  // Bug in babel won't export async function for some reason?
-  return document.respecIsReady.then(() => {
-    const dataURL = toDataURL(serialize(format), mimeType);
-    const encodedString = dataURL.replace(/^data:\w+\/\w+;charset=utf-8,/, "");
-    const decodedString = decodeURIComponent(encodedString);
-    return decodedString;
-  });
-}
-
 export function show() {
-  if (!supportsDownload) {
-    return;
-  }
+  if (!supportsDownload) return;
   saveDialog.show(button);
 }

--- a/src/ui/save-html.js
+++ b/src/ui/save-html.js
@@ -5,7 +5,9 @@ import { l10n, lang } from "core/l10n";
 import { pub } from "core/pubsubhub";
 import { rsDocToDataURL } from "core/exporter";
 import "deps/hyperhtml";
+
 export const name = "ui/save-html";
+
 // Create and download an EPUB 3 version of the content
 // Using (by default) the EPUB 3 conversion service set up at labs.w3.org/epub-generator
 // For more details on that service, see https://github.com/iherman/respec2epub
@@ -14,6 +16,7 @@ const epubURL = new URL(
 );
 epubURL.searchParams.append("type", "respec");
 epubURL.searchParams.append("url", document.location.href);
+
 const downloadLinks = [
   {
     id: "respec-save-as-html",

--- a/src/ui/save-html.js
+++ b/src/ui/save-html.js
@@ -2,7 +2,13 @@
 // Saves content to HTML when asked to
 import { ui } from "core/ui";
 import { l10n, lang } from "core/l10n";
-import { toDataURL, makeEPubHref, serialize } from "core/exporter";
+import { pub } from "core/pubsubhub";
+import {
+  toDataURL,
+  makeEPubHref,
+  serialize,
+  exportDocument as newExportDoc,
+} from "core/exporter";
 export const name = "ui/save-html";
 
 const downloadLinks = [
@@ -60,7 +66,7 @@ const saveDialog = {
   },
 };
 
-const supportsDownload = "download" in document.createElement("a");
+const supportsDownload = "download" in HTMLAnchorElement.prototype;
 let button;
 if (supportsDownload) {
   button = ui.addCommand(
@@ -74,4 +80,13 @@ if (supportsDownload) {
 export function show() {
   if (!supportsDownload) return;
   saveDialog.show(button);
+}
+
+export function exportDocument(format, mimeType) {
+  const msg =
+    "Exporting via ui/save-html module's `exportDocument()` is deprecated and will be removed. " +
+    "Use core/exporter `exportDocument()` instead.";
+  pub("warn", msg);
+  console.warn(msg);
+  newExportDoc(format, mimeType);
 }

--- a/tests/spec/core/exporter-spec.js
+++ b/tests/spec/core/exporter-spec.js
@@ -1,24 +1,23 @@
 "use strict";
 
-fdescribe("Core - exporter", () => {
+describe("Core - exporter", () => {
   afterAll(flushIframes);
 
   async function getExportedDoc(ops) {
-    const rsDocToDataURL = await new Promise(resolve => {
-      require(["core/exporter"], ({rsDocToDataURL: _rsDocToDataURL}) => {
-        resolve(_rsDocToDataURL);
-      });
+    const { rsDocToDataURL } = await new Promise(resolve => {
+      require(["core/exporter"], resolve);
     });
     const doc = await makeRSDoc(ops);
     await doc.respecIsReady;
     const parser = new DOMParser();
-    const docString = decodeURIComponent(rsDocToDataURL("text/html", doc))
-      .replace("data:text/html;charset=utf-8,", "");
+    const docString = decodeURIComponent(
+      rsDocToDataURL("text/html", doc)
+    ).replace("data:text/html;charset=utf-8,", "");
     const exportedDoc = parser.parseFromString(docString, "text/html");
     return exportedDoc;
   }
 
-  it("should remove .removeOnSave elements", async () => {
+  it("removes .removeOnSave elements", async () => {
     const ops = makeStandardOps();
     ops.body = `<div class="removeOnSave" id="this-should-be-removed">this should be removed</div>`;
     const doc = await getExportedDoc(ops);
@@ -27,22 +26,20 @@ fdescribe("Core - exporter", () => {
     expect(doc.querySelectorAll(".removeOnSave").length).toBe(0);
   });
 
-  it("should cleanup hyperHTML comments", async () => {
+  it("cleans up hyperHTML comments", async () => {
     const ops = makeStandardOps();
     ops.body = `<div><!--_hyper: LEAVE;-->PASS<!-- STAY --></div>`;
     const doc = await getExportedDoc(ops);
 
-    const walker = document.createTreeWalker(
-      doc.body,
-      NodeFilter.SHOW_COMMENT,
-    );
+    const walker = document.createTreeWalker(doc.body, NodeFilter.SHOW_COMMENT);
     const comments = [];
     while (walker.nextNode()) {
       comments.push(walker.currentNode);
     }
 
-    const hyperComments = comments.filter(
-      comment => comment.textContent.startsWith("_hyper"));
+    const hyperComments = comments.filter(comment =>
+      comment.textContent.startsWith("_hyper")
+    );
     expect(hyperComments.length).toBe(0);
 
     expect(comments.length).toBe(1);

--- a/tests/spec/core/exporter-spec.js
+++ b/tests/spec/core/exporter-spec.js
@@ -1,0 +1,51 @@
+"use strict";
+
+fdescribe("Core - exporter", () => {
+  afterAll(flushIframes);
+
+  async function getExportedDoc(ops) {
+    const rsDocToDataURL = await new Promise(resolve => {
+      require(["core/exporter"], ({rsDocToDataURL: _rsDocToDataURL}) => {
+        resolve(_rsDocToDataURL);
+      });
+    });
+    const doc = await makeRSDoc(ops);
+    await doc.respecIsReady;
+    const parser = new DOMParser();
+    const docString = decodeURIComponent(rsDocToDataURL("text/html", doc))
+      .replace("data:text/html;charset=utf-8,", "");
+    const exportedDoc = parser.parseFromString(docString, "text/html");
+    return exportedDoc;
+  }
+
+  it("should remove .removeOnSave elements", async () => {
+    const ops = makeStandardOps();
+    ops.body = `<div class="removeOnSave" id="this-should-be-removed">this should be removed</div>`;
+    const doc = await getExportedDoc(ops);
+
+    expect(doc.getElementById("this-should-be-removed")).toBeFalsy();
+    expect(doc.querySelectorAll(".removeOnSave").length).toBe(0);
+  });
+
+  it("should cleanup hyperHTML comments", async () => {
+    const ops = makeStandardOps();
+    ops.body = `<div><!--_hyper: LEAVE;-->PASS<!-- STAY --></div>`;
+    const doc = await getExportedDoc(ops);
+
+    const walker = document.createTreeWalker(
+      doc.body,
+      NodeFilter.SHOW_COMMENT,
+    );
+    const comments = [];
+    while (walker.nextNode()) {
+      comments.push(walker.currentNode);
+    }
+
+    const hyperComments = comments.filter(
+      comment => comment.textContent.startsWith("_hyper"));
+    expect(hyperComments.length).toBe(0);
+
+    expect(comments.length).toBe(1);
+    expect(comments[0].textContent.trim()).toBe("STAY");
+  });
+});

--- a/tests/test-main.js
+++ b/tests/test-main.js
@@ -28,7 +28,7 @@ require.config({
       "/base/js/core/linter-rules/check-punctuation",
     "core/l10n": "/base/js/core/l10n",
     "w3c/linter-rules/privsec-section":
-      "/base/js/w3c/linter-rules/privsec-section",
+    "/base/js/w3c/linter-rules/privsec-section",
     "w3c/l10n": "/base/js/w3c/l10n",
     "core/LinterRule": "/base/js/core/LinterRule",
     "core/biblio-db": "/base/js/core/biblio-db",
@@ -38,6 +38,7 @@ require.config({
     "deps/jquery": "/base/js/deps/jquery",
     "deps/marked": "/base/js/deps/marked",
     "w3c/linter": "/base/js/w3c/linter",
+    "core/exporter": "/base/js/core/exporter",
   },
 });
 

--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -172,10 +172,10 @@ async function isRespec() {
 async function evaluateHTML() {
   try {
     await document.respecIsReady;
-    const { exportDocument } = await new Promise(resolve => {
+    const { rsDocToDataURL } = await new Promise(resolve => {
       require(["core/exporter"], resolve);
     });
-    return exportDocument();
+    return rsDocToDataURL("text/html");
   } catch (err) {
     throw err.stack;
   }

--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -172,10 +172,8 @@ async function isRespec() {
 async function evaluateHTML() {
   try {
     await document.respecIsReady;
-    const exportDocument = await new Promise(resolve => {
-      require(["ui/save-html"], ({ exportDocument }) => {
-        resolve(exportDocument);
-      });
+    const { exportDocument } = await new Promise(resolve => {
+      require(["core/exporter"], resolve);
     });
     return exportDocument();
   } catch (err) {


### PR DESCRIPTION
basically moved export code to a separate file and made a little changes.

Reasons:
 - Couldn't test exported html without including unneeded modules (core/ui etc)


Can test easily now as:

``` js
  fit("lets access exported html", async() => {
    const doc = await makeRSDoc(makeStandardOps());
    await doc.respecIsReady;

    const { exportDocument } = await new Promise(resolve => {
      require(["core/exporter"], resolve);
    });
   const exportedHtml = await exportDocument("html", "text/html", doc);
   // .. tests  
  });
``` 

Please let me know if i broke something in between and the parameters that refactored functions need. :)