### PR TITLE
Fix caniuse hover show/hide

### DIFF
--- a/js/core/css/caniuse.css
+++ b/js/core/css/caniuse.css
@@ -82,6 +82,6 @@ see https://github.com/Fyrd/caniuse/blob/master/CONTRIBUTING.md for stats */
 
 /* show rest of the browser versions */
 .caniuse-stats button:focus + ul,
-.caniuse-stats button:hover + ul {
+.caniuse-stats .caniuse-browser:hover > ul {
   display: block;
 }


### PR DESCRIPTION
Fix the following: when button loses hover, it hides the browsers. 
Intended behaviour: hide active browser list when list is out of hover.
![](https://user-images.githubusercontent.com/8426945/39866426-496deeda-546e-11e8-9613-56e137b612cd.gif)
