### PR TITLE
feat(core/xref): use inline references to provide context

### DIFF
--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -48,11 +48,9 @@ function createXrefMap(elems) {
       : [];
     if (datacite !== elem) {
       // if element itself contains data-cite, we don't take inline context into account
-      const inlineContext = elem
-        .closest("section")
-        .querySelectorAll("a.bibref");
-      if (inlineContext) {
-        const inlineContextSpecs = [...inlineContext].map(el =>
+      const refs = elem.closest("section").querySelectorAll("a.bibref");
+      if (refs) {
+        const inlineContextSpecs = [...refs].map(el =>
           el.textContent.toLowerCase().replace(/^!/, "")
         );
         specs.push(...inlineContextSpecs);

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -46,6 +46,14 @@ function createXrefMap(elems) {
           .replace(/!/g, "")
           .split(" ")
       : [];
+    const inlineContext = elem.parentElement.querySelectorAll("a.bibref");
+    if (inlineContext) {
+      const inlineContextSpecs = [...inlineContext].map(el =>
+        el.textContent.toLowerCase().replace(/^!/, "")
+      );
+      specs.push(...inlineContextSpecs);
+    }
+
     const xrefsForTerm = map.has(term) ? map.get(term) : [];
     xrefsForTerm.push({ elem, specs });
     return map.set(term, xrefsForTerm);

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -46,7 +46,7 @@ function createXrefMap(elems) {
           .replace(/!/g, "")
           .split(" ")
       : [];
-    if (datacite != elem) {
+    if (datacite !== elem) {
       // if element itself contains data-cite, we don't take inline context into account
       const inlineContext = elem.parentElement.querySelectorAll("a.bibref");
       if (inlineContext) {

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -46,12 +46,15 @@ function createXrefMap(elems) {
           .replace(/!/g, "")
           .split(" ")
       : [];
-    const inlineContext = elem.parentElement.querySelectorAll("a.bibref");
-    if (inlineContext) {
-      const inlineContextSpecs = [...inlineContext].map(el =>
-        el.textContent.toLowerCase().replace(/^!/, "")
-      );
-      specs.push(...inlineContextSpecs);
+    if (datacite != elem) {
+      // if element itself contains data-cite, we don't take inline context into account
+      const inlineContext = elem.parentElement.querySelectorAll("a.bibref");
+      if (inlineContext) {
+        const inlineContextSpecs = [...inlineContext].map(el =>
+          el.textContent.toLowerCase().replace(/^!/, "")
+        );
+        specs.push(...inlineContextSpecs);
+      }
     }
 
     const xrefsForTerm = map.has(term) ? map.get(term) : [];

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -48,7 +48,9 @@ function createXrefMap(elems) {
       : [];
     if (datacite !== elem) {
       // if element itself contains data-cite, we don't take inline context into account
-      const inlineContext = elem.parentElement.querySelectorAll("a.bibref");
+      const inlineContext = elem
+        .closest("section")
+        .querySelectorAll("a.bibref");
       if (inlineContext) {
         const inlineContextSpecs = [...inlineContext].map(el =>
           el.textContent.toLowerCase().replace(/^!/, "")

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -46,12 +46,12 @@ function createXrefMap(elems) {
           .replace(/!/g, "")
           .split(" ")
       : [];
+    // if element itself contains data-cite, we don't take inline context into account
     if (datacite !== elem) {
-      // if element itself contains data-cite, we don't take inline context into account
-      const refs = elem.closest("section").querySelectorAll("a.bibref");
-      if (refs) {
-        specs.push(...[...refs].map(el => el.textContent.toLowerCase()));
-      }
+      const refs = [
+        ...elem.closest("section").querySelectorAll("a.bibref"),
+      ].map(el => el.textContent.toLowerCase());
+      specs.push(...refs);
     }
 
     const xrefsForTerm = map.has(term) ? map.get(term) : [];

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -50,10 +50,7 @@ function createXrefMap(elems) {
       // if element itself contains data-cite, we don't take inline context into account
       const refs = elem.closest("section").querySelectorAll("a.bibref");
       if (refs) {
-        const inlineContextSpecs = [...refs].map(el =>
-          el.textContent.toLowerCase().replace(/^!/, "")
-        );
-        specs.push(...inlineContextSpecs);
+        specs.push(...[...refs].map(el => el.textContent.toLowerCase()));
       }
     }
 

--- a/tests/spec/core/xref-spec.js
+++ b/tests/spec/core/xref-spec.js
@@ -258,4 +258,33 @@ describe("Core — xref", () => {
       )
     ).toBeTruthy();
   });
+
+  it("uses inline references to provide context", async () => {
+    const body = `
+      <section id="test">
+        <p>Uses [[WEBIDL]] to create context for <a id="one">object</a></p>
+        <p>Uses [[html]] to create context for <a id="two">object</a></p>
+        <p>Uses [[html]] and [[webidl]] to create context for <a id="three">object</a>. It fails as it's defined in both.</p>
+      </section>
+    `;
+    const config = { xref: true, localBiblio };
+    const ops = makeStandardOps(config, body);
+    const doc = await makeRSDoc(ops);
+
+    const expectedLink1 = "https://heycam.github.io/webidl/#idl-object";
+    const expectedLink2 =
+      "https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-object-element";
+
+    const link1 = doc.getElementById("one");
+    const link2 = doc.getElementById("two");
+    const link3 = doc.getElementById("three");
+
+    expect(link1.href).toEqual(expectedLink1);
+    expect(link2.href).toEqual(expectedLink2);
+    expect(link3.href).toBeFalsy();
+
+    expect(link1.classList.contains("respec-offending-class")).toBeFalsy();
+    expect(link2.classList.contains("respec-offending-class")).toBeFalsy();
+    expect(link3.classList.contains("respec-offending-class")).toBeTruthy();
+  });
 });

--- a/tests/spec/core/xref-spec.js
+++ b/tests/spec/core/xref-spec.js
@@ -328,10 +328,10 @@ describe("Core — xref", () => {
     expect(link4.href).toEqual(expectedLink1);
     expect(link5.href).toEqual(expectedLink2);
 
-    expect(link1.classList.contains("respec-offending-class")).toBeFalsy();
-    expect(link2.classList.contains("respec-offending-class")).toBeFalsy();
-    expect(link3.classList.contains("respec-offending-class")).toBeTruthy();
-    expect(link4.classList.contains("respec-offending-class")).toBeFalsy();
-    expect(link5.classList.contains("respec-offending-class")).toBeFalsy();
+    expect(link1.classList.contains("respec-offending-element")).toBeFalsy();
+    expect(link2.classList.contains("respec-offending-element")).toBeFalsy();
+    expect(link3.classList.contains("respec-offending-element")).toBeTruthy();
+    expect(link4.classList.contains("respec-offending-element")).toBeFalsy();
+    expect(link5.classList.contains("respec-offending-element")).toBeFalsy();
   });
 });

--- a/tests/spec/core/xref-spec.js
+++ b/tests/spec/core/xref-spec.js
@@ -324,7 +324,7 @@ describe("Core — xref", () => {
 
     expect(link1.href).toEqual(expectedLink1);
     expect(link2.href).toEqual(expectedLink2);
-    expect(link3.href).toBeFalsy();
+    expect(link3.href).toEqual("");
     expect(link4.href).toEqual(expectedLink1);
     expect(link5.href).toEqual(expectedLink2);
 

--- a/tests/spec/core/xref-spec.js
+++ b/tests/spec/core/xref-spec.js
@@ -344,7 +344,7 @@ describe("Core — xref", () => {
     expect(link4.classList.contains("respec-offending-element")).toBeFalsy();
     expect(link5.classList.contains("respec-offending-element")).toBeFalsy();
   });
-  
+
   it("adds normative and informative references", async () => {
     const body = `
       <section class="informative">

--- a/tests/spec/core/xref-spec.js
+++ b/tests/spec/core/xref-spec.js
@@ -309,7 +309,8 @@ describe("Core — xref", () => {
           <p>Uses [[html]] to create context for <a id="two">object</a></p>
         </section>
         <section>
-          <p>Uses [[html]] and [[webidl]] to create context for <a id="three">object</a>. It fails as it's defined in both.</p>
+          <p>Uses [[html]] and [[webidl]] to create context for <a id="three">object</a>.
+          It fails as it's defined in both.</p>
         </section>
         <section>
           <p>But data-cite on element itself wins. <a id="four">object</a> uses [[webidl]],

--- a/tests/spec/core/xref-spec.js
+++ b/tests/spec/core/xref-spec.js
@@ -265,6 +265,7 @@ describe("Core — xref", () => {
         <p>Uses [[WEBIDL]] to create context for <a id="one">object</a></p>
         <p>Uses [[html]] to create context for <a id="two">object</a></p>
         <p>Uses [[html]] and [[webidl]] to create context for <a id="three">object</a>. It fails as it's defined in both.</p>
+        <p>But data-cite on element itself wins. <a id="four">object</a> uses [[webidl]], whereas <a data-cite="html" id="five">object</a> uses html.</p>
       </section>
     `;
     const config = { xref: true, localBiblio };
@@ -278,13 +279,19 @@ describe("Core — xref", () => {
     const link1 = doc.getElementById("one");
     const link2 = doc.getElementById("two");
     const link3 = doc.getElementById("three");
+    const link4 = doc.getElementById("four");
+    const link5 = doc.getElementById("five");
 
     expect(link1.href).toEqual(expectedLink1);
     expect(link2.href).toEqual(expectedLink2);
     expect(link3.href).toBeFalsy();
+    expect(link4.href).toEqual(expectedLink1);
+    expect(link5.href).toEqual(expectedLink2);
 
     expect(link1.classList.contains("respec-offending-class")).toBeFalsy();
     expect(link2.classList.contains("respec-offending-class")).toBeFalsy();
     expect(link3.classList.contains("respec-offending-class")).toBeTruthy();
+    expect(link4.classList.contains("respec-offending-class")).toBeFalsy();
+    expect(link5.classList.contains("respec-offending-class")).toBeFalsy();
   });
 });

--- a/tests/spec/core/xref-spec.js
+++ b/tests/spec/core/xref-spec.js
@@ -46,7 +46,7 @@ describe("Core — xref", () => {
   });
 
   it("adds link to unique <a> terms", async () => {
-    const body = `<a id="external-link">event handler</a>`;
+    const body = `<section><a id="external-link">event handler</a></section>`;
     const config = { xref: { url: apiURL }, localBiblio };
     const ops = makeStandardOps(config, body);
     const doc = await makeRSDoc(ops);
@@ -62,7 +62,7 @@ describe("Core — xref", () => {
   });
 
   it("fails to add link to non-existing terms", async () => {
-    const body = `<a id="external-link">NOT_FOUND</a>`;
+    const body = `<section><a id="external-link">NOT_FOUND</a></section>`;
     const config = { xref: { url: apiURL } };
     const ops = makeStandardOps(config, body);
     const doc = await makeRSDoc(ops);
@@ -302,10 +302,19 @@ describe("Core — xref", () => {
   it("uses inline references to provide context", async () => {
     const body = `
       <section id="test">
-        <p>Uses [[WEBIDL]] to create context for <a id="one">object</a></p>
-        <p>Uses [[html]] to create context for <a id="two">object</a></p>
-        <p>Uses [[html]] and [[webidl]] to create context for <a id="three">object</a>. It fails as it's defined in both.</p>
-        <p>But data-cite on element itself wins. <a id="four">object</a> uses [[webidl]], whereas <a data-cite="html" id="five">object</a> uses html.</p>
+        <section>
+          <p>Uses [[WEBIDL]] to create context for <a id="one">object</a></p>
+        </section>
+        <section>
+          <p>Uses [[html]] to create context for <a id="two">object</a></p>
+        </section>
+        <section>
+          <p>Uses [[html]] and [[webidl]] to create context for <a id="three">object</a>. It fails as it's defined in both.</p>
+        </section>
+        <section>
+          <p>But data-cite on element itself wins. <a id="four">object</a> uses [[webidl]],
+          whereas <a data-cite="html" id="five">object</a> uses html.</p>
+        </section>
       </section>
     `;
     const config = { xref: true, localBiblio };


### PR DESCRIPTION
Uses nearby `[[SPEC]]` to provide context as `specs` to search for (as a part of https://github.com/w3c/respec/issues/1662)

Maybe this should be enabled via a flag, not always. Why? Consider:
``` html
<section data-cite="html">Uses [[WEBIDL]] to create context for <a>object</a></section>
```
Above, the query for this term will contain `specs: ["html", "webidl"]`, which results in an ambiguity that can't be resolved unless (either):
- User removes `data-cite="html"` from parent or remove the nearby `[[WEBIDL]]` 
- Instead of `specs.push(...inlineContextSpecs)`, we do `specs = inlineContextSpecs`

