### PR TITLE
fix(core/issues-notes): don't remove closed issues

### DIFF
--- a/js/core/css/issues-notes.css
+++ b/js/core/css/issues-notes.css
@@ -32,6 +32,10 @@ span.note, span.ednote, span.issue, span.warning { padding: .1em .5em .15em; }
     border-color: #e05252;
     background: #fbe9e9;
 }
+.issue.closed span.issue-number {
+    text-decoration: line-through;
+}
+
 .note, .ednote {
     border-color: #52e052;
     background: #e9fbe9;

--- a/src/core/issues-notes.js
+++ b/src/core/issues-notes.js
@@ -27,21 +27,6 @@ function handleIssues(ins, ghIssues, conf) {
       "<div><h2>" + conf.l10n.issue_summary + "</h2><ul></ul></div>"
     ),
     $issueList = $issueSummary.find("ul");
-  if (githubAPI) {
-    Array.from($ins)
-      .filter(
-        ({ dataset: { number: value } }) =>
-          value !== undefined && ghIssues.get(Number(value)).state === "closed"
-      )
-      .forEach(issue => {
-        const {
-          dataset: { number },
-        } = issue;
-        const msg = `Github issue ${number} was closed on GitHub, so removing from spec`;
-        pub("warn", msg);
-        issue.remove();
-      });
-  }
   $ins.filter((i, issue) => issue.parentNode).each(function(i, inno) {
     var $inno = $(inno),
       isIssue = $inno.hasClass("issue"),
@@ -114,6 +99,7 @@ function handleIssues(ins, ghIssues, conf) {
                 .find("span")
                 .wrap($("<a href='" + conf.atRiskBase + dataNum + "'/>"));
             }
+            $tit.find("span")[0].classList.add("issue-number");
             ghIssue = ghIssues.get(Number(dataNum));
             if (ghIssue && !report.title) {
               report.title = ghIssue.title;
@@ -143,7 +129,8 @@ function handleIssues(ins, ghIssues, conf) {
       }
       $tit.find("span").text(text);
       if (ghIssue && report.title && githubAPI) {
-        const labelsGroup = Array.from(ghIssue.labels)
+        if (ghIssue.state === "closed") $div[0].classList.add("closed");
+        const labelsGroup = Array.from(ghIssue.labels || [])
           .map(label => {
             const issuesURL = new URL("issues/", conf.github.repoURL + "/");
             issuesURL.searchParams.set(

--- a/tests/spec/core/issues-notes-spec.js
+++ b/tests/spec/core/issues-notes-spec.js
@@ -225,7 +225,7 @@ describe("Core — Issues and Notes", function() {
     expect($piss.text()).toEqual("ISSUE");
   });
 
-  it("removes closed issues from spec", async () => {
+  it("marks closed issues as closed in the spec", async () => {
     const githubConfig = {
       github: "https://github.com/mock-company/mock-repository",
       githubAPI: `${window.location.origin}/tests/data`,
@@ -235,7 +235,7 @@ describe("Core — Issues and Notes", function() {
       body:
         makeDefaultBody() +
         `
-        <div class='issue' id='this-should-not-exist' data-number='1548'>issue is closed on github</div>
+        <div class='issue' id='this-should-exist' data-number='1548'>issue is closed on github</div>
         <div class='issue' data-number='1540'>issue is open on github</div>
         <div class='issue' id='i-should-be-here-too'>regular issue</div>
         <div class='issue' id='this-is-404' data-number='404'>this is 404</div>
@@ -243,8 +243,9 @@ describe("Core — Issues and Notes", function() {
       `,
     };
     const doc = await makeRSDoc(ops);
-    const issueDiv1 = doc.getElementById("this-should-not-exist");
-    expect(issueDiv1).toBeFalsy();
+    const issueDiv1 = doc.getElementById("this-should-exist");
+    expect(issueDiv1).toBeTruthy();
+    expect(issueDiv1.classList.contains("closed")).toBeTruthy();
 
     const issueDiv2 = doc.getElementById("issue-container-number-1540");
     expect(issueDiv2).toBeTruthy();


### PR DESCRIPTION
Based on discussions https://github.com/w3c/hr-time/pull/59#issuecomment-408119539

![screenshot 2018-07-27 11 03 12](https://user-images.githubusercontent.com/870154/43296116-b14581c0-918c-11e8-90b2-cad4ae16ecc2.png)

Crossing out the issue number is fairly standard in bug tracking systems (e.g., bugzilla) 