### PR TITLE
fix(core/webidl): idl not rendering correctly

### DIFF
--- a/js/core/templates/webidl-contiguous/dict-member.html
+++ b/js/core/templates/webidl-contiguous/dict-member.html
@@ -1,4 +1,4 @@
 <span class='idlMember' id="{{obj.idlId}}" data-idl data-title='{{obj.name}}'>{{extAttr obj
-}}{{{qualifiers}}}<span class='idlMemberType'>{{idlType obj}}</span> <span class='idlMemberName'>{{#tryLink
+}}{{{qualifiers}}}<span class='idlMemberType'>{{{idlType obj}}}</span> <span class='idlMemberName'>{{#tryLink
 obj}}{{obj.name}}{{/tryLink}}</span>{{#if obj.default}} = <span class='idlMemberValue'>{{
 stringifyIdlConst obj.default}}</span>{{/if}};</span>

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -141,8 +141,8 @@ function registerHelpers() {
 }
 
 function writeTrivia(text) {
-  if (!text.length) {
-    return "";
+  if (!text.trim().length) {
+    return text;
   }
   return idlLineCommentTmpl({ text });
 }

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -507,6 +507,21 @@ describe("Core - WebIDL", function() {
     done();
   });
 
+  it("handles multiple dictionaries", async () => {
+    const idl = doc.getElementById("multiple-dictionaries");
+    const expected = `
+dictionary OneThing {
+  int x;
+};
+
+
+partial dictionary AnotherThing {
+  int y;
+};`.trim();
+    expect(idl.textContent).toEqual(expected);
+    expect(idl.querySelector(".idlSectionComment")).toBeNull();
+  });
+
   it("should handle enumerations", function(done) {
     var $target = $("#enum-basic", doc);
     var text =

--- a/tests/spec/core/webidl.html
+++ b/tests/spec/core/webidl.html
@@ -467,6 +467,16 @@
           long undocField;
         };
       </pre>
+      <pre class="idl" id="multiple-dictionaries">
+        dictionary OneThing {
+          int x;
+        };
+
+
+        partial dictionary AnotherThing {
+          int y;
+        };
+      </pre>
       <p id='dict-doc-p'><dfn>DictDocTest</dfn> contains <dfn data-dfn-for="DictDocTest">dictDocField</dfn> and <dfn data-dfn-for="DictDocTest">otherField</dfn></p>
     </section>
     <section id="enumerations">


### PR DESCRIPTION
closes #1717

 * only actual comments should be treated as comments
 * type in template should be treated as HTML

