### PR TITLE
fix: link-to-dfn module may report a TypeError

### DIFF
--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -67,12 +67,12 @@ export function run(conf, doc, cb) {
     }
   });
   $("a:not([href]):not([data-cite]):not(.logo)").each(function() {
-    var $ant = $(this);
+    const $ant = $(this);
     if ($ant.hasClass("externalDFN")) return;
-    var linkTargets = $ant.linkTargets();
-    var foundDfn = linkTargets.some(function(target) {
+    const linkTargets = $ant.linkTargets();
+    const foundDfn = linkTargets.some(function(target) {
       if (titles[target.title] && titles[target.title][target.for]) {
-        var dfn = titles[target.title][target.for];
+        const dfn = titles[target.title][target.for];
         if (dfn[0].dataset.cite) {
           $ant[0].dataset.cite = dfn[0].dataset.cite;
         } else {
@@ -108,15 +108,15 @@ export function run(conf, doc, cb) {
       }
       return false;
     });
-    if (!foundDfn) {
+    if (!foundDfn && linkTargets.length != 0) {
       // ignore WebIDL
       if (
         !$ant.parents(
           ".idl:not(.extAttr), dl.methods, dl.attributes, dl.constants, dl.constructors, dl.fields, dl.dictionary-members, span.idlMemberType, span.idlTypedefType, div.idlImplementsDesc"
         ).length
       ) {
-        var link_for = linkTargets[0].for;
-        var title = linkTargets[0].title;
+        const link_for = linkTargets[0].for;
+        const title = linkTargets[0].title;
         this.classList.add("respec-offending-element");
         this.title = "Linking error: not matching <dfn>";
         pub(

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -108,7 +108,7 @@ export function run(conf, doc, cb) {
       }
       return false;
     });
-    if (!foundDfn && linkTargets.length != 0) {
+    if (!foundDfn && linkTargets.length !== 0) {
       // ignore WebIDL
       if (
         !$ant.parents(

--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -540,7 +540,7 @@ export function run(conf) {
   if (conf.isCGBG && !conf.wg) {
     pub(
       "error",
-      "[`respecConfig.wg`](https://github.com/w3c/respec/wiki/wg)" +
+      "[`wg`](https://github.com/w3c/respec/wiki/wg)" +
         " configuration option is required for CG documents."
     );
   }

--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -540,7 +540,8 @@ export function run(conf) {
   if (conf.isCGBG && !conf.wg) {
     pub(
       "error",
-      "[`respecConfig.wg`](https://github.com/w3c/respec/wiki/wg) configuration option is required for CG documents."
+      "[`respecConfig.wg`](https://github.com/w3c/respec/wiki/wg)" +
+        " configuration option is required for CG documents."
     );
   }
   if (Array.isArray(conf.wg)) {

--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -538,7 +538,10 @@ export function run(conf) {
     );
   }
   if (conf.isCGBG && !conf.wg) {
-    pub("error", "`respecConfig.wg` is required.");
+    pub(
+      "error",
+      "[`respecConfig.wg`](https://github.com/w3c/respec/wiki/wg) configuration option is required for CG documents."
+    );
   }
   if (Array.isArray(conf.wg)) {
     conf.multipleWGs = conf.wg.length > 1;

--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -537,6 +537,9 @@ export function run(conf) {
       "If one of '`wg`', '`wgURI`', or '`wgPatentURI`' is an array, they all have to be."
     );
   }
+  if (conf.isCGBG && !conf.wg) {
+    pub("error", "`respecConfig.wg` is required.");
+  }
   if (Array.isArray(conf.wg)) {
     conf.multipleWGs = conf.wg.length > 1;
     conf.wgHTML = joinAnd(conf.wg, function(wg, idx) {

--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -541,7 +541,7 @@ export function run(conf) {
     pub(
       "error",
       "[`wg`](https://github.com/w3c/respec/wiki/wg)" +
-        " configuration option is required for CG documents."
+        " configuration option is required for this kind of document."
     );
   }
   if (Array.isArray(conf.wg)) {


### PR DESCRIPTION
- Make CG template complain if `conf.wg` is not set (`pub("error")`)
- Prevent `linkTargets` from crashing when it encounters an empty `<a>`
- Closes #1666