### PR TITLE
fix(core/xref): Improve error messages

### DIFF
--- a/src/core/data-cite.js
+++ b/src/core/data-cite.js
@@ -13,8 +13,8 @@
  * Usage:
  * https://github.com/w3c/respec/wiki/data--cite
  */
-import { pub } from "core/pubsubhub";
 import { resolveRef, updateFromNetwork } from "core/biblio";
+import { showInlineError } from "core/utils";
 export const name = "core/data-cite";
 
 function requestLookup(conf) {
@@ -31,10 +31,7 @@ function requestLookup(conf) {
       const entry = await resolveRef(key);
       cleanElement(elem);
       if (!entry) {
-        let msg = `Couldn't find a match for "${originalKey}". Please check developer console for offending element.`;
-        pub("warn", msg);
-        msg = `Couldn't find a match for "${originalKey}".`;
-        console.warn(msg, elem);
+        showInlineError(elem, `Couldn't find a match for "${originalKey}".`);
         return;
       }
       href = entry.href;

--- a/src/core/data-cite.js
+++ b/src/core/data-cite.js
@@ -31,10 +31,10 @@ function requestLookup(conf) {
       const entry = await resolveRef(key);
       cleanElement(elem);
       if (!entry) {
-        var msg = `Couldn't find a match for 'data-cite=${originalKey}'.`;
-        console.warn(msg, elem);
-        msg += " Please check developer console for offending element.";
+        let msg = `Couldn't find a match for "${originalKey}". Please check developer console for offending element.`;
         pub("warn", msg);
+        msg = `Couldn't find a match for "${originalKey}".`;
+        console.warn(msg, elem);
         return;
       }
       href = entry.href;

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -293,11 +293,20 @@ export function removeReSpec(doc) {
   });
 }
 
-export function showInlineError(elem, msg, title) {
-  elem.classList.add("respec-offending-element");
-  elem.setAttribute("title", title || msg);
+/**
+ * Adds error class of each element while emitting a warning
+ * @param {Element|Array:Elements} elems
+ * @param {String} msg message to show in warning
+ * @param {String} title error message to add on each element
+ */
+export function showInlineError(elems, msg, title) {
+  if (!Array.isArray(elems)) elems = [elems];
+  elems.forEach(elem => {
+    elem.classList.add("respec-offending-element");
+    elem.setAttribute("title", title || msg);
+  });
   pub("warn", msg + " See developer console for details.");
-  console.warn(msg, elem);
+  console.warn(msg, elems);
 }
 
 // STRING HELPERS

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -293,9 +293,9 @@ export function removeReSpec(doc) {
   });
 }
 
-export function showInlineError(elem, msg) {
+export function showInlineError(elem, msg, title) {
   elem.classList.add("respec-offending-element");
-  elem.setAttribute("title", msg);
+  elem.setAttribute("title", title || msg);
   pub("warn", msg + " See develper console for details.");
   console.warn(msg, elem);
 }

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -294,16 +294,17 @@ export function removeReSpec(doc) {
 }
 
 /**
- * Adds error class of each element while emitting a warning
+ * Adds error class to each element while emitting a warning
  * @param {Element|Array:Elements} elems
  * @param {String} msg message to show in warning
  * @param {String} title error message to add on each element
  */
 export function showInlineError(elems, msg, title) {
   if (!Array.isArray(elems)) elems = [elems];
+  if (!title) title = msg;
   elems.forEach(elem => {
     elem.classList.add("respec-offending-element");
-    elem.setAttribute("title", title || msg);
+    elem.setAttribute("title", title);
   });
   pub("warn", msg + " See developer console for details.");
   console.warn(msg, elems);

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -296,7 +296,7 @@ export function removeReSpec(doc) {
 export function showInlineError(elem, msg, title) {
   elem.classList.add("respec-offending-element");
   elem.setAttribute("title", title || msg);
-  pub("warn", msg + " See develper console for details.");
+  pub("warn", msg + " See developer console for details.");
   console.warn(msg, elem);
 }
 

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -19,7 +19,7 @@ export async function run(conf, elems) {
   const { xref } = conf;
   const xrefMap = createXrefMap(elems);
   const query = createXrefQuery(xrefMap);
-  const apiURL = (xref.url && new URL(xref.url, location.href)) || API_URL;
+  const apiURL = xref.url ? new URL(xref.url, location.href) : API_URL;
   if (!(apiURL instanceof URL)) {
     throw new TypeError("respecConfig.xref.url must be a valid URL instance");
   }

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -113,7 +113,9 @@ function disambiguate(data, context, term) {
     `The term "**${term}**" is defined in ${ambiguousSpecs.length} ` +
     `spec(s) in ${data.length} ways, so it's ambiguous. ` +
     "To disambiguate, you need to add a [`data-cite`](https://github.com/w3c/respec/wiki/data--cite) attribute. " +
-    `The specs where it's defined are: ${ambiguousSpecs.join(", ")}.`;
+    `The specs where it's defined are: ${ambiguousSpecs
+      .map(s => `**${s}**`)
+      .join(", ")}.`;
   const title = "Error: Linking an ambiguous dfn.";
   showInlineError(elem, msg, title);
   return null;

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -99,7 +99,7 @@ function disambiguate(data, context, term) {
     const msg =
       `Couldn't match "**${term}**" to anything in the document or to any other spec. ` +
       "Please provide a [`data-cite`](https://github.com/w3c/respec/wiki/data--cite) attribute for it.";
-    const title = `Error: No matching dfn found.`;
+    const title = "Error: No matching dfn found.";
     showInlineError(elem, msg, title);
     return null;
   }

--- a/tests/spec/core/xref-spec.js
+++ b/tests/spec/core/xref-spec.js
@@ -40,8 +40,6 @@ describe("Core — xref", () => {
     const link = doc.getElementById("external-link");
     expect(link.classList.contains("respec-offending-element")).toBeTruthy();
     expect(link.getAttribute("href")).toBeFalsy();
-    expect(link.title).toEqual(
-      "No external reference data found for term `NOT_FOUND`."
-    );
+    expect(link.title).toEqual("Error: No matching dfn found.");
   });
 });


### PR DESCRIPTION
- Updates error messages

One present issue that needs to be resolved is that the multiple warnings are emitted for same term. It also tells that our `disambiguate` algorithm is executing for each term (even when they are same). So, that fix is coming up next.

![image](https://user-images.githubusercontent.com/8426945/42094770-7234e8e6-7bce-11e8-8b65-c15364e1ac5f.png)

