### PR TITLE
fix(core/dfn): improve backwards compat

### DIFF
--- a/src/core/dfn.js
+++ b/src/core/dfn.js
@@ -33,16 +33,25 @@ export function run(conf) {
 
     // add automatic pluralization to `data-lt` attributes
     // see https://github.com/w3c/respec/pull/1682
-    const normText = norm(dfn.textContent).toLowerCase();
     if (
       pluralizeDfn &&
       !dfn.hasAttribute("data-lt-no-plural") &&
       !dfn.hasAttribute("data-lt-noDefault")
     ) {
+      const normText = norm(dfn.textContent).toLowerCase();
       const plural = pluralizeDfn(normText);
       if (plural) {
-        dfnTitles.push(plural);
-        dfn.dataset.lt = dfnTitles.join("|");
+        if (dfnTitles[0] === normText) {
+          // if normText is first `dfnTitles`, then use plural as `id`
+          dfnTitles.unshift(plural);
+        } else {
+          // otherwise, to prevent breaking exising links,
+          //  first data-lt is used as `id`
+          dfnTitles.push(plural);
+        }
+        dfn.dataset.lt = dfnTitles
+          .filter(title => title !== normText)
+          .join("|");
       }
     }
 

--- a/tests/spec/core/dfn-spec.js
+++ b/tests/spec/core/dfn-spec.js
@@ -59,12 +59,11 @@ describe("Core — Definitions", function() {
       const doc = await makeRSDoc(ops);
 
       const dfn = doc.querySelector("#section dfn");
-      expect(dfn.id).toEqual("dfn-foo");
-      const dfnlt = dfn.dataset.lt.split("|").sort();
-      const expectedDfnlt = "foo|foos".split("|");
-      expect(dfnlt).toEqual(expectedDfnlt);
-      const links = [...doc.querySelectorAll("#one a")];
-      expect(links.every(el => getLinkHash(el) === "#dfn-foo")).toBeTruthy();
+      expect(dfn.id).toEqual("dfn-foos");
+      expect(dfn.dataset.lt).toEqual("foos");
+      const links = [...doc.querySelectorAll("#section a")];
+      expect(links.length).toEqual(2);
+      expect(links.every(el => getLinkHash(el) === "#dfn-foos")).toBeTruthy();
     });
 
     it("adds pluralization when [data-lt] is defined", async () => {
@@ -83,9 +82,7 @@ describe("Core — Definitions", function() {
 
       const dfn = doc.querySelector("#section dfn");
       expect(dfn.id).toEqual("dfn-baz"); // uses first data-lt as `id`
-      const dfnlt = dfn.dataset.lt.split("|").sort();
-      const expectedDfnlt = "bar|bars|baz".split("|");
-      expect(dfnlt).toEqual(expectedDfnlt);
+      expect(dfn.dataset.lt).toEqual("baz|bars");
 
       const validLinks = [...doc.querySelectorAll("#section a")].slice(0, 3);
       expect(validLinks.length).toEqual(3);
@@ -202,8 +199,7 @@ describe("Core — Definitions", function() {
       const dfnFoos = doc.getElementById("dfn-foos");
       expect(dfnFoos).toBeTruthy();
       expect(dfnFoos.textContent).toEqual("baz");
-      const ltFoos = dfnFoos.dataset.lt.split("|").sort();
-      expect(ltFoos.join("|")).toEqual("baz|bazs|foos");
+      expect(dfnFoos.dataset.lt).toEqual("foos|bazs");
 
       const linkToBar = doc.getElementById("link-to-bar");
       const linkToBars = doc.getElementById("link-to-bars");


### PR DESCRIPTION
Fixes following bugs in `dfn`:
- `textContent` shouldn't be in `data-lt`
- plural term should used for `dfn.id` to prevent breaking existing links