### PR TITLE
Make RespecDocWriter work with older versions of ReSpec

### DIFF
--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -189,13 +189,13 @@ async function evaluateHTML() {
       // Document references an older version of ReSpec that does not yet
       // have the "core/exporter" module. Try with the old "ui/save-html"
       // module.
-      const { exportDocument } = await new Promise((resolve, reject) => {
-        require(["ui/save-html"], resolve, reject);
+      const { exportDocument } = await new Promise(resolve => {
+        require(["ui/save-html"], resolve);
       });
       return exportDocument("html", "text/html");
     } else {
-      const { rsDocToDataURL } = await new Promise((resolve, reject) => {
-        require(["core/exporter"], resolve, reject);
+      const { rsDocToDataURL } = await new Promise(resolve => {
+        require(["core/exporter"], resolve);
       });
       const dataURL = rsDocToDataURL("text/html");
       const encodedString = dataURL.replace(

--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -181,9 +181,10 @@ async function isRespec() {
 async function evaluateHTML() {
   try {
     await document.respecIsReady;
-    const [mayor, minor] = window.respecVersion === "Developer Edition"
-      ? [123456789, 0, 0]
-      : window.respecVersion.split(".").map(str => parseInt(str, 10));
+    const [mayor, minor] =
+      window.respecVersion === "Developer Edition"
+        ? [123456789, 0, 0]
+        : window.respecVersion.split(".").map(str => parseInt(str, 10));
     if (mayor < 20 || (mayor === 20 && minor < 10)) {
       // Document references an older version of ReSpec that does not yet
       // have the "core/exporter" module. Try with the old "ui/save-html"

--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -181,11 +181,11 @@ async function isRespec() {
 async function evaluateHTML() {
   try {
     await document.respecIsReady;
-    const [mayor, minor] =
+    const [major, minor] =
       window.respecVersion === "Developer Edition"
         ? [123456789, 0, 0]
         : window.respecVersion.split(".").map(str => parseInt(str, 10));
-    if (mayor < 20 || (mayor === 20 && minor < 10)) {
+    if (major < 20 || (major === 20 && minor < 10)) {
       // Document references an older version of ReSpec that does not yet
       // have the "core/exporter" module. Try with the old "ui/save-html"
       // module.

--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -181,10 +181,10 @@ async function isRespec() {
 async function evaluateHTML() {
   try {
     await document.respecIsReady;
-    const [mayor, minor] = (window.respecVersion === "Developer Edition") ?
-      [123456789, 0, 0] :
-      window.respecVersion.split(".").map(str => parseInt(str, 10));
-    if ((mayor < 20) || ((mayor === 20) && (minor < 10))) {
+    const [mayor, minor] = window.respecVersion === "Developer Edition"
+      ? [123456789, 0, 0]
+      : window.respecVersion.split(".").map(str => parseInt(str, 10));
+    if (mayor < 20 || (mayor === 20 && minor < 10)) {
       // Document references an older version of ReSpec that does not yet
       // have the "core/exporter" module. Try with the old "ui/save-html"
       // module.
@@ -192,13 +192,15 @@ async function evaluateHTML() {
         require(["ui/save-html"], resolve, reject);
       });
       return exportDocument("html", "text/html");
-    }
-    else {
+    } else {
       const { rsDocToDataURL } = await new Promise((resolve, reject) => {
         require(["core/exporter"], resolve, reject);
       });
       const dataURL = rsDocToDataURL("text/html");
-      const encodedString = dataURL.replace(/^data:\w+\/\w+;charset=utf-8,/, "");
+      const encodedString = dataURL.replace(
+        /^data:\w+\/\w+;charset=utf-8,/,
+        ""
+      );
       const decodedString = decodeURIComponent(encodedString);
       return decodedString;
     }


### PR DESCRIPTION
Version 20.10 introduced the `core/exporter` module, which is now used in `RespecDocWriter`. Problem is the spec on which RespecDocWriter runs may still reference an older version of ReSpec that does not have that module.

An example of a spec that has this problem today is [Media Capture and Streams](https://w3c.github.io/mediacapture-main/) which uses version 20.1.0. Running `RespecDocWriter` on it makes it crash badly (badly because the `Promise` that wraps the code to `require` does not get properly rejected when the module cannot be found, so the execution stays locked there with the error being reported to the console by RequireJS).

The writer checks the version of ReSpec and refuses to run on very old versions (lower than version 18). It still accepts to run on versions between 18 and 20.10 (which is a good thing :)). The old `ui/save-html` module needs to be used in such cases, which is what this update does.

Notes:
1. I copied the logic from `getVersion` to `evaluateHTML`. Not sure if there's a way to call that function directly from within `evaluateHTML`. I suppose not.
2. FWIW, I noticed the problem because Reffy uses `RespecDocWriter` to generate the HTML of all Respec specs it knows.