### PR TITLE
Fix temp ID syntax in list sorter

### DIFF
--- a/src/core/list-sorter.js
+++ b/src/core/list-sorter.js
@@ -29,7 +29,7 @@ function getDirectDescendents(elem, wantedDescendentName) {
     let tempId = "";
     // We give a temporary id, to overcome lack of ":scope" support in Edge.
     if (!elem.id) {
-      tempId = `temp-${Math.random()}`;
+      tempId = `temp-${String(Math.random()).substr(2)}`;
       elem.id = tempId;
     }
     const query = `#${elem.id} > ${wantedDescendentName}`;


### PR DESCRIPTION
Use of `Math.random()` means the resulting selector looked like `#temp-0.924252548658087 > dt`, which is not a valid CSS selector due to the presence of a `.` (class selector), followed only by numbers (an `ident-token` cannot start with a digit:
https://drafts.csswg.org/css-syntax-3/#ref-for-typedef-ident-token%E2%91%A0

Using `${String(Math.random()).substr(2)}`, as in other places in Respec that create random IDs.