### PR TITLE
Add a period and space to unlinked references

### DIFF
--- a/src/core/biblio.js
+++ b/src/core/biblio.js
@@ -99,6 +99,7 @@ export function stringifyReference(ref) {
   if (ref.href) {
     output = `<a href="${ref.href}">${output}</a>. `;
   }
+  else output = `${output}. `;
   if (ref.authors && ref.authors.length) {
     output += ref.authors.join("; ");
     if (ref.etAl) output += " et al";

--- a/src/core/biblio.js
+++ b/src/core/biblio.js
@@ -96,10 +96,9 @@ export function wireReference(rawRef, target = "_blank") {
 export function stringifyReference(ref) {
   if (typeof ref === "string") return ref;
   let output = `<cite>${ref.title}</cite>`;
-  if (ref.href) {
-    output = `<a href="${ref.href}">${output}</a>. `;
-  }
-  else output = `${output}. `;
+  
+  output = ref.href ? `<a href="${ref.href}">${output}</a>. ` : `${output}. `;
+
   if (ref.authors && ref.authors.length) {
     output += ref.authors.join("; ");
     if (ref.etAl) output += " et al";


### PR DESCRIPTION
When a reference has a link, the stringifyReference function wraps the
title in the link and adds a ". " to the end of it to separate it from
the rest of the reference text. But if it doesn't have a link, neither
the link nor the ". " are added, causing the title to run into the next
portion of the output. This commit adds the separator for this case.
There may be more elegant ways to handle but this fix seems
straightforward.