### PR TITLE
fix(core/webidl): unindentMarkup() should work with space-only lines

### DIFF
--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -294,7 +294,7 @@ function unindentMarkup(text) {
   if (!text) {
     return text;
   }
-  // TODO: use trimEnd when Edge and Firefox support it
+  // TODO: use trimEnd when Edge supports it
   const lines = text.trimRight().split("\n");
   while (lines.length && !lines[0].trim()) {
     lines.shift();

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -294,12 +294,12 @@ function unindentMarkup(text) {
   if (!text) {
     return text;
   }
-  // TODO: use trimEnd if Edge and Firefox support it
+  // TODO: use trimEnd when Edge and Firefox support it
   const lines = text.trimRight().split("\n");
   while (lines.length && !lines[0].trim()) {
     lines.shift();
   }
-  const indents = lines.filter(s => s).map(s => s.search(/[^\s]/));
+  const indents = lines.filter(s => s.trim()).map(s => s.search(/[^\s]/));
   const leastIndent = Math.min(...indents);
   return lines.map(s => s.slice(leastIndent)).join("\n");
 }

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -492,6 +492,7 @@ describe("Core - WebIDL", function() {
       "  /* This one\n" +
       "     has\n" +
       "     three. */\n" +
+      "  \n" +
       "};";
     expect($target.text()).toEqual(text);
     expect($target.find(".idlSectionComment").length).toEqual(1);

--- a/tests/spec/core/webidl.html
+++ b/tests/spec/core/webidl.html
@@ -413,6 +413,7 @@
           /* This one
              has
              three. */
+          <!-- this is an HTML comment that will be ignored -->
         };
       </pre>
     </section>


### PR DESCRIPTION
The [Browser Extensions](https://browserext.github.io/browserext/) spec is broken because of this. (...which still has `implements`, BTW!)