### PR TITLE
perf: dont create arrays unnecessarily

### DIFF
--- a/src/core/best-practices.js
+++ b/src/core/best-practices.js
@@ -12,7 +12,7 @@ export function run() {
   let num = 0;
   const bps = document.querySelectorAll("span.practicelab");
   const ul = document.createElement("ul");
-  for (const bp of Array.from(bps)) {
+  for (const bp of bps) {
     num++;
     const id = window.$.fn.makeID.call([bp], "bp");
     const li = hyperHTML`<li><a href="${`#${id}`}">Best Practice ${num}</a>: ${bp.textContent}</li>`;

--- a/src/core/data-cite.js
+++ b/src/core/data-cite.js
@@ -126,7 +126,8 @@ export async function run(conf) {
 
 export async function linkInlineCitations(doc, conf = respecConfig) {
   const toLookupRequest = requestLookup(conf);
-  const citedSpecs = doc.querySelectorAll("dfn[data-cite], a[data-cite]");
-  const lookupRequests = Array.from(citedSpecs).map(toLookupRequest);
+  const lookupRequests = [
+    ...doc.querySelectorAll("dfn[data-cite], a[data-cite]"),
+  ].map(toLookupRequest);
   return await Promise.all(lookupRequests);
 }

--- a/src/core/data-transform.js
+++ b/src/core/data-transform.js
@@ -16,7 +16,7 @@ import { runTransforms } from "core/utils";
 export const name = "core/data-transform";
 
 export function run(conf, doc, cb) {
-  Array.from(doc.querySelectorAll("[data-transform]")).forEach(el => {
+  doc.querySelectorAll("[data-transform]").forEach(el => {
     el.innerHTML = runTransforms(el.innerHTML, el.dataset.transform);
     el.removeAttribute("data-transform");
   });

--- a/src/core/figures.js
+++ b/src/core/figures.js
@@ -94,12 +94,12 @@ export function run(conf, doc, cb) {
 }
 
 function normalizeImages(doc) {
-  [
-    ...doc.querySelectorAll(
+  doc
+    .querySelectorAll(
       ":not(picture)>img:not([width]):not([height]):not([srcset])"
-    ),
-  ].forEach(img => {
-    img.height = img.naturalHeight;
-    img.width = img.naturalWidth;
-  });
+    )
+    .forEach(img => {
+      img.height = img.naturalHeight;
+      img.width = img.naturalWidth;
+    });
 }

--- a/src/core/highlight-vars.js
+++ b/src/core/highlight-vars.js
@@ -20,17 +20,17 @@ export function run(conf) {
   styleElement.classList.add("removeOnSave");
   document.head.appendChild(styleElement);
 
-  [...document.querySelectorAll("var")].forEach(varElem =>
-    varElem.addEventListener("click", hightlightListener)
-  );
+  document
+    .querySelectorAll("var")
+    .forEach(varElem => varElem.addEventListener("click", highlightListener));
 
   // remove highlights, cleanup empty class/style attributes
   sub("beforesave", outputDoc => {
-    [...outputDoc.querySelectorAll("var.respec-hl")].forEach(removeHighlight);
+    outputDoc.querySelectorAll("var.respec-hl").forEach(removeHighlight);
   });
 }
 
-function hightlightListener(ev) {
+function highlightListener(ev) {
   ev.stopPropagation();
   const { target: varElem } = ev;
   const hightligtedElems = highlightVars(varElem);
@@ -66,10 +66,7 @@ function getHighlightColor(target) {
   if (HL_COLORS.get("respec-hl-c1") === true) return "respec-hl-c1";
 
   // otherwise get some other available color
-  return (
-    [...HL_COLORS.keys()].find(c => HL_COLORS.get(c)) ||
-    "respec-hl-c1"
-  );
+  return [...HL_COLORS.keys()].find(c => HL_COLORS.get(c)) || "respec-hl-c1";
 }
 
 function highlightVars(varElem) {

--- a/src/core/id-headers.js
+++ b/src/core/id-headers.js
@@ -4,13 +4,12 @@
 
 export const name = "core/id-headers";
 
-export function run(conf, doc, cb) {
-  Array.from(
-    document.querySelectorAll(
+export function run() {
+  document
+    .querySelectorAll(
       "h2:not([id]), h3:not([id]), h4:not([id]), h5:not([id]), h6:not([id])"
     )
-  ).forEach(elem => {
-    $(elem).makeID();
-  });
-  cb();
+    .forEach(elem => {
+      $(elem).makeID();
+    });
 }

--- a/src/core/issues-notes.js
+++ b/src/core/issues-notes.js
@@ -267,12 +267,11 @@ async function processResponse(response, issueNumber) {
 }
 
 export async function run(conf) {
-  const issuesAndNotes = document.querySelectorAll(
-    ".issue, .note, .warning, .ednote"
-  );
-  if (!issuesAndNotes.length) {
+  const query = ".issue, .note, .warning, .ednote";
+  if (!document.querySelector(query)) {
     return; // nothing to do.
   }
+  const issuesAndNotes = document.querySelectorAll(query);
   const ghIssues = conf.githubAPI
     ? await fetchAndStoreGithubIssues(conf)
     : new Map();

--- a/src/core/linter-rules/no-headingless-sections.js
+++ b/src/core/linter-rules/no-headingless-sections.js
@@ -28,7 +28,7 @@ const hasNoHeading = ({ firstElementChild: elem }) => {
 };
 
 function linterFunction(conf, doc) {
-  const offendingElements = Array.from(doc.querySelectorAll("section")).filter(
+  const offendingElements = [...doc.querySelectorAll("section")].filter(
     hasNoHeading
   );
   if (!offendingElements.length) {

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -288,9 +288,7 @@ export function normalizePadding(text = "") {
 
 // RESPEC STUFF
 export function removeReSpec(doc) {
-  Array.from(
-    doc.querySelectorAll(".remove, script[data-requiremodule]")
-  ).forEach(elem => {
+  doc.querySelectorAll(".remove, script[data-requiremodule]").forEach(elem => {
     elem.remove();
   });
 }

--- a/src/core/webidl-index.js
+++ b/src/core/webidl-index.js
@@ -55,9 +55,7 @@ export function run(conf, doc, cb) {
       return collector;
     }, pre);
   // Remove duplicate IDs
-  Array.from(pre.querySelectorAll("*[id]")).forEach(elem =>
-    elem.removeAttribute("id")
-  );
+  pre.querySelectorAll("*[id]").forEach(elem => elem.removeAttribute("id"));
   virtualSummary.appendChild(pre);
   idlIndexSec.appendChild(virtualSummary);
   cb();

--- a/src/w3c/informative.js
+++ b/src/w3c/informative.js
@@ -8,6 +8,9 @@ export function run() {
     .map(informative => informative.querySelector("h2, h3, h4, h5, h6"))
     .filter(heading => heading)
     .forEach(heading => {
-      heading.parentNode.insertBefore(hyperHTML`<p><em>This section is non-normative.</em></p>`, heading.nextSibling);
+      heading.parentNode.insertBefore(
+        hyperHTML`<p><em>This section is non-normative.</em></p>`,
+        heading.nextSibling
+      );
     });
 }

--- a/tests/spec/core/dfn-spec.js
+++ b/tests/spec/core/dfn-spec.js
@@ -74,7 +74,7 @@ describe("Core — Definitions", function() {
           or <a>bar</a>
           or <a>bars</a>
           but not as <a id="link1">bazs</a>
-          or <a id="link2" href="PASS">bar</a>
+          or <a id="link2" href="/PASS">bar</a>
         </section>
       `;
       const ops = makeStandardOps({ pluralize: true }, body);


### PR DESCRIPTION
as all browsers now treat NodeList as `@@iterable`, don't need to convert to array in some cases. 