### PR TITLE
feat(core/xref): use data-cite to disambiguate

### DIFF
--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -125,6 +125,10 @@ export async function run(conf, doc, cb) {
     }
   });
 
+  possibleExternalLinks.push(
+    ...document.querySelectorAll("a[data-cite]:not([data-cite*='#'])")
+  );
+
   if (conf.xref) {
     try {
       await addExternalReferences(conf, possibleExternalLinks);

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -301,6 +301,7 @@ export function removeReSpec(doc) {
  */
 export function showInlineError(elems, msg, title) {
   if (!Array.isArray(elems)) elems = [elems];
+  if (!elems.length) return;
   if (!title) title = msg;
   elems.forEach(elem => {
     elem.classList.add("respec-offending-element");

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -56,9 +56,9 @@ function createXrefMap(elems) {
 function createXrefQuery(xrefs) {
   const queryKeys = [...xrefs.entries()].reduce(
     (queryKeys, [term, entries]) => {
-      entries.forEach(({ specs }) => {
+      for (const { specs } of entries) {
         queryKeys.add(JSON.stringify({ term, specs })); // only unique
-      });
+      }
       return queryKeys;
     },
     new Set()

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -36,7 +36,12 @@ function createXrefMap(elems) {
   return elems.reduce((map, elem) => {
     const term = normalize(elem.textContent);
     const datacite = elem.closest("[data-cite]");
-    const specs = datacite ? datacite.dataset.cite.split(" ") : [];
+    const specs = datacite
+      ? datacite.dataset.cite
+          .toLowerCase()
+          .replace(/!/g, "")
+          .split(" ")
+      : [];
     const xrefsForTerm = map.has(term) ? map.get(term) : [];
     xrefsForTerm.push({ elem, specs });
     return map.set(term, xrefsForTerm);
@@ -107,7 +112,7 @@ function disambiguate(data, context, term) {
       `Couldn't match "**${term}**" to anything in the document or to any other spec. ` +
       "Please provide a [`data-cite`](https://github.com/w3c/respec/wiki/data--cite) attribute for it.";
     const title = "Error: No matching dfn found.";
-    showInlineError(elems, msg, title);
+    showInlineError(elems.filter(el => !el.dataset.cite), msg, title);
     return null;
   }
 

--- a/tests/spec/core/xref-spec.js
+++ b/tests/spec/core/xref-spec.js
@@ -3,9 +3,19 @@ describe("Core — xref", () => {
   afterAll(flushIframes);
 
   const apiURL = location.origin + "/tests/data/xref.json";
+  const localBiblio = {
+    html: {
+      href: "https://html.spec.whatwg.org/multipage/",
+      id: "HTML",
+    },
+    "service-workers": {
+      href: "https://www.w3.org/TR/service-workers-1/",
+      id: "service-workers-1",
+    },
+  };
 
   it("does nothing if xref is not enabled", async () => {
-    const body = `<a id="external-link">EventHandler</a>`;
+    const body = `<a id="external-link">event handler</a>`;
     const ops = makeStandardOps(null, body);
     const doc = await makeRSDoc(ops);
 
@@ -15,7 +25,7 @@ describe("Core — xref", () => {
 
   it("adds link to unique <a> terms", async () => {
     const body = `<a id="external-link">event handler</a>`;
-    const config = { xref: { url: apiURL } };
+    const config = { xref: { url: apiURL }, localBiblio };
     const ops = makeStandardOps(config, body);
     const doc = await makeRSDoc(ops);
 
@@ -41,5 +51,38 @@ describe("Core — xref", () => {
     expect(link.classList.contains("respec-offending-element")).toBeTruthy();
     expect(link.getAttribute("href")).toBeFalsy();
     expect(link.title).toEqual("Error: No matching dfn found.");
+  });
+
+  it("uses data-cite to disambiguate results", async () => {
+    const body = `
+      <section data-cite="service-workers">
+        <a id="link">fetch</a> is defined in service-workers and fetch spec.
+      </section>
+    `;
+    // using default API url here as xref.json cannot disambiguate
+    const config = { xref: true, localBiblio };
+    const ops = makeStandardOps(config, body);
+    const doc = await makeRSDoc(ops);
+
+    const link = doc.getElementById("link");
+    expect(link.getAttribute("href")).toEqual(
+      "https://www.w3.org/TR/service-workers-1/#service-worker-global-scope-fetch-event"
+    );
+    expect(link.classList.contains("respec-offending-element")).toBeFalsy();
+  });
+
+  it("gives error if cannot resolve by data-cite", async () => {
+    const body = `
+      <section data-cite="fetch">
+        <a id="link">fetch</a> is defined in service-workers and fetch spec.
+      </section>
+    `;
+    const config = { xref: { url: apiURL }, localBiblio };
+    const ops = makeStandardOps(config, body);
+    const doc = await makeRSDoc(ops);
+
+    const link = doc.getElementById("link");
+    expect(link.classList.contains("respec-offending-element")).toBeTruthy();
+    expect(link.title).toEqual("Error: Linking an ambiguous dfn.");
   });
 });

--- a/tests/spec/core/xref-spec.js
+++ b/tests/spec/core/xref-spec.js
@@ -60,7 +60,7 @@ describe("Core — xref", () => {
   it("uses data-cite to disambiguate results", async () => {
     const body = `
       <section data-cite="service-workers" id="links">
-        <p><a>fetch</a> is defined in service-workers and fetch spec. It uses parent's data-cite.</p>
+        <p><a>fetch</a> is defined once in service-workers and twice in fetch spec. It uses parent's data-cite.</p>
 
         <p>As <a data-cite="!infra">ASCII uppercase</a> is valid dfn, it resolves to fragment. a local data-cite (infra) overrides parent's datacite.</p>
 
@@ -98,7 +98,7 @@ describe("Core — xref", () => {
   it("shows error if cannot resolve by data-cite", async () => {
     const body = `
       <section data-cite="fetch">
-        <a id="link">fetch</a> is defined in service-workers and fetch spec.
+        <a id="link">fetch</a> is defined once in service-workers and twice in fetch spec.
       </section>
     `;
     const config = { xref: { url: apiURL }, localBiblio };


### PR DESCRIPTION
- presently only supports parent's `data-cite`, not self `data-cite`

**Update**: Also supports self `data-cite` as:
- if the term exists, url resolves to url fragment
- else: url resolves to spec itself. no warning is emitted