### PR TITLE
feat(core/css/respec): add :target highlight #1683

### DIFF
--- a/js/core/css/respec2.css
+++ b/js/core/css/respec2.css
@@ -39,11 +39,8 @@ a.bibref {
   text-decoration: none;
 }
 
-a.bibref:target {
-  background: #e2e2e2;
-  box-shadow: 0 0 5px;
-  padding: 5px;
-  margin-bottom: 5px;
+:target {
+  background: #eaf3ff;
 }
 
 cite .bibref {

--- a/js/core/css/respec2.css
+++ b/js/core/css/respec2.css
@@ -39,7 +39,7 @@ a.bibref {
   text-decoration: none;
 }
 
-#references:target {
+#references :target {
   background: #eaf3ff;
 }
 

--- a/js/core/css/respec2.css
+++ b/js/core/css/respec2.css
@@ -39,6 +39,13 @@ a.bibref {
   text-decoration: none;
 }
 
+a.bibref:target {
+  background: #e2e2e2;
+  box-shadow: 0 0 5px;
+  padding: 5px;
+  margin-bottom: 5px;
+}
+
 cite .bibref {
   font-style: normal;
 }

--- a/js/core/css/respec2.css
+++ b/js/core/css/respec2.css
@@ -150,9 +150,9 @@ details.respec-tests-details[open] {
   z-index: 999999;
   position: absolute;
   border: thin solid #cad3e2;
-  border-radius: .3em;
+  border-radius: 0.3em;
   background-color: white;
-  padding-bottom: .5em;
+  padding-bottom: 0.5em;
 }
 
 details.respec-tests-details[open] > summary {

--- a/js/core/css/respec2.css
+++ b/js/core/css/respec2.css
@@ -39,7 +39,7 @@ a.bibref {
   text-decoration: none;
 }
 
-:target {
+#references:target {
   background: #eaf3ff;
 }
 


### PR DESCRIPTION
#1683 
Added a little CSS on :target which lets one focus easily where the hash link lead to.
Here is the screenshot.

![screenshot from 2018-06-28 23-56-07](https://user-images.githubusercontent.com/32068121/42053678-cf6f2cfa-7b2f-11e8-9946-147794c002f4.png)
