### PR TITLE
refactor(tests/spec/core/webidl-spec): remove jQuery from ctor/const/attr tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -122,8 +122,8 @@ module.exports = function(config) {
     browserNoActivityTimeout: 100000,
 
     client: {
-      args: ["--grep", config.grep]
-    }
+      args: ["--grep", config.grep],
+    },
   };
   if (process.env.TRAVIS) {
     options.detectBrowsers.enabled = false;

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -120,6 +120,10 @@ module.exports = function(config) {
     concurrency: 1,
 
     browserNoActivityTimeout: 100000,
+
+    client: {
+      args: ["--grep", config.grep]
+    }
   };
   if (process.env.TRAVIS) {
     options.detectBrowsers.enabled = false;

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -294,9 +294,9 @@ describe("Core - WebIDL", function() {
     ).toBeNull();
   });
 
-  it("should handle attributes", function() {
-    var $target = $("#attr-basic", doc);
-    var text = `interface AttrBasic {
+  it("should handle attributes", () => {
+    const target = doc.getElementById("attr-basic");
+    const text = `interface AttrBasic {
   // 1
   attribute DOMString regular;
   // 2
@@ -313,33 +313,37 @@ describe("Core - WebIDL", function() {
   attribute FrozenArray<DOMString> alist;
   // 4.0
   attribute Promise<DOMString> operation;
-};`.trim();
-    expect($target.text()).toEqual(text);
-    expect($target.find(".idlAttribute").length).toEqual(8);
-    var $at = $target.find(".idlAttribute").first();
-    expect($at.find(".idlAttrType").text()).toEqual(" DOMString");
-    expect($at.find(".idlAttrName").text()).toEqual("regular");
-    var $ro = $target.find(".idlAttribute").eq(2);
-    expect($ro.find(".idlAttrName").text()).toEqual("_readonly");
-    var $frozen = $target.find(".idlAttribute").eq(6);
-    expect($frozen.find(".idlAttrType").text()).toEqual(
+};`;
+    expect(target.textContent).toEqual(text);
+    const attrs = [...target.getElementsByClassName("idlAttribute")];
+    expect(attrs.length).toEqual(8);
+    const at = attrs[0];
+    expect(at.querySelector(".idlAttrType").textContent).toEqual(" DOMString");
+    expect(at.querySelector(".idlAttrName").textContent).toEqual("regular");
+    const ro = attrs[2];
+    expect(ro.querySelector(".idlAttrName").textContent).toEqual("_readonly");
+    const frozen = attrs[6];
+    expect(frozen.querySelector(".idlAttrType").textContent).toEqual(
       " FrozenArray<DOMString>"
     );
-    var $promise = $target.find(".idlAttribute").eq(7);
-    expect($promise.find(".idlAttrType").text()).toEqual(" Promise<DOMString>");
+    const promise = attrs[7];
+    expect(promise.querySelector(".idlAttrType").textContent).toEqual(" Promise<DOMString>");
     expect(
-      $target
-        .find(":contains('_readonly')")
-        .parents(".idlAttribute")
-        .attr("id")
+      attrs
+        .filter(c => c.textContent.includes("_readonly"))[0]
+        .getAttribute("id")
     ).toEqual("idl-def-attrbasic-readonly");
     expect(
-      $target
-        .find(":contains('regular')")
-        .filter("a")
-        .attr("href")
+      attrs
+        .filter(c => c.textContent.includes("regular"))[0]
+        .querySelector(".idlAttrName a")
+        .getAttribute("href")
     ).toEqual("#dom-attrbasic-regular");
-    expect($target.find(":contains('dates')").filter("a").length).toEqual(0);
+    expect(
+      attrs
+        .filter(c => c.textContent.includes("alist"))[0]
+        .querySelector(".idlAttrName a")
+    ).toBeNull();
   });
 
   it("handles stringifiers special operations", () => {

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -174,11 +174,17 @@ describe("Core - WebIDL", function() {
     const ctors = target.getElementsByClassName("idlCtor");
     expect(ctors.length).toEqual(2);
     const ctor = ctors[1];
-    expect(ctor.querySelector(".extAttrName").textContent).toEqual("Constructor");
+    expect(ctor.querySelector(".extAttrName").textContent).toEqual(
+      "Constructor"
+    );
     const params = [...ctor.getElementsByClassName("idlParam")];
     expect(params.length).toEqual(3);
-    expect(params.filter(p => p.textContent.includes("sequence")).length).toEqual(1);
-    expect(params.filter(p => p.textContent.includes("Promise")).length).toEqual(1);
+    expect(
+      params.filter(p => p.textContent.includes("sequence")).length
+    ).toEqual(1);
+    expect(
+      params.filter(p => p.textContent.includes("Promise")).length
+    ).toEqual(1);
     expect(
       ctor.querySelector(".idlParam .idlParamType").textContent
     ).toEqual("boolean");
@@ -202,7 +208,9 @@ describe("Core - WebIDL", function() {
     expect(ctor.querySelector(".extAttrRhs").textContent).toEqual("Sun");
     const params = [...ctor.getElementsByClassName("idlParam")];
     expect(params.length).toEqual(2);
-    expect(params.filter(p => p.textContent.includes("Date")).length).toEqual(1);
+    expect(params.filter(p => p.textContent.includes("Date")).length).toEqual(
+      1
+    );
     expect(
       ctor.querySelector(".idlParam .idlParamType").textContent
     ).toEqual("boolean");
@@ -256,7 +264,9 @@ describe("Core - WebIDL", function() {
     const consts = [...target.getElementsByClassName("idlConst")];
     expect(consts.length).toEqual(19);
     const const1 = target.querySelector(".idlConst");
-    expect(const1.querySelector(".idlConstType").textContent).toEqual(" boolean");
+    expect(const1.querySelector(".idlConstType").textContent).toEqual(
+      " boolean"
+    );
     expect(const1.querySelector(".idlConstName").textContent).toEqual("test");
     expect(const1.querySelector(".idlConstValue").textContent).toEqual("true");
     expect(
@@ -265,8 +275,7 @@ describe("Core - WebIDL", function() {
 
     // Links and IDs.
     expect(
-      consts
-        .find(c => c.textContent.includes("rambaldi"))
+      consts.find(c => c.textContent.includes("rambaldi"))
         .querySelector(".idlConstName a")
         .getAttribute("href")
     ).toEqual("#dom-consttest-rambaldi");
@@ -327,10 +336,11 @@ describe("Core - WebIDL", function() {
       " FrozenArray<DOMString>"
     );
     const promise = attrs[7];
-    expect(promise.querySelector(".idlAttrType").textContent).toEqual(" Promise<DOMString>");
+    expect(promise.querySelector(".idlAttrType").textContent).toEqual(
+      " Promise<DOMString>"
+    );
     expect(
-      attrs
-        .find(c => c.textContent.includes("_readonly"))
+      attrs.find(c => c.textContent.includes("_readonly"))
         .getAttribute("id")
     ).toEqual("idl-def-attrbasic-readonly");
     expect(

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -266,30 +266,30 @@ describe("Core - WebIDL", function() {
     // Links and IDs.
     expect(
       consts
-        .filter(c => c.textContent.includes("rambaldi"))[0]
+        .find(c => c.textContent.includes("rambaldi"))
         .querySelector(".idlConstName a")
         .getAttribute("href")
     ).toEqual("#dom-consttest-rambaldi");
     expect(
       consts
-        .filter(c => c.textContent.includes("rambaldi"))[0]
+        .find(c => c.textContent.includes("rambaldi"))
         .getAttribute("id")
     ).toEqual("idl-def-consttest-rambaldi");
     expect(
       consts
-        .filter(c => c.textContent.includes("why"))[0]
+        .find(c => c.textContent.includes("why"))
         .querySelector(".idlConstName a")
         .getAttribute("href")
     ).toEqual("#dom-consttest-why");
     expect(
       consts
-        .filter(c => c.textContent.includes("inf"))[0]
+        .find(c => c.textContent.includes("inf"))
         .querySelector(".idlConstName a")
         .getAttribute("href")
     ).toEqual("#dom-consttest-inf");
     expect(
       consts
-        .filter(c => c.textContent.includes("ationDevice"))[0]
+        .find(c => c.textContent.includes("ationDevice"))
         .querySelector(".idlConstName a")
     ).toBeNull();
   });
@@ -330,18 +330,18 @@ describe("Core - WebIDL", function() {
     expect(promise.querySelector(".idlAttrType").textContent).toEqual(" Promise<DOMString>");
     expect(
       attrs
-        .filter(c => c.textContent.includes("_readonly"))[0]
+        .find(c => c.textContent.includes("_readonly"))
         .getAttribute("id")
     ).toEqual("idl-def-attrbasic-readonly");
     expect(
       attrs
-        .filter(c => c.textContent.includes("regular"))[0]
+        .find(c => c.textContent.includes("regular"))
         .querySelector(".idlAttrName a")
         .getAttribute("href")
     ).toEqual("#dom-attrbasic-regular");
     expect(
       attrs
-        .filter(c => c.textContent.includes("alist"))[0]
+        .find(c => c.textContent.includes("alist"))
         .querySelector(".idlAttrName a")
     ).toBeNull();
   });

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -275,14 +275,13 @@ describe("Core - WebIDL", function() {
 
     // Links and IDs.
     expect(
-      consts.find(c => c.textContent.includes("rambaldi"))
+      consts
+        .find(c => c.textContent.includes("rambaldi"))
         .querySelector(".idlConstName a")
         .getAttribute("href")
     ).toEqual("#dom-consttest-rambaldi");
     expect(
-      consts
-        .find(c => c.textContent.includes("rambaldi"))
-        .getAttribute("id")
+      consts.find(c => c.textContent.includes("rambaldi")).getAttribute("id")
     ).toEqual("idl-def-consttest-rambaldi");
     expect(
       consts
@@ -340,8 +339,7 @@ describe("Core - WebIDL", function() {
       " Promise<DOMString>"
     );
     expect(
-      attrs.find(c => c.textContent.includes("_readonly"))
-        .getAttribute("id")
+      attrs.find(c => c.textContent.includes("_readonly")).getAttribute("id")
     ).toEqual("idl-def-attrbasic-readonly");
     expect(
       attrs

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -208,9 +208,9 @@ describe("Core - WebIDL", function() {
     ).toEqual("boolean");
   });
 
-  it("should handle constants", function(done) {
-    var $target = $("#const-basic", doc);
-    var text =
+  it("should handle constants", () => {
+    const target = doc.getElementById("const-basic");
+    const text =
       "interface ConstTest {\n" +
       "  // 1\n" +
       "  const boolean test = true;\n" +
@@ -252,48 +252,46 @@ describe("Core - WebIDL", function() {
       "  // 19\n" +
       "  [Something] const short extAttr = NaN;\n" +
       "};";
-    expect($target.text()).toEqual(text);
-    expect($target.find(".idlConst").length).toEqual(19);
-    var $const1 = $target.find(".idlConst").first();
-    expect($const1.find(".idlConstType").text()).toEqual(" boolean");
-    expect($const1.find(".idlConstName").text()).toEqual("test");
-    expect($const1.find(".idlConstValue").text()).toEqual("true");
+    expect(target.textContent).toEqual(text);
+    const consts = [...target.getElementsByClassName("idlConst")];
+    expect(consts.length).toEqual(19);
+    const const1 = target.querySelector(".idlConst");
+    expect(const1.querySelector(".idlConstType").textContent).toEqual(" boolean");
+    expect(const1.querySelector(".idlConstName").textContent).toEqual("test");
+    expect(const1.querySelector(".idlConstValue").textContent).toEqual("true");
     expect(
-      $target
-        .find(".idlConst")
-        .last()
-        .find(".extAttr").length
+      consts[consts.length - 1].querySelectorAll(".extAttr").length
     ).toEqual(1);
 
     // Links and IDs.
     expect(
-      $target
-        .find(":contains('rambaldi')")
-        .filter("a")
-        .attr("href")
+      consts
+        .filter(c => c.textContent.includes("rambaldi"))[0]
+        .querySelector(".idlConstName a")
+        .getAttribute("href")
     ).toEqual("#dom-consttest-rambaldi");
     expect(
-      $target
-        .find(":contains('rambaldi')")
-        .parents(".idlConst")
-        .attr("id")
+      consts
+        .filter(c => c.textContent.includes("rambaldi"))[0]
+        .getAttribute("id")
     ).toEqual("idl-def-consttest-rambaldi");
     expect(
-      $target
-        .find(":contains('why')")
-        .filter("a")
-        .attr("href")
+      consts
+        .filter(c => c.textContent.includes("why"))[0]
+        .querySelector(".idlConstName a")
+        .getAttribute("href")
     ).toEqual("#dom-consttest-why");
     expect(
-      $target
-        .find(":contains('inf')")
-        .filter("a")
-        .attr("href")
+      consts
+        .filter(c => c.textContent.includes("inf"))[0]
+        .querySelector(".idlConstName a")
+        .getAttribute("href")
     ).toEqual("#dom-consttest-inf");
-    expect($target.find(":contains('ationDevice')").filter("a").length).toEqual(
-      0
-    );
-    done();
+    expect(
+      consts
+        .filter(c => c.textContent.includes("ationDevice"))[0]
+        .querySelector(".idlConstName a")
+    ).toBeNull();
   });
 
   it("should handle attributes", function() {

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -163,55 +163,49 @@ describe("Core - WebIDL", function() {
     ).toBeNull();
   });
 
-  it("should handle constructors", function(done) {
-    var $target = $("#ctor-basic", doc);
-    var text =
+  it("should handle constructors", () => {
+    let target = doc.getElementById("ctor-basic");
+    let text =
       "[Something,\n" +
       " Constructor,\n" +
       " Constructor(boolean bar, sequence<double> foo, Promise<double> blah)]\n" +
       "interface SuperStar {};";
-    expect($target.text()).toEqual(text);
-    expect($target.find(".idlCtor").length).toEqual(2);
-    var $ctor1 = $target.find(".idlCtor").last();
-    expect($ctor1.find(".extAttrName").text()).toEqual("Constructor");
-    expect($ctor1.find(".idlParam").length).toEqual(3);
-    expect($ctor1.find(".idlParam:contains('sequence')").length).toEqual(1);
-    expect($ctor1.find(".idlParam:contains('Promise')").length).toEqual(1);
+    expect(target.textContent).toEqual(text);
+    const ctors = target.getElementsByClassName("idlCtor");
+    expect(ctors.length).toEqual(2);
+    const ctor = ctors[1];
+    expect(ctor.querySelector(".extAttrName").textContent).toEqual("Constructor");
+    const params = [...ctor.getElementsByClassName("idlParam")];
+    expect(params.length).toEqual(3);
+    expect(params.filter(p => p.textContent.includes("sequence")).length).toEqual(1);
+    expect(params.filter(p => p.textContent.includes("Promise")).length).toEqual(1);
     expect(
-      $ctor1
-        .find(".idlParam")
-        .first()
-        .find(".idlParamType")
-        .text()
+      ctor.querySelector(".idlParam .idlParamType").textContent
     ).toEqual("boolean");
 
-    $target = $("#ctor-noea", doc);
+    target = doc.getElementById("ctor-noea");
     text = "[Constructor] interface SuperStar {};";
-    expect($target.text()).toEqual(text);
-    done();
+    expect(target.textContent).toEqual(text);
   });
 
-  it("should handle named constructors", function(done) {
-    var $target = $("#namedctor-basic", doc);
-    var text =
+  it("should handle named constructors", () => {
+    const target = doc.getElementById("namedctor-basic");
+    const text =
       "[Something,\n" +
       " NamedConstructor=Sun(),\n" +
       " NamedConstructor=Sun(boolean bar, Date foo)]\n" +
       "interface SuperStar {};";
-    expect($target.text()).toEqual(text);
-    expect($target.find(".idlCtor").length).toEqual(2);
-    var $ctor1 = $target.find(".idlCtor").last();
-    expect($ctor1.find(".extAttrRhs").text()).toEqual("Sun");
-    expect($ctor1.find(".idlParam").length).toEqual(2);
-    expect($ctor1.find(".idlParam:contains('Date')").length).toEqual(1);
+    expect(target.textContent).toEqual(text);
+    const ctors = target.getElementsByClassName("idlCtor");
+    expect(ctors.length).toEqual(2);
+    const ctor = ctors[1];
+    expect(ctor.querySelector(".extAttrRhs").textContent).toEqual("Sun");
+    const params = [...ctor.getElementsByClassName("idlParam")];
+    expect(params.length).toEqual(2);
+    expect(params.filter(p => p.textContent.includes("Date")).length).toEqual(1);
     expect(
-      $ctor1
-        .find(".idlParam")
-        .first()
-        .find(".idlParamType")
-        .text()
+      ctor.querySelector(".idlParam .idlParamType").textContent
     ).toEqual("boolean");
-    done();
   });
 
   it("should handle constants", function(done) {


### PR DESCRIPTION
... to save kittens!

Bonus: `npm run karma -- --grep (regex)` [as suggested](https://github.com/karma-runner/karma/issues/672#issuecomment-204620473).