### PR TITLE
Update to webidl2.js 14

### DIFF
--- a/js/core/templates/webidl-contiguous/attribute.html
+++ b/js/core/templates/webidl-contiguous/attribute.html
@@ -1,3 +1,3 @@
 <span class='idlAttribute' id="{{obj.idlId}}" data-idl data-title='{{obj.name}}'>{{extAttr obj
-}}{{qualifiers}}{{obj.trivia.base}}attribute<span class='idlAttrType'>{{idlType
+}}{{{qualifiers}}}{{{trivia obj.trivia.base}}}attribute<span class='idlAttrType'>{{idlType
 obj}}</span> <span class='idlAttrName'>{{#tryLink obj}}{{obj.escapedName}}{{/tryLink}}</span>;</span>

--- a/js/core/templates/webidl-contiguous/attribute.html
+++ b/js/core/templates/webidl-contiguous/attribute.html
@@ -1,3 +1,3 @@
-<span class='idlAttribute' id="{{obj.idlId}}" data-idl data-title='{{obj.name}}'>{{extAttr obj indent
-}}{{idn indent}}{{qualifiers}}attribute <span class='idlAttrType'>{{idlType obj}}</span> {{pads
-pad}}<span class='idlAttrName'>{{#tryLink obj}}{{escapeAttributeName obj.name}}{{/tryLink}}</span>;</span>
+<span class='idlAttribute' id="{{obj.idlId}}" data-idl data-title='{{obj.name}}'>{{extAttr obj
+}}{{qualifiers}}{{obj.trivia.base}}attribute<span class='idlAttrType'>{{idlType
+obj}}</span> <span class='idlAttrName'>{{#tryLink obj}}{{obj.escapedName}}{{/tryLink}}</span>;</span>

--- a/js/core/templates/webidl-contiguous/callback.html
+++ b/js/core/templates/webidl-contiguous/callback.html
@@ -1,3 +1,3 @@
-<span class='idlCallback' id='{{obj.idlId}}' data-idl data-title='{{obj.name}}'>{{extAttr obj indent
-}}{{obj.trivia.base}}callback <span class='idlCallbackID'>{{#tryLink obj}}{{obj.name
+<span class='idlCallback' id='{{obj.idlId}}' data-idl data-title='{{obj.name}}'>{{extAttr obj
+}}{{{trivia obj.trivia.base}}}callback <span class='idlCallbackID'>{{#tryLink obj}}{{obj.name
 }}{{/tryLink}}</span> =<span class='idlCallbackType'>{{idlType obj}}</span> ({{{children}}});</span>

--- a/js/core/templates/webidl-contiguous/callback.html
+++ b/js/core/templates/webidl-contiguous/callback.html
@@ -1,3 +1,3 @@
 <span class='idlCallback' id='{{obj.idlId}}' data-idl data-title='{{obj.name}}'>{{extAttr obj indent
-}}{{idn indent}}callback <span class='idlCallbackID'>{{#tryLink obj}}{{obj.name
-}}{{/tryLink}}</span> = <span class='idlCallbackType'>{{idlType obj}}</span> ({{{children}}});</span>
+}}{{obj.trivia.base}}callback <span class='idlCallbackID'>{{#tryLink obj}}{{obj.name
+}}{{/tryLink}}</span> =<span class='idlCallbackType'>{{idlType obj}}</span> ({{{children}}});</span>

--- a/js/core/templates/webidl-contiguous/const.html
+++ b/js/core/templates/webidl-contiguous/const.html
@@ -1,4 +1,4 @@
 <span class='idlConst' id="{{obj.idlId}}" data-idl data-title='{{obj.name}}'>{{extAttr obj
-}}{{obj.trivia.base}}const<span class='idlConstType'>{{idlType obj}}</span>{{nullable
+}}{{{trivia obj.trivia.base}}}const<span class='idlConstType'>{{idlType obj}}</span>{{nullable
 }} <span class='idlConstName'>{{#tryLink obj}}{{obj.name}}{{/tryLink
 }}</span> = <span class='idlConstValue'>{{stringifyIdlConst obj.value}}</span>;</span>

--- a/js/core/templates/webidl-contiguous/const.html
+++ b/js/core/templates/webidl-contiguous/const.html
@@ -1,4 +1,4 @@
-<span class='idlConst' id="{{obj.idlId}}" data-idl data-title='{{obj.name}}'>{{extAttr obj indent
-}}{{idn indent}}const <span class='idlConstType'>{{idlType obj}}</span>{{nullable}} {{pads pad
-}}<span class='idlConstName'>{{#tryLink obj}}{{obj.name
-}}{{/tryLink}}</span> = <span class='idlConstValue'>{{stringifyIdlConst obj.value}}</span>;</span>
+<span class='idlConst' id="{{obj.idlId}}" data-idl data-title='{{obj.name}}'>{{extAttr obj
+}}{{obj.trivia.base}}const<span class='idlConstType'>{{idlType obj}}</span>{{nullable
+}} <span class='idlConstName'>{{#tryLink obj}}{{obj.name}}{{/tryLink
+}}</span> = <span class='idlConstValue'>{{stringifyIdlConst obj.value}}</span>;</span>

--- a/js/core/templates/webidl-contiguous/dict-member.html
+++ b/js/core/templates/webidl-contiguous/dict-member.html
@@ -1,4 +1,4 @@
 <span class='idlMember' id="{{obj.idlId}}" data-idl data-title='{{obj.name}}'>{{extAttr obj
-}}{{qualifiers}}<span class='idlMemberType'>{{idlType obj}}</span> <span class='idlMemberName'>{{#tryLink
+}}{{{qualifiers}}}<span class='idlMemberType'>{{idlType obj}}</span> <span class='idlMemberName'>{{#tryLink
 obj}}{{obj.name}}{{/tryLink}}</span>{{#if obj.default}} = <span class='idlMemberValue'>{{
 stringifyIdlConst obj.default}}</span>{{/if}};</span>

--- a/js/core/templates/webidl-contiguous/dict-member.html
+++ b/js/core/templates/webidl-contiguous/dict-member.html
@@ -1,4 +1,4 @@
-<span class='idlMember' id="{{obj.idlId}}" data-idl data-title='{{obj.name}}'>{{extAttr obj indent
-}}{{idn indent}}{{qualifiers}}<span class='idlMemberType'>{{idlType obj}}</span> {{pads typePad
-}}<span class='idlMemberName'>{{#tryLink obj}}{{obj.name}}{{/tryLink}}</span>{{#if obj.default
-}} = <span class='idlMemberValue'>{{stringifyIdlConst obj.default}}</span>{{/if}};</span>
+<span class='idlMember' id="{{obj.idlId}}" data-idl data-title='{{obj.name}}'>{{extAttr obj
+}}{{qualifiers}}<span class='idlMemberType'>{{idlType obj}}</span> <span class='idlMemberName'>{{#tryLink
+obj}}{{obj.name}}{{/tryLink}}</span>{{#if obj.default}} = <span class='idlMemberValue'>{{
+stringifyIdlConst obj.default}}</span>{{/if}};</span>

--- a/js/core/templates/webidl-contiguous/dictionary.html
+++ b/js/core/templates/webidl-contiguous/dictionary.html
@@ -1,4 +1,4 @@
-<span class='idlDictionary' id='{{obj.idlId}}' data-idl data-title='{{obj.name}}'>{{extAttr obj indent
-}}{{idn indent}}{{partial}}dictionary <span class='idlDictionaryID'>{{#tryLink obj}}{{obj.name}}{{/tryLink
-}}</span>{{#if obj.inheritance}} : <span class='idlSuperclass'><a>{{obj.inheritance}}</a></span>{{/if}} &#123;
-{{{children}}}&#125;;</span>
+<span class='idlDictionary' id='{{obj.idlId}}' data-idl data-title='{{obj.name}}'>{{extAttr obj
+}}{{partial}}{{obj.trivia.base}}dictionary <span class='idlDictionaryID'>{{#tryLink obj}}{{obj.name}}{{/tryLink
+}}</span>{{#if obj.inheritance}} : <span class='idlSuperclass'><a>{{obj.inheritance.name}}</a></span>{{/if
+}} &#123;{{{children}}}{{obj.trivia.close}}&#125;;</span>

--- a/js/core/templates/webidl-contiguous/dictionary.html
+++ b/js/core/templates/webidl-contiguous/dictionary.html
@@ -1,4 +1,4 @@
 <span class='idlDictionary' id='{{obj.idlId}}' data-idl data-title='{{obj.name}}'>{{extAttr obj
-}}{{partial}}{{obj.trivia.base}}dictionary <span class='idlDictionaryID'>{{#tryLink obj}}{{obj.name}}{{/tryLink
+}}{{partial}}{{{trivia obj.trivia.base}}}dictionary <span class='idlDictionaryID'>{{#tryLink obj}}{{obj.name}}{{/tryLink
 }}</span>{{#if obj.inheritance}} : <span class='idlSuperclass'><a>{{obj.inheritance.name}}</a></span>{{/if
-}} &#123;{{{children}}}{{obj.trivia.close}}&#125;;</span>
+}} &#123;{{{children}}}{{{trivia obj.trivia.close}}}&#125;;</span>

--- a/js/core/templates/webidl-contiguous/enum-item.html
+++ b/js/core/templates/webidl-contiguous/enum-item.html
@@ -1,2 +1,2 @@
-{{obj.trivia}}<a href="#dom-{{parentID}}-{{lname}}" class="idlEnumItem">"{{obj.value}}"</a>{{#if
-obj.separator}}{{obj.separator.trivia}},{{/if}}
+{{{trivia obj.trivia}}}<a href="#dom-{{parentID}}-{{lname}}" class="idlEnumItem">"{{obj.value}}"</a>{{#if
+obj.separator}}{{{trivia obj.separator.trivia}}},{{/if}}

--- a/js/core/templates/webidl-contiguous/enum-item.html
+++ b/js/core/templates/webidl-contiguous/enum-item.html
@@ -1,1 +1,2 @@
-{{idn indent}}<a href="#dom-{{parentID}}-{{lname}}" class="idlEnumItem">"{{name}}"</a>{{#if needsComma}},{{/if}}
+{{obj.trivia}}<a href="#dom-{{parentID}}-{{lname}}" class="idlEnumItem">"{{obj.value}}"</a>{{#if
+obj.separator}}{{obj.separator.trivia}},{{/if}}

--- a/js/core/templates/webidl-contiguous/enum.html
+++ b/js/core/templates/webidl-contiguous/enum.html
@@ -1,3 +1,3 @@
 <span class='idlEnum' id='{{obj.idlId}}' data-idl data-title='{{obj.name}}'>{{extAttr obj
-}}{{obj.trivia.base}}enum <span class='idlEnumID'>{{#tryLink obj}}{{obj.name}}{{/tryLink
-}}</span> &#123;{{{children}}}{{obj.trivia.close}}&#125;;</span>
+}}{{{trivia obj.trivia.base}}}enum <span class='idlEnumID'>{{#tryLink obj}}{{obj.name}}{{/tryLink
+}}</span> &#123;{{{children}}}{{{trivia obj.trivia.close}}}&#125;;</span>

--- a/js/core/templates/webidl-contiguous/enum.html
+++ b/js/core/templates/webidl-contiguous/enum.html
@@ -1,3 +1,3 @@
-<span class='idlEnum' id='{{obj.idlId}}' data-idl data-title='{{obj.name}}'>{{extAttr obj indent
-}}{{idn indent}}enum <span class='idlEnumID'>{{#tryLink obj}}{{obj.name}}{{/tryLink}}</span> &#123;
-{{{children}}}{{idn indent}}&#125;;</span>
+<span class='idlEnum' id='{{obj.idlId}}' data-idl data-title='{{obj.name}}'>{{extAttr obj
+}}{{obj.trivia.base}}enum <span class='idlEnumID'>{{#tryLink obj}}{{obj.name}}{{/tryLink
+}}</span> &#123;{{{children}}}{{obj.trivia.close}}&#125;;</span>

--- a/js/core/templates/webidl-contiguous/extended-attribute.html
+++ b/js/core/templates/webidl-contiguous/extended-attribute.html
@@ -1,5 +1,5 @@
 {{!-- extAttrs should match the structure at https://github.com/darobin/webidl2.js#extended-attributes.
---}}{{extAttrs.trivia.open}}[{{#join extAttrs.items sep
+--}}{{{trivia extAttrs.trivia.open}}}[{{#join extAttrs.items sep
   }}<span class='{{extAttrClassName}}'><span class="extAttrName">{{name
   }}</span>{{#if rhs}}=<span class="extAttrRhs">{{#extAttrRhs rhs}}{{ this }}{{/extAttrRhs}}</span>{{/if
   }}{{#jsIf signature}}({{#joinNonWhitespace signature.arguments ","}}{{param this}}{{/joinNonWhitespace}}){{/jsIf

--- a/js/core/templates/webidl-contiguous/extended-attribute.html
+++ b/js/core/templates/webidl-contiguous/extended-attribute.html
@@ -1,6 +1,6 @@
 {{!-- extAttrs should match the structure at https://github.com/darobin/webidl2.js#extended-attributes.
 --}}{{{trivia extAttrs.trivia.open}}}[{{#join extAttrs.items sep
-  }}<span class='{{extAttrClassName}}'><span class="extAttrName">{{name
-  }}</span>{{#if rhs}}=<span class="extAttrRhs">{{#extAttrRhs rhs}}{{ this }}{{/extAttrRhs}}</span>{{/if
-  }}{{#jsIf signature}}({{#joinNonWhitespace signature.arguments ","}}{{param this}}{{/joinNonWhitespace}}){{/jsIf
+}}{{{trivia trivia.name}}}<span class='{{extAttrClassName}}'><span class="extAttrName">{{name
+}}</span>{{#if rhs}}=<span class="extAttrRhs">{{#extAttrRhs rhs}}{{ this }}{{/extAttrRhs}}</span>{{/if
+}}{{#jsIf signature}}({{#joinNonWhitespace signature.arguments ","}}{{param this}}{{/joinNonWhitespace}}){{/jsIf
 }}</span>{{/join}}]

--- a/js/core/templates/webidl-contiguous/extended-attribute.html
+++ b/js/core/templates/webidl-contiguous/extended-attribute.html
@@ -1,5 +1,5 @@
 {{!-- extAttrs should match the structure at https://github.com/darobin/webidl2.js#extended-attributes.
---}}{{{trivia extAttrs.trivia.open}}}[{{#join extAttrs.items sep
+--}}{{{trivia extAttrs.trivia.open}}}[{{#join extAttrs.items ","
 }}{{{trivia trivia.name}}}<span class='{{extAttrClassName}}'><span class="extAttrName">{{name
 }}</span>{{#if rhs}}=<span class="extAttrRhs">{{#extAttrRhs rhs}}{{ this }}{{/extAttrRhs}}</span>{{/if
 }}{{#jsIf signature}}({{#joinNonWhitespace signature.arguments ","}}{{param this}}{{/joinNonWhitespace}}){{/jsIf

--- a/js/core/templates/webidl-contiguous/extended-attribute.html
+++ b/js/core/templates/webidl-contiguous/extended-attribute.html
@@ -1,6 +1,6 @@
 {{!-- extAttrs should match the structure at https://github.com/darobin/webidl2.js#extended-attributes.
---}}{{idn indent}}[{{#join extAttrs sep
+--}}{{extAttrs.trivia.open}}[{{#join extAttrs.items sep
   }}<span class='{{extAttrClassName}}'><span class="extAttrName">{{name
   }}</span>{{#if rhs}}=<span class="extAttrRhs">{{#extAttrRhs rhs}}{{ this }}{{/extAttrRhs}}</span>{{/if
-  }}{{#jsIf arguments}}({{#joinNonWhitespace arguments ", "}}{{param this}}{{/joinNonWhitespace}}){{/jsIf
-}}</span>{{/join}}]{{end}}
+  }}{{#jsIf signature}}({{#joinNonWhitespace signature.arguments ","}}{{param this}}{{/joinNonWhitespace}}){{/jsIf
+}}</span>{{/join}}]

--- a/js/core/templates/webidl-contiguous/field.html
+++ b/js/core/templates/webidl-contiguous/field.html
@@ -1,3 +1,3 @@
-<span class='idlField' id="{{obj.idlId}}" data-idl data-title='{{obj.name}}'>{{extAttr obj indent
+<span class='idlField' id="{{obj.idlId}}" data-idl data-title='{{obj.name}}'>{{extAttr obj
 }}{{idn indent}}<span class='idlFieldType'>{{idlType obj}}</span> {{pads
 pad}}<span class='idlFieldName'>{{#tryLink obj}}{{obj.name}}{{/tryLink}}</span>;</span>

--- a/js/core/templates/webidl-contiguous/field.html
+++ b/js/core/templates/webidl-contiguous/field.html
@@ -1,3 +1,3 @@
 <span class='idlField' id="{{obj.idlId}}" data-idl data-title='{{obj.name}}'>{{extAttr obj
-}}{{idn indent}}<span class='idlFieldType'>{{idlType obj}}</span> {{pads
+}}<span class='idlFieldType'>{{idlType obj}}</span> {{pads
 pad}}<span class='idlFieldName'>{{#tryLink obj}}{{obj.name}}{{/tryLink}}</span>;</span>

--- a/js/core/templates/webidl-contiguous/implements.html
+++ b/js/core/templates/webidl-contiguous/implements.html
@@ -1,2 +1,2 @@
-<span class='idlImplements'>{{extAttr obj indent
-}}{{idn indent}}<a>{{obj.target}}</a> implements <a>{{obj.implements}}</a>;</span>
+<span class='idlImplements'>{{extAttr obj}}{{{trivia
+obj.trivia.target}}}<a>{{obj.target}}</a> implements <a>{{obj.implements}}</a>;</span>

--- a/js/core/templates/webidl-contiguous/includes.html
+++ b/js/core/templates/webidl-contiguous/includes.html
@@ -1,2 +1,2 @@
-<span class='idlIncludes'>{{extAttr obj indent
-}}{{idn indent}}<a>{{obj.target}}</a> includes <a>{{obj.includes}}</a>;</span>
+<span class='idlIncludes'>{{extAttr obj
+}}{{obj.trivia.target}}<a>{{obj.target}}</a> includes <a>{{obj.includes}}</a>;</span>

--- a/js/core/templates/webidl-contiguous/includes.html
+++ b/js/core/templates/webidl-contiguous/includes.html
@@ -1,2 +1,2 @@
-<span class='idlIncludes'>{{extAttr obj
-}}{{obj.trivia.target}}<a>{{obj.target}}</a> includes <a>{{obj.includes}}</a>;</span>
+<span class='idlIncludes'>{{extAttr obj}}{{{trivia
+obj.trivia.target}}}<a>{{obj.target}}</a> includes <a>{{obj.includes}}</a>;</span>

--- a/js/core/templates/webidl-contiguous/interface.html
+++ b/js/core/templates/webidl-contiguous/interface.html
@@ -1,4 +1,4 @@
 <span class='idlInterface' id='{{obj.idlId}}' data-idl data-title='{{obj.name}}'>{{extAttr obj
-}}{{partial}}{{callback}}{{obj.trivia.base}}interface{{mixin}} <span class='idlInterfaceID'>{{#tryLink
+}}{{partial}}{{callback}}{{{trivia obj.trivia.base}}}interface{{{mixin}}} <span class='idlInterfaceID'>{{#tryLink
 obj}}{{obj.name}}{{/tryLink}}</span>{{#if obj.inheritance}} : <span class='idlSuperclass'><a>{{
-obj.inheritance.name}}</a></span>{{/if}} &#123;{{{children}}}{{obj.trivia.close}}&#125;;</span>
+obj.inheritance.name}}</a></span>{{/if}} &#123;{{{children}}}{{{trivia obj.trivia.close}}}&#125;;</span>

--- a/js/core/templates/webidl-contiguous/interface.html
+++ b/js/core/templates/webidl-contiguous/interface.html
@@ -1,4 +1,4 @@
-<span class='idlInterface' id='{{obj.idlId}}' data-idl data-title='{{obj.name}}'>{{extAttr obj indent
-}}{{idn indent}}{{partial}}{{callback}}interface {{mixin}}<span class='idlInterfaceID'>{{#tryLink obj}}{{obj.name}}{{/tryLink
-}}</span>{{#if obj.inheritance}} : <span class='idlSuperclass'><a>{{obj.inheritance}}</a></span>{{/if}} &#123;
-{{{children}}}{{idn indent}}&#125;;</span>
+<span class='idlInterface' id='{{obj.idlId}}' data-idl data-title='{{obj.name}}'>{{extAttr obj
+}}{{partial}}{{callback}}{{obj.trivia.base}}interface{{mixin}} <span class='idlInterfaceID'>{{#tryLink
+obj}}{{obj.name}}{{/tryLink}}</span>{{#if obj.inheritance}} : <span class='idlSuperclass'><a>{{
+obj.inheritance.name}}</a></span>{{/if}} &#123;{{{children}}}{{obj.trivia.close}}&#125;;</span>

--- a/js/core/templates/webidl-contiguous/iterable-like.html
+++ b/js/core/templates/webidl-contiguous/iterable-like.html
@@ -1,3 +1,3 @@
-<span class='{{className}}' id="{{obj.idlId}}" data-idl data-title='iterable'>{{
-obj.trivia.base}}{{extAttr obj}}{{qualifiers}}{{#tryLink obj}}{{obj.type}}{{/tryLink
+<span class='{{className}}' id="{{obj.idlId}}" data-idl data-title='iterable'>{{{trivia
+obj.trivia.base}}}{{extAttr obj}}{{qualifiers}}{{#tryLink obj}}{{obj.type}}{{/tryLink
 }}&lt;{{idlType obj}}&gt;;</span>

--- a/js/core/templates/webidl-contiguous/iterable-like.html
+++ b/js/core/templates/webidl-contiguous/iterable-like.html
@@ -1,3 +1,3 @@
-<span class='{{className}}' id="{{obj.idlId}}" data-idl data-title='iterable'>{{extAttr obj indent
-}}{{idn indent}}{{qualifiers}}{{#tryLink obj}}{{obj.type}}{{/tryLink
+<span class='{{className}}' id="{{obj.idlId}}" data-idl data-title='iterable'>{{
+obj.trivia.base}}{{extAttr obj}}{{qualifiers}}{{#tryLink obj}}{{obj.type}}{{/tryLink
 }}&lt;{{idlType obj}}&gt;;</span>

--- a/js/core/templates/webidl-contiguous/line-comment.html
+++ b/js/core/templates/webidl-contiguous/line-comment.html
@@ -1,1 +1,1 @@
-<span class='idlSectionComment'>{{idn indent}}//{{comment}}</span>
+<span class='idlSectionComment'>{{text}}</span>

--- a/js/core/templates/webidl-contiguous/method.html
+++ b/js/core/templates/webidl-contiguous/method.html
@@ -1,3 +1,3 @@
-<span class='idlMethod' id="{{obj.idlId}}" data-idl data-title='{{obj.name}}'>{{idn indent}}{{extAttrInline obj indent
-}}{{special}}{{#if obj.idlType}}<span class='idlMethType'>{{idlType obj}}</span> {{pads pad
-}}{{#if obj.name}}<span class='idlMethName'>{{#tryLink obj}}{{obj.name}}{{/tryLink}}</span>{{/if}}({{{children}}}){{/if}};</span>
+<span class='idlMethod' id="{{obj.idlId}}" data-idl data-title='{{name}}'>{{extAttrInline obj
+}}{{special}}{{#if obj.body}}<span class='idlMethType'>{{idlType obj.body}}</span> {{#if name
+}}<span class='idlMethName'>{{#tryLink obj}}{{name}}{{/tryLink}}</span>{{/if}}({{{children}}}){{/if}};</span>

--- a/js/core/templates/webidl-contiguous/method.html
+++ b/js/core/templates/webidl-contiguous/method.html
@@ -1,3 +1,3 @@
 <span class='idlMethod' id="{{obj.idlId}}" data-idl data-title='{{name}}'>{{extAttrInline obj
-}}{{special}}{{#if obj.body}}<span class='idlMethType'>{{idlType obj.body}}</span> {{#if name
+}}{{{special}}}{{#if obj.body}}<span class='idlMethType'>{{idlType obj.body}}</span> {{#if name
 }}<span class='idlMethName'>{{#tryLink obj}}{{name}}{{/tryLink}}</span>{{/if}}({{{children}}}){{/if}};</span>

--- a/js/core/templates/webidl-contiguous/multiline-comment.html
+++ b/js/core/templates/webidl-contiguous/multiline-comment.html
@@ -1,3 +1,0 @@
-<span class='idlSectionComment'>{{idn indent}}/*{{firstLine}}
-{{#each innerLine}}{{idn ../indent}}{{this}}
-{{/each}}{{idn indent}}{{lastLine}}*/</span>

--- a/js/core/templates/webidl-contiguous/param.html
+++ b/js/core/templates/webidl-contiguous/param.html
@@ -1,5 +1,5 @@
 {{!-- obj is an instance of https://github.com/darobin/webidl2.js#arguments
 --}}<span class='idlParam'>{{extAttrInline obj
 }}{{optional}}<span class='idlParamType'>{{idlType obj}}{{variadic
-}}</span> <span class='idlParamName'>{{obj.name}}</span>{{#if obj.default
+}}</span> <span class='idlParamName'>{{obj.escapedName}}</span>{{#if obj.default
 }} = <span class='idlDefaultValue'>{{stringifyIdlConst obj.default}}</span>{{/if}}</span>

--- a/js/core/templates/webidl-contiguous/typedef.html
+++ b/js/core/templates/webidl-contiguous/typedef.html
@@ -1,2 +1,2 @@
-<span class='idlTypedef' id='{{obj.idlId}}' data-idl data-title='{{obj.name}}'>typedef <span class='idlTypedefType'>{{idlType obj
+<span class='idlTypedef' id='{{obj.idlId}}' data-idl data-title='{{obj.name}}'>typedef<span class='idlTypedefType'>{{idlType obj
 }}</span> <span class='idlTypedefID'>{{#tryLink obj}}{{obj.name}}{{/tryLink}}</span>;</span>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4751,9 +4751,9 @@
       }
     },
     "karma": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-2.0.3.tgz",
-      "integrity": "sha512-7bVCQs8+DCLWj5TIUBIgPa95/o8X9pBhyF+E2hX51Z6Ttq2biYWQlynBmunKZGRyNOIyg89TnVtC58q9eGBFFw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-2.0.4.tgz",
+      "integrity": "sha512-32yhTwoi6BZgJZhR78GwhzyFABbYG/1WwQqYgY7Vh96Demvua2jM3+FyRltIMTUH/Kd5xaQvDw2L7jTvkYFeXg==",
       "dev": true,
       "requires": {
         "bluebird": "^3.3.0",
@@ -5909,9 +5909,9 @@
       }
     },
     "mailgun-js": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/mailgun-js/-/mailgun-js-0.18.0.tgz",
-      "integrity": "sha512-o0P6jjZlx5CQj12tvVgDTbgjTqVN0+5h6/6P1+3c6xmozVKBwniQ6Qt3MkCSF0+ueVTbobAfWyGpWRZMJu8t1g==",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/mailgun-js/-/mailgun-js-0.18.1.tgz",
+      "integrity": "sha512-lvuMP14u24HS2uBsJEnzSyPMxzU2b99tQsIx1o6QNjqxjk8b3WvR+vq5oG1mjqz/IBYo+5gF+uSoDS0RkMVHmg==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -9012,9 +9012,9 @@
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
     },
     "webidl2": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/webidl2/-/webidl2-10.3.3.tgz",
-      "integrity": "sha512-C3rxCpkX2XQ9FW1EIllN0nW2zlN21S+PgE59xQ6ErI5awVaXYm3TTsDDsdCYIfwjVwNZZIpKjcW1xJF89ZlAew==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/webidl2/-/webidl2-14.0.0.tgz",
+      "integrity": "sha512-e78hGcpFGw51Yx1SpRgIEx0+xxgBFo9w9EMsTtzZX2jpvT2Edtew+EECWDk3rVaamfGXgsbeUpB1CYqiHaaapw==",
       "dev": true
     },
     "whatwg-encoding": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9012,9 +9012,9 @@
       "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
     },
     "webidl2": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/webidl2/-/webidl2-14.0.0.tgz",
-      "integrity": "sha512-e78hGcpFGw51Yx1SpRgIEx0+xxgBFo9w9EMsTtzZX2jpvT2Edtew+EECWDk3rVaamfGXgsbeUpB1CYqiHaaapw==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/webidl2/-/webidl2-14.0.1.tgz",
+      "integrity": "sha512-sAb1biHP+jYZ7OBBDjEIuSfOBor4m8u9tHCFkekvBAnmrJgEGNDjzdKgBz7Ea763iVWQxzakB6WRxfr5JXCIOw==",
       "dev": true
     },
     "whatwg-encoding": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "text": "github:requirejs/text#d04de4ffd7bf5ba6cb80cdca2d40d4f6f52a1b1f",
     "uglify-es": "3.3.7",
     "url-search-params": "^0.10.0",
-    "webidl2": "^10.3.3"
+    "webidl2": "^14.0.0"
   },
   "scripts": {
     "babel:build": "babel src -d js --source-maps -q",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "text": "github:requirejs/text#d04de4ffd7bf5ba6cb80cdca2d40d4f6f52a1b1f",
     "uglify-es": "3.3.7",
     "url-search-params": "^0.10.0",
-    "webidl2": "^14.0.0"
+    "webidl2": "^14.0.1"
   },
   "scripts": {
     "babel:build": "babel src -d js --source-maps -q",

--- a/src/core/webidl-index.js
+++ b/src/core/webidl-index.js
@@ -45,8 +45,8 @@ export function run(conf, doc, cb) {
       const { children } = elem.cloneNode(true);
       for (const child of Array.from(children)) {
         span.appendChild(child);
-        span.appendChild(document.createTextNode("\n"));
       }
+      span.appendChild(document.createTextNode("\n"));
       span.classList.add("respec-idl-separator");
       return span;
     })

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -450,7 +450,9 @@ function writeDefinition(obj) {
       const paramObjs = obj.arguments.map(it =>
         idlParamTmpl({
           obj: it,
-          optional: it.optional ? `${writeTrivia(it.optional.trivia)}optional` : "",
+          optional: it.optional
+            ? `${writeTrivia(it.optional.trivia)}optional`
+            : "",
           variadic: it.variadic ? "..." : "",
         })
       );
@@ -513,7 +515,9 @@ function writeInterfaceDefinition(opt, fixes = {}) {
   return idlInterfaceTmpl({
     obj,
     partial: obj.partial ? `${writeTrivia(obj.partial.trivia)}partial` : "",
-    callback: fixes.callback ? `${writeTrivia(obj.trivia.callback)}callback` : "",
+    callback: fixes.callback
+      ? `${writeTrivia(obj.trivia.callback)}callback`
+      : "",
     mixin: fixes.mixin ? `${writeTrivia(obj.trivia.mixin)}mixin` : "",
     children,
   });
@@ -530,12 +534,10 @@ function writeField(attr, max, indent) {
 
 function writeAttributeQualifiers(attr) {
   var qualifiers = "";
-  if (attr.static)
-    qualifiers += `${writeTrivia(attr.static.trivia)}static`;
+  if (attr.static) qualifiers += `${writeTrivia(attr.static.trivia)}static`;
   if (attr.stringifier)
     qualifiers += `${writeTrivia(attr.stringifier.trivia)}stringifier`;
-  if (attr.inherit)
-    qualifiers += `${writeTrivia(attr.inherit.trivia)}inherit`;
+  if (attr.inherit) qualifiers += `${writeTrivia(attr.inherit.trivia)}inherit`;
   if (attr.readonly)
     qualifiers += `${writeTrivia(attr.readonly.trivia)}readonly`;
   return qualifiers;

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -568,19 +568,17 @@ function writeMethod(meth) {
       })
     );
   var params = paramObjs.join(", ");
-  var specialProps = [
+  var modifiers = [
     "getter",
     "setter",
     "deleter",
     "stringifier",
-    "static", // not "special op", but serves same role
+    "static",
   ];
   var special = "";
-  for (const specialProp of specialProps) {
+  for (const specialProp of modifiers) {
     if (meth[specialProp]) {
       special = writeTrivia(meth[specialProp].trivia) + specialProp;
-      len += special.length;
-      break;
     }
   }
   const methObj = {

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -558,7 +558,7 @@ function writeAttribute(attr, max, indent, maxQualifiers) {
 }
 
 function writeMethod(meth) {
-  var paramObjs = ((meth.body && meth.body.arguments) || [])
+  const paramObjs = ((meth.body && meth.body.arguments) || [])
     .filter(it => !typeIsWhitespace(it.type))
     .map(it =>
       idlParamTmpl({
@@ -567,15 +567,9 @@ function writeMethod(meth) {
         variadic: it.variadic ? "..." : "",
       })
     );
-  var params = paramObjs.join(", ");
-  var modifiers = [
-    "getter",
-    "setter",
-    "deleter",
-    "stringifier",
-    "static",
-  ];
-  var special = "";
+  const params = paramObjs.join(", ");
+  const modifiers = ["getter", "setter", "deleter", "stringifier", "static"];
+  let special = "";
   for (const specialProp of modifiers) {
     if (meth[specialProp]) {
       special = writeTrivia(meth[specialProp].trivia) + specialProp;

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -253,18 +253,13 @@ function extAttr(extAttrs, indent, singleLine) {
     // If there are no extended attributes, omit the [] entirely.
     return "";
   }
-  var opt = {
-    extAttrs,
-    sep: ","
-  };
+  const opt = { extAttrs };
   const safeString = new hb.SafeString(idlExtAttributeTmpl(opt));
   const tmpParser = document.createElement("div");
   tmpParser.innerHTML = safeString;
   Array.from(tmpParser.querySelectorAll(".extAttrName"))
-    .filter(function(elem) {
-      return extenedAttributesLinks.has(elem.textContent);
-    })
-    .forEach(function(elem) {
+    .filter(elem => extenedAttributesLinks.has(elem.textContent))
+    .forEach(elem => {
       const a = elem.ownerDocument.createElement("a");
       a.dataset.cite = extenedAttributesLinks.get(elem.textContent);
       a.textContent = elem.textContent;

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -71,9 +71,6 @@ function registerHelpers() {
       return options.inverse(this);
     }
   });
-  hb.registerHelper("idn", function(indent) {
-    return new hb.SafeString(idn(indent));
-  });
   hb.registerHelper("idlType", function(obj) {
     return new hb.SafeString(idlType2Html(obj.idlType));
   });
@@ -148,10 +145,6 @@ function writeTrivia(text) {
     return "";
   }
   return idlLineCommentTmpl({ text });
-}
-
-function idn(lvl) {
-  return "    ".repeat(lvl);
 }
 
 function idlType2Html(idlType) {
@@ -261,9 +254,8 @@ function extAttr(extAttrs, indent, singleLine) {
     return "";
   }
   var opt = {
-    extAttrs: extAttrs,
-    indent: indent,
-    sep: singleLine ? ", " : ",\n " + idn(indent),
+    extAttrs,
+    sep: ","
   };
   const safeString = new hb.SafeString(idlExtAttributeTmpl(opt));
   const tmpParser = document.createElement("div");

--- a/tests/spec/core/idl-index-spec.js
+++ b/tests/spec/core/idl-index-spec.js
@@ -21,10 +21,10 @@ describe("Core — IDL Index", () => {
       <section id="idl-index"></section>
     `;
     const expectedIDL = `interface Foo {
-    readonly attribute DOMString bar;
+  readonly attribute DOMString bar;
 };
 interface Bar {
-    readonly attribute DOMString foo;
+  readonly attribute DOMString foo;
 };\n`;
     const ops = {
       config: makeBasicConfig(),
@@ -61,7 +61,7 @@ interface BeforeInstallPromptEvent : Event {
     Promise<PromptResponseObject> prompt();
 };
 dictionary PromptResponseObject {
-    AppBannerPromptOutcome userChoice;
+  AppBannerPromptOutcome userChoice;
 };\n`;
     const ops = {
       config: makeBasicConfig(),

--- a/tests/spec/core/idl-index-spec.js
+++ b/tests/spec/core/idl-index-spec.js
@@ -55,8 +55,7 @@ interface Bar {
       </section>
       <section id="idl-index"></section>
     `;
-    const expectedIDL = `[Constructor,
- Exposed=Window]
+    const expectedIDL = `[Constructor, Exposed=Window]
 interface BeforeInstallPromptEvent : Event {
     Promise<PromptResponseObject> prompt();
 };

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -116,8 +116,7 @@ describe("Core - WebIDL", function() {
     expect($target.find(".idlCtor").text()).toEqual("Constructor()");
 
     $target = $("#if-identifier-list", doc);
-    text =
-      "[Global=Window,\n Exposed=(Window,Worker)] interface SuperStar {};";
+    text = "[Global=Window,\n Exposed=(Window,Worker)] interface SuperStar {};";
     expect($target.text()).toEqual(text);
     expect($target.find(".extAttrRhs").first().text()).toEqual("Window");
     expect($target.find(".extAttrRhs").last().text()).toEqual(

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -11,7 +11,7 @@ describe("Core - WebIDL", function() {
     const idl = doc.querySelector("#records pre");
     expect(idl).toBeTruthy(idl);
     expect(idl.querySelector(".idlMemberType:first-child").textContent).toEqual(
-      "record<DOMString, USVString>"
+      "\n  record<DOMString, USVString>"
     );
     expect(idl.querySelector(".idlMemberName").textContent).toEqual("pass");
     done();
@@ -258,7 +258,7 @@ describe("Core - WebIDL", function() {
     expect($target.text()).toEqual(text);
     expect($target.find(".idlConst").length).toEqual(19);
     var $const1 = $target.find(".idlConst").first();
-    expect($const1.find(".idlConstType").text()).toEqual("boolean");
+    expect($const1.find(".idlConstType").text()).toEqual(" boolean");
     expect($const1.find(".idlConstName").text()).toEqual("test");
     expect($const1.find(".idlConstValue").text()).toEqual("true");
     expect($target.find(".idlConst").last().find(".extAttr").length).toEqual(1);
@@ -305,16 +305,16 @@ describe("Core - WebIDL", function() {
     expect($target.text()).toEqual(text);
     expect($target.find(".idlAttribute").length).toEqual(8);
     var $at = $target.find(".idlAttribute").first();
-    expect($at.find(".idlAttrType").text()).toEqual("DOMString");
+    expect($at.find(".idlAttrType").text()).toEqual(" DOMString");
     expect($at.find(".idlAttrName").text()).toEqual("regular");
     var $ro = $target.find(".idlAttribute").eq(2);
     expect($ro.find(".idlAttrName").text()).toEqual("_readonly");
     var $frozen = $target.find(".idlAttribute").eq(6);
     expect($frozen.find(".idlAttrType").text()).toEqual(
-      "FrozenArray<DOMString>"
+      " FrozenArray<DOMString>"
     );
     var $promise = $target.find(".idlAttribute").eq(7);
-    expect($promise.find(".idlAttrType").text()).toEqual("Promise<DOMString>");
+    expect($promise.find(".idlAttrType").text()).toEqual(" Promise<DOMString>");
     expect(
       $target.find(":contains('_readonly')").parents(".idlAttribute").attr("id")
     ).toEqual("idl-def-attrbasic-readonly");
@@ -328,11 +328,11 @@ describe("Core - WebIDL", function() {
     const stringifierTestElems = [...doc.querySelectorAll("#stringifiertest .idlMethod")];
     const [stringifierAnon, stringifierNamed] = stringifierTestElems;
     expect(stringifierAnon).toBeTruthy();
-    expect(stringifierAnon.querySelector(".idlMethType").textContent).toBe("StringPass");
+    expect(stringifierAnon.querySelector(".idlMethType").textContent).toBe(" StringPass");
     expect(stringifierAnon.querySelector(".idlMethName")).toBeNull();
     
     expect(stringifierNamed).toBeTruthy();
-    expect(stringifierNamed.querySelector(".idlMethType").textContent).toBe("StringNamedPass");
+    expect(stringifierNamed.querySelector(".idlMethType").textContent).toBe(" StringNamedPass");
     expect(stringifierNamed.querySelector(".idlMethName").textContent).toBe("named");
   });
   
@@ -340,11 +340,11 @@ describe("Core - WebIDL", function() {
     const getterTestElems = [...doc.querySelectorAll("#gettertest .idlMethod")];
     const [getterAnon, getterNamed] = getterTestElems;
     expect(getterAnon).toBeTruthy();
-    expect(getterAnon.querySelector(".idlMethType").textContent).toBe("GetterPass");
+    expect(getterAnon.querySelector(".idlMethType").textContent).toBe(" GetterPass");
     expect(getterAnon.querySelector(".idlMethName")).toBeNull();
     
     expect(getterNamed).toBeTruthy();
-    expect(getterNamed.querySelector(".idlMethType").textContent).toBe("GetterNamedPass");
+    expect(getterNamed.querySelector(".idlMethType").textContent).toBe(" GetterNamedPass");
     expect(getterNamed.querySelector(".idlMethName").textContent).toBe("named");
   });
   
@@ -352,11 +352,11 @@ describe("Core - WebIDL", function() {
     const setterTestElems = [...doc.querySelectorAll("#settertest .idlMethod")];
     const [setterAnon, setterNamed] = setterTestElems;
     expect(setterAnon).toBeTruthy();
-    expect(setterAnon.querySelector(".idlMethType").textContent).toBe("SetterPass");
+    expect(setterAnon.querySelector(".idlMethType").textContent).toBe(" SetterPass");
     expect(setterAnon.querySelector(".idlMethName")).toBeNull();
     
     expect(setterNamed).toBeTruthy();
-    expect(setterNamed.querySelector(".idlMethType").textContent).toBe("SetterNamedPass");
+    expect(setterNamed.querySelector(".idlMethType").textContent).toBe(" SetterNamedPass");
     expect(setterNamed.querySelector(".idlMethName").textContent).toBe("named");
   });
   
@@ -392,7 +392,7 @@ describe("Core - WebIDL", function() {
     expect($target.find(".idlMethod").length).toEqual(12);
     expect($target.find(".idlMethName").length).toEqual(8);
     var $meth = $target.find(".idlMethod").first();
-    expect($meth.find(".idlMethType").text()).toEqual("void");
+    expect($meth.find(".idlMethType").text()).toEqual("\n  // 1\n  void");
     expect($meth.find(".idlMethName").text()).toEqual("basic");
     expect(
       $target.find(".idlMethType:contains('SuperStar?') a").text()
@@ -429,7 +429,7 @@ describe("Core - WebIDL", function() {
       "     three. */\n" +
       "};";
     expect($target.text()).toEqual(text);
-    expect($target.find(".idlSectionComment").length).toEqual(3);
+    expect($target.find(".idlSectionComment").length).toEqual(1);
     done();
   });
 
@@ -471,7 +471,7 @@ describe("Core - WebIDL", function() {
     expect($target.text()).toEqual(text);
     expect($target.find(".idlMember").length).toEqual(9);
     var $mem = $target.find(".idlMember").first();
-    expect($mem.find(".idlMemberType").text()).toEqual("DOMString");
+    expect($mem.find(".idlMemberType").text()).toEqual("\n  // 1\n  DOMString");
     expect($mem.find(".idlMemberName").text()).toEqual("value");
     expect(
       $target.find(".idlMember").last().find(".idlMemberValue").text()
@@ -480,8 +480,8 @@ describe("Core - WebIDL", function() {
     $target = $("#dict-required-fields", doc);
     text =
       "dictionary SuperStar {\n" +
-      "    required DOMString value;\n" +
-      "             DOMString optValue;\n" +
+      "  required DOMString value;\n" +
+      "  DOMString optValue;\n" +
       "};";
     expect($target.text()).toEqual(text);
 
@@ -572,17 +572,17 @@ describe("Core - WebIDL", function() {
     expect($target.text()).toEqual(text);
     expect($target.find(".idlCallback").length).toEqual(1);
     expect($target.find(".idlCallbackID").text()).toEqual("SuperStar");
-    expect($target.find(".idlCallbackType").text()).toEqual("void");
+    expect($target.find(".idlCallbackType").text()).toEqual(" void");
 
     $target = $("#cb-less-basic", doc);
     text = "callback CbLessBasic = unsigned long long? (optional any value);";
     expect($target.text()).toEqual(text);
     expect($target.find(".idlCallbackType").text()).toEqual(
-      "unsigned long long?"
+      " unsigned long long?"
     );
     var $prm = $target.find(".idlCallback").last().find(".idlParam");
     expect($prm.length).toEqual(1);
-    expect($prm.find(".idlParamType").text()).toEqual("any");
+    expect($prm.find(".idlParamType").text()).toEqual(" any");
     expect($prm.find(".idlParamName").text()).toEqual("value");
 
     // Links and IDs.
@@ -600,7 +600,7 @@ describe("Core - WebIDL", function() {
     expect($prm.length).toEqual(2);
     expect($prm.find(".idlParamType").first().text()).toEqual("any");
     expect($prm.find(".idlParamName").first().text()).toEqual("a");
-    expect($prm.find(".idlParamType").last().text()).toEqual("any");
+    expect($prm.find(".idlParamType").last().text()).toEqual(" any");
     expect($prm.find(".idlParamName").last().text()).toEqual("b");
     done();
   });
@@ -611,7 +611,7 @@ describe("Core - WebIDL", function() {
     expect(target.textContent).toEqual(text);
     expect(target.querySelectorAll(".idlTypedef").length).toEqual(1);
     expect(target.querySelector(".idlTypedefID").textContent).toEqual("string");
-    expect(target.querySelector(".idlTypedefType").textContent).toEqual("DOMString");
+    expect(target.querySelector(".idlTypedefType").textContent).toEqual(" DOMString");
 
     target = doc.getElementById("td-less-basic");
     text = "typedef unsigned long long? tdLessBasic;";

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -104,20 +104,20 @@ describe("Core - WebIDL", function() {
   });
   it("should handle interfaces", function(done) {
     var $target = $("#if-basic", doc);
-    var text = "interface SuperStar {\n};";
+    var text = "interface SuperStar {};";
     expect($target.text()).toEqual(text);
     expect($target.find(".idlInterface").length).toEqual(1);
     expect($target.find(".idlInterfaceID").text()).toEqual("SuperStar");
 
     $target = $("#if-extended-attribute", doc);
-    text = "[Something,\n Constructor()]\n" + text;
+    text = "[Something,\n Constructor()] " + text;
     expect($target.text()).toEqual(text);
     expect($target.find(".extAttr").text()).toEqual("Something");
     expect($target.find(".idlCtor").text()).toEqual("Constructor()");
 
     $target = $("#if-identifier-list", doc);
     text =
-      "[Global=Window,\n Exposed=(Window,Worker)]\ninterface SuperStar {\n};";
+      "[Global=Window,\n Exposed=(Window,Worker)] interface SuperStar {};";
     expect($target.text()).toEqual(text);
     expect($target.find(".extAttrRhs").first().text()).toEqual("Window");
     expect($target.find(".extAttrRhs").last().text()).toEqual(
@@ -125,24 +125,24 @@ describe("Core - WebIDL", function() {
     );
 
     $target = $("#if-inheritance", doc);
-    text = "interface SuperStar : HyperStar {\n};";
+    text = "interface SuperStar : HyperStar {};";
     expect($target.text()).toEqual(text);
     expect($target.find(".idlSuperclass").text()).toEqual("HyperStar");
 
     $target = $("#if-partial", doc);
-    text = "partial interface SuperStar {\n};";
+    text = "partial interface SuperStar {};";
     expect($target.text()).toEqual(text);
 
     $target = $("#if-callback", doc);
-    text = "callback interface SuperStar {\n};";
+    text = "callback interface SuperStar {};";
     expect($target.text()).toEqual(text);
 
     $target = $("#if-mixin", doc);
-    text = "interface mixin SuperStar {\n};";
+    text = "interface mixin SuperStar {};";
     expect($target.text()).toEqual(text);
 
     $target = $("#if-partial-mixin", doc);
-    text = "partial interface mixin SuperStar {\n};";
+    text = "partial interface mixin SuperStar {};";
     expect($target.text()).toEqual(text);
 
     $target = $("#if-doc", doc);
@@ -174,8 +174,7 @@ describe("Core - WebIDL", function() {
       "[Something,\n" +
       " Constructor,\n" +
       " Constructor(boolean bar, sequence<double> foo, Promise<double> blah)]\n" +
-      "interface SuperStar {\n" +
-      "};";
+      "interface SuperStar {};";
     expect($target.text()).toEqual(text);
     expect($target.find(".idlCtor").length).toEqual(2);
     var $ctor1 = $target.find(".idlCtor").last();
@@ -188,7 +187,7 @@ describe("Core - WebIDL", function() {
     ).toEqual("boolean");
 
     $target = $("#ctor-noea", doc);
-    text = "[Constructor]\n" + "interface SuperStar {\n" + "};";
+    text = "[Constructor] interface SuperStar {};";
     expect($target.text()).toEqual(text);
     done();
   });
@@ -199,8 +198,7 @@ describe("Core - WebIDL", function() {
       "[Something,\n" +
       " NamedConstructor=Sun(),\n" +
       " NamedConstructor=Sun(boolean bar, Date foo)]\n" +
-      "interface SuperStar {\n" +
-      "};";
+      "interface SuperStar {};";
     expect($target.text()).toEqual(text);
     expect($target.find(".idlCtor").length).toEqual(2);
     var $ctor1 = $target.find(".idlCtor").last();
@@ -217,46 +215,45 @@ describe("Core - WebIDL", function() {
     var $target = $("#const-basic", doc);
     var text =
       "interface ConstTest {\n" +
-      "    // 1\n" +
-      "    const boolean             test = true;\n" +
-      "    // 2\n" +
-      "    const byte                bite = 8;\n" +
-      "    // 3\n" +
-      "    const octet               eight = 7;\n" +
-      "    // 4\n" +
-      "    const short               small = 42;\n" +
-      "    // 5\n" +
-      "    const unsigned short      shortish = 250;\n" +
-      "    // 6\n" +
-      "    const long                notSoLong = 99999;\n" +
-      "    // 7\n" +
-      "    const unsigned long       somewhatLong = 9999999;\n" +
-      "    // 8\n" +
-      "    const long long           veryLong = 9999999999999;\n" +
-      "    // 9\n" +
-      "    const unsigned long long  soLong = 99999999999999999;\n" +
-      "    // 10\n" +
-      "    const float               ationDevice = 4.2;\n" +
-      "    // 11\n" +
-      "    const unrestricted float  buoy = 4.2222222222;\n" +
-      "    // 12\n" +
-      "    const double              twice = 4.222222222;\n" +
-      "    // 13\n" +
-      "    const unrestricted double rambaldi = 47.0;\n" +
+      "  // 1\n" +
+      "  const boolean test = true;\n" +
+      "  // 2\n" +
+      "  const byte bite = 8;\n" +
+      "  // 3\n" +
+      "  const octet eight = 7;\n" +
+      "  // 4\n" +
+      "  const short small = 42;\n" +
+      "  // 5\n" +
+      "  const unsigned short shortish = 250;\n" +
+      "  // 6\n" +
+      "  const long notSoLong = 99999;\n" +
+      "  // 7\n" +
+      "  const unsigned long somewhatLong = 9999999;\n" +
+      "  // 8\n" +
+      "  const long long veryLong = 9999999999999;\n" +
+      "  // 9\n" +
+      "  const unsigned long long soLong = 99999999999999999;\n" +
+      "  // 10\n" +
+      "  const float ationDevice = 4.2;\n" +
+      "  // 11\n" +
+      "  const unrestricted float buoy = 4.2222222222;\n" +
+      "  // 12\n" +
+      "  const double twice = 4.222222222;\n" +
+      "  // 13\n" +
+      "  const unrestricted double rambaldi = 47.0;\n" +
       "\n" +
-      "    // 14\n" +
-      "    const boolean?            why = false;\n" +
-      "    // 15\n" +
-      "    const boolean?            notSo = null;\n" +
-      "    // 16\n" +
-      "    const short               inf = Infinity;\n" +
-      "    // 17\n" +
-      "    const short               mininf = -Infinity;\n" +
-      "    // 18\n" +
-      "    const short               cheese = NaN;\n" +
-      "    // 19\n" +
-      "    [Something]\n" +
-      "    const short               extAttr = NaN;\n" +
+      "  // 14\n" +
+      "  const boolean? why = false;\n" +
+      "  // 15\n" +
+      "  const boolean? notSo = null;\n" +
+      "  // 16\n" +
+      "  const short inf = Infinity;\n" +
+      "  // 17\n" +
+      "  const short mininf = -Infinity;\n" +
+      "  // 18\n" +
+      "  const short cheese = NaN;\n" +
+      "  // 19\n" +
+      "  [Something] const short extAttr = NaN;\n" +
       "};";
     expect($target.text()).toEqual(text);
     expect($target.find(".idlConst").length).toEqual(19);
@@ -288,23 +285,22 @@ describe("Core - WebIDL", function() {
   it("should handle attributes", function() {
     var $target = $("#attr-basic", doc);
     var text =`interface AttrBasic {
-    // 1
-                attribute DOMString              regular;
-    // 2
-    readonly    attribute DOMString              ro;
-    // 2.2
-    readonly    attribute DOMString              _readonly;
-    // 2.5
-    inherit     attribute DOMString              in;
-    // 2.7
-    stringifier attribute DOMString              st;
-    // 3
-    [Something]
-    readonly    attribute DOMString              ext;
-    // 3.10.31
-                attribute FrozenArray<DOMString> alist;
-    // 4.0
-                attribute Promise<DOMString>     operation;
+  // 1
+  attribute DOMString regular;
+  // 2
+  readonly attribute DOMString ro;
+  // 2.2
+  readonly attribute DOMString _readonly;
+  // 2.5
+  inherit attribute DOMString in;
+  // 2.7
+  stringifier attribute DOMString st;
+  // 3
+  [Something] readonly attribute DOMString ext;
+  // 3.10.31
+  attribute FrozenArray<DOMString> alist;
+  // 4.0
+  attribute Promise<DOMString> operation;
 };`.trim();
     expect($target.text()).toEqual(text);
     expect($target.find(".idlAttribute").length).toEqual(8);
@@ -367,30 +363,30 @@ describe("Core - WebIDL", function() {
   it("should handle operations", function(done) {
     var $target = $("#meth-basic", doc);
     var text =`interface MethBasic {
-    // 1
-    void                           basic();
-    // 2
-    [Something] void                           ext();
-    // 3
-    unsigned long long             ull(short s);
-    // 3.5
-    SuperStar?                     ull();
-    // 5
-    getter float                   ();
-    // 6
-    getter float                   withName();
-    // 7
-    setter void                    ();
-    // 8
-    setter void                    named();
-    // 9
-    static Promise<RTCCertificate> generateCertificate(AlgorithmIdentifier keygenAlgorithm);
-    // 10
-    stringifier DOMString          identifier();
-    // 11
-    stringifier DOMString          ();
-    // 12
-    stringifier ;
+  // 1
+  void basic();
+  // 2
+  [Something] void ext();
+  // 3
+  unsigned long long ull(short s);
+  // 3.5
+  SuperStar? ull();
+  // 5
+  getter float ();
+  // 6
+  getter float withName();
+  // 7
+  setter void ();
+  // 8
+  setter void named();
+  // 9
+  static Promise<RTCCertificate> generateCertificate(AlgorithmIdentifier keygenAlgorithm);
+  // 10
+  stringifier DOMString identifier();
+  // 11
+  stringifier DOMString ();
+  // 12
+  stringifier;
 };`
     expect($target.text()).toEqual(text);
     expect($target.find(".idlMethod").length).toEqual(12);
@@ -426,11 +422,11 @@ describe("Core - WebIDL", function() {
     var // TODO: Handle comments when WebIDL2 does.
     text =
       "interface SuperStar {\n" +
-      "    // This is a comment\n" +
-      "    // over two lines.\n" +
-      "    /* This one\n" +
-      "       has\n" +
-      "       three. */\n" +
+      "  // This is a comment\n" +
+      "  // over two lines.\n" +
+      "  /* This one\n" +
+      "     has\n" +
+      "     three. */\n" +
       "};";
     expect($target.text()).toEqual(text);
     expect($target.find(".idlSectionComment").length).toEqual(3);
@@ -439,39 +435,38 @@ describe("Core - WebIDL", function() {
 
   it("should handle dictionaries", function(done) {
     var $target = $("#dict-basic", doc);
-    var text = "dictionary SuperStar {\n};";
+    var text = "dictionary SuperStar {};";
     expect($target.text()).toEqual(text);
     expect($target.find(".idlDictionary").length).toEqual(1);
     expect($target.find(".idlDictionaryID").text()).toEqual("SuperStar");
 
     $target = $("#dict-inherit", doc);
-    text = "dictionary SuperStar : HyperStar {\n};";
+    text = "dictionary SuperStar : HyperStar {};";
     expect($target.text()).toEqual(text);
     expect($target.find(".idlSuperclass").text()).toEqual("HyperStar");
 
     $target = $("#dict-fields", doc);
     text =
       "dictionary SuperStar {\n" +
-      "    // 1\n" +
-      "    DOMString          value;\n" +
-      "    // 2\n" +
-      "    DOMString?         nullable;\n" +
-      "    // 3\n" +
-      "    [Something]\n" +
-      "    float              ext;\n" +
-      "    // 4\n" +
-      "    unsigned long long longLong;\n" +
+      "  // 1\n" +
+      "  DOMString value;\n" +
+      "  // 2\n" +
+      "  DOMString? nullable;\n" +
+      "  // 3\n" +
+      "  [Something]float ext;\n" +
+      "  // 4\n" +
+      "  unsigned long long longLong;\n" +
       "\n" +
-      "    // 5\n" +
-      "    boolean            test = true;\n" +
-      "    // 6\n" +
-      "    byte               little = 2;\n" +
-      "    // 7\n" +
-      "    byte               big = Infinity;\n" +
-      "    // 8\n" +
-      "    byte               cheese = NaN;\n" +
-      "    // 9\n" +
-      '    DOMString          blah = "blah blah";\n' +
+      "  // 5\n" +
+      "  boolean test = true;\n" +
+      "  // 6\n" +
+      "  byte little = 2;\n" +
+      "  // 7\n" +
+      "  byte big = Infinity;\n" +
+      "  // 8\n" +
+      "  byte cheese = NaN;\n" +
+      "  // 9\n" +
+      '  DOMString blah = "blah blah";\n' +
       "};";
     expect($target.text()).toEqual(text);
     expect($target.find(".idlMember").length).toEqual(9);
@@ -517,15 +512,15 @@ describe("Core - WebIDL", function() {
     var $target = $("#enum-basic", doc);
     var text =
       "enum EnumBasic {\n" +
-      "    // 1\n" +
-      '    "one",\n' +
-      "    // 2\n" +
-      '    "two",\n' +
-      "    // 3\n" +
-      '    "three",\n' +
+      "  // 1\n" +
+      '  "one",\n' +
+      "  // 2\n" +
+      '  "two"\n' +
+      "  // 3\n" +
+      ', "three",\n' +
       "\n" +
-      "    // 4\n" +
-      '    "white space"\n' +
+      "  // 4\n" +
+      '  "white space"\n' +
       "};";
     expect($target.text()).toEqual(text);
     expect($target.find(".idlEnum").length).toEqual(1);
@@ -646,7 +641,7 @@ describe("Core - WebIDL", function() {
     expect($target.find(".idlIncludes").length).toEqual(1);
 
     $target = $("#incl-less-basic", doc);
-    text = "[Something]\n" + text;
+    text = "[Something]" + text;
     expect($target.text()).toEqual(text);
   });
 
@@ -657,7 +652,7 @@ describe("Core - WebIDL", function() {
     expect($target.find(".idlImplements").length).toEqual(1);
 
     $target = $("#impl-less-basic", doc);
-    text = "[Something]\n" + text;
+    text = "[Something]" + text;
     expect($target.text()).toEqual(text);
   });
 

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -110,13 +110,13 @@ describe("Core - WebIDL", function() {
     expect($target.find(".idlInterfaceID").text()).toEqual("SuperStar");
 
     $target = $("#if-extended-attribute", doc);
-    text = "[Something,\n Constructor()] " + text;
+    text = "[Something, Constructor()] " + text;
     expect($target.text()).toEqual(text);
     expect($target.find(".extAttr").text()).toEqual("Something");
     expect($target.find(".idlCtor").text()).toEqual("Constructor()");
 
     $target = $("#if-identifier-list", doc);
-    text = "[Global=Window,\n Exposed=(Window,Worker)] interface SuperStar {};";
+    text = "[Global=Window, Exposed=(Window,Worker)] interface SuperStar {};";
     expect($target.text()).toEqual(text);
     expect($target.find(".extAttrRhs").first().text()).toEqual("Window");
     expect($target.find(".extAttrRhs").last().text()).toEqual(


### PR DESCRIPTION
...and replace `opt.ws` with the new trivia feature. It means that we lose the IDL formatting feature, and @marcoscaceres agreed to remove it in https://github.com/w3c/respec/issues/1559#issuecomment-371998009.

(This PR does not really support full whitespace conservation as the purpose here is to update without test breakage.)

Closes #1675 
Closes #1684 
Closes #1701 