### PR TITLE
fix(tools/respecDocWriter): support Puppeteer 1.4 error reporting

### DIFF
--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -253,8 +253,8 @@ function makeConsoleMsgHandler(page) {
       const type = message.type();
       if (
         type === "error" &&
-        !message.args().length && // browser errors have no arguments
-        text.startsWith("Failed to load")
+        text && // browser errors have text
+        !message.args().length // browser errors have no arguments
       ) {
         // Since Puppeteer 1.4 reports _all_ errors, including CORS
         // violations. Unfortunately, there is no way to distinguish these errors

--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -283,7 +283,5 @@ function makeConsoleMsgHandler(page) {
     });
   };
 }
-async function stringifyJSHandle(handle) {
-  return await handle.executionContext().evaluate(o => String(o), handle);
-};
+
 exports.fetchAndWrite = fetchAndWrite;

--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -248,7 +248,7 @@ function makeConsoleMsgHandler(page) {
    * @return {Void}
    */
   return function handleConsoleMessages(whenToHalt) {
-    page.on("console", async message => {
+    page.on("console", message => {
       const text = message.text();
       const type = message.type();
       if (

--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -262,15 +262,14 @@ function makeConsoleMsgHandler(page) {
         // https://github.com/GoogleChrome/puppeteer/issues/1939
         return;
       }
-
-      const abortOnWarning = whenToHalt.haltOnWarn && type === "warn";
+      const abortOnWarning = whenToHalt.haltOnWarn && type === "warning";
       const abortOnError = whenToHalt.haltOnError && type === "error";
       const output = `ReSpec ${type}: ${colors.debug(text)}`;
       switch (type) {
         case "error":
           console.error(colors.error(`😱 ${output}`));
           break;
-        case "warn":
+        case "warning":
           // Ignore polling of respecDone
           if (/document\.respecDone/.test(text)) {
             return;
@@ -284,5 +283,7 @@ function makeConsoleMsgHandler(page) {
     });
   };
 }
-
+async function stringifyJSHandle(handle) {
+  return await handle.executionContext().evaluate(o => String(o), handle);
+};
 exports.fetchAndWrite = fetchAndWrite;


### PR DESCRIPTION
Because of Puppeteer 1.4 (https://github.com/GoogleChrome/puppeteer/issues/1939), `respecDocWriter` is incorrectly exiting with: 

```
Failed to load file:////respec/js/core/css/var.css: Cross origin requests are only supported for protocol schemes: http, data, chrome, https.
```

For every css file.  