### PR TITLE
fix(core/idl): linking attribute id/type with same name

### DIFF
--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -138,7 +138,7 @@ function writeTrivia(text) {
 
 function idlType2Html(idlType) {
   if (typeof idlType === "string") {
-    return `<a>${hb.Utils.escapeExpression(idlType)}</a>`;
+    return `<a data-link-for="">${hb.Utils.escapeExpression(idlType)}</a>`;
   }
   if (Array.isArray(idlType)) {
     return idlType.map(idlType2Html).join(",");

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -323,7 +323,7 @@ describe("Core - WebIDL", function() {
   attribute Promise<DOMString> operation;
   // 5.0
   readonly attribute Performance performance;
-};`.trim();
+};`;
     expect(target.textContent).toEqual(text);
     const attrs = [...target.getElementsByClassName("idlAttribute")];
     expect(attrs.length).toEqual(9);

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -336,9 +336,11 @@ describe("Core - WebIDL", function() {
   attribute FrozenArray<DOMString> alist;
   // 4.0
   attribute Promise<DOMString> operation;
+  // 5.0
+  readonly attribute Performance performance;
 };`.trim();
     expect($target.text()).toEqual(text);
-    expect($target.find(".idlAttribute").length).toEqual(8);
+    expect($target.find(".idlAttribute").length).toEqual(9);
     var $at = $target.find(".idlAttribute").first();
     expect($at.find(".idlAttrType").text()).toEqual(" DOMString");
     expect($at.find(".idlAttrName").text()).toEqual("regular");
@@ -363,6 +365,22 @@ describe("Core - WebIDL", function() {
         .attr("href")
     ).toEqual("#dom-attrbasic-regular");
     expect($target.find(":contains('dates')").filter("a").length).toEqual(0);
+    const performanceIterfaceLink = Array.from(
+      $target[0].querySelectorAll("a")
+    ).find(({ textContent }) => textContent === "Performance");
+    const performanceAttrLink = Array.from(
+      $target[0].querySelectorAll("a")
+    ).find(({ textContent }) => textContent === "performance");
+
+    expect(performanceIterfaceLink).toBeTruthy();
+    expect(performanceIterfaceLink.getAttribute("href")).toEqual(
+      "#dfn-performance"
+    );
+
+    expect(performanceAttrLink).toBeTruthy();
+    expect(performanceAttrLink.getAttribute("href")).toEqual(
+      "#dom-attrbasic-performance"
+    );
   });
 
   it("handles stringifiers special operations", () => {

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -350,11 +350,11 @@ describe("Core - WebIDL", () => {
         .querySelector(".idlAttrName a")
     ).toBeNull();
 
-    const performanceIterfaceLink = Array.from(
+    const performanceInterfaceLink = Array.from(
       target.querySelectorAll("a")
     ).find(({ textContent }) => textContent === "Performance");
-    expect(performanceIterfaceLink).toBeTruthy();
-    expect(performanceIterfaceLink.getAttribute("href")).toEqual(
+    expect(performanceInterfaceLink).toBeTruthy();
+    expect(performanceInterfaceLink.getAttribute("href")).toEqual(
       "#dfn-performance"
     );
 

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -453,8 +453,8 @@ describe("Core - WebIDL", () => {
 };`;
     expect(target.textContent).toEqual(text);
     const methods = [...target.getElementsByClassName("idlMethod")];
-    expect(methods.length).toEqual(14);
-    expect(target.getElementsByClassName("idlMethName").length).toEqual(10);
+    expect(methods.length).toEqual(15);
+    expect(target.getElementsByClassName("idlMethName").length).toEqual(11);
     const first = methods[0];
     expect(first.querySelector(".idlMethType").textContent).toEqual(
       "\n  // 1\n  void"
@@ -477,6 +477,21 @@ describe("Core - WebIDL", () => {
         .find(m => m.textContent.includes("withName"))
         .querySelector(".idlMethName a")
     ).toBeNull();
+
+    const performanceTypeLink = Array.from(target.querySelectorAll("a")).find(
+      ({ textContent }) => textContent === "Performance"
+    );
+    expect(performanceTypeLink).toBeTruthy();
+    expect(performanceTypeLink.getAttribute("href")).toEqual(
+      "#dfn-performance"
+    );
+    const performanceMethodLink = Array.from(target.querySelectorAll("a")).find(
+      ({ textContent }) => textContent === "performance"
+    );
+    expect(performanceMethodLink).toBeTruthy();
+    expect(performanceMethodLink.getAttribute("href")).toEqual(
+      "#dom-methbasic-performance"
+    );
   });
 
   it("should handle iterable-like interface member declarations", () => {

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -326,7 +326,7 @@ describe("Core - WebIDL", function() {
 };`.trim();
     expect(target.textContent).toEqual(text);
     const attrs = [...target.getElementsByClassName("idlAttribute")];
-    expect(attrs.length).toEqual(8);
+    expect(attrs.length).toEqual(9);
     const at = attrs[0];
     expect(at.querySelector(".idlAttrType").textContent).toEqual(" DOMString");
     expect(at.querySelector(".idlAttrName").textContent).toEqual("regular");
@@ -354,18 +354,18 @@ describe("Core - WebIDL", function() {
         .find(c => c.textContent.includes("alist"))
         .querySelector(".idlAttrName a")
     ).toBeNull();
+
     const performanceIterfaceLink = Array.from(
       target.querySelectorAll("a")
     ).find(({ textContent }) => textContent === "Performance");
-    const performanceAttrLink = Array.from(
-      $target[0].querySelectorAll("a")
-    ).find(({ textContent }) => textContent === "performance");
-
     expect(performanceIterfaceLink).toBeTruthy();
     expect(performanceIterfaceLink.getAttribute("href")).toEqual(
       "#dfn-performance"
     );
 
+    const performanceAttrLink = Array.from(target.querySelectorAll("a")).find(
+      ({ textContent }) => textContent === "performance"
+    );
     expect(performanceAttrLink).toBeTruthy();
     expect(performanceAttrLink.getAttribute("href")).toEqual(
       "#dom-attrbasic-performance"
@@ -453,10 +453,11 @@ describe("Core - WebIDL", function() {
   stringifier;
   Promise<void> complete(optional PaymentComplete result = "unknown");
   Promise<void> another(optional  /*trivia*/  PaymentComplete result = "unknown");
+  Performance performance();
 };`;
     expect($target.text()).toEqual(text);
-    expect($target.find(".idlMethod").length).toEqual(14);
-    expect($target.find(".idlMethName").length).toEqual(10);
+    expect($target.find(".idlMethod").length).toEqual(15);
+    expect($target.find(".idlMethName").length).toEqual(11);
     var $meth = $target.find(".idlMethod").first();
     expect($meth.find(".idlMethType").text()).toEqual("\n  // 1\n  void");
     expect($meth.find(".idlMethName").text()).toEqual("basic");
@@ -479,6 +480,22 @@ describe("Core - WebIDL", function() {
         .attr("href")
     ).toEqual("#dom-methbasic-ull!overload-1");
     expect($target.find(":contains('dates')").filter("a").length).toEqual(0);
+
+    const target = $target[0];
+    const performanceTypeLink = Array.from(target.querySelectorAll("a")).find(
+      ({ textContent }) => textContent === "Performance"
+    );
+    expect(performanceTypeLink).toBeTruthy();
+    expect(performanceTypeLink.getAttribute("href")).toEqual(
+      "#dfn-performance"
+    );
+    const performanceMethodLink = Array.from(target.querySelectorAll("a")).find(
+      ({ textContent }) => textContent === "performance"
+    );
+    expect(performanceMethodLink).toBeTruthy();
+    expect(performanceMethodLink.getAttribute("href")).toEqual(
+      "#dom-methbasic-performance"
+    );
     done();
   });
 

--- a/tests/spec/core/webidl.html
+++ b/tests/spec/core/webidl.html
@@ -641,7 +641,7 @@
     <section>
       <pre id='retain-css-classes' class='idl a b c overlarge'>
         interface NotTested {};
-      </pre>      
+      </pre>
     </section>
     <section>
       <h2>Autolink to WebIDL spec for toJSON</h2>
@@ -657,7 +657,7 @@
         interface DefinedToJson {
           readonly attribute DOMString country;
           [Default] object toJSON();
-          void toWhatever(); 
+          void toWhatever();
         };
       </pre>
       <section>

--- a/tests/spec/core/webidl.html
+++ b/tests/spec/core/webidl.html
@@ -357,6 +357,9 @@
           setter SetterNamedPass named ();
         };
       </pre>
+      <p data-dfn-for="MethBasic">
+        <dfn>performance()</dfn> method.
+      </p>
       <pre id='meth-basic' class='idl'>
         interface MethBasic {
           // 1
@@ -385,6 +388,7 @@
           stringifier;
           Promise&lt;void> complete(optional PaymentComplete result = "unknown");
           Promise&lt;void> another(optional  /*trivia*/  PaymentComplete result = "unknown");
+          Performance performance();
         };
       </pre>
       <p id="meth-basic-doc" data-dfn-for="MethBasic">

--- a/tests/spec/core/webidl.html
+++ b/tests/spec/core/webidl.html
@@ -289,6 +289,12 @@
       <p>
         Basic attributes testing.
       </p>
+      <p>
+        The <code><dfn>Performance</dfn></code> interface.
+      </p>
+      <p data-dfn-for="AttrBasic">
+        The <dfn>performance</dfn> attribute.
+      </p>
       <pre id='attr-basic' class='idl'>
         interface AttrBasic {
           // 1
@@ -306,8 +312,9 @@
           // 3.10.31
           attribute FrozenArray&lt;DOMString&gt; alist;
           // 4.0
-          attribute Promise&lt;DOMString&gt; operation;<!--
-
+          attribute Promise&lt;DOMString&gt; operation;
+          // 5.0
+          readonly attribute Performance performance;<!--
           // 3
            static attribute DOMString unmovable;
           // 4


### PR DESCRIPTION
closes #1768

This prevents the attribute's type from using the parent element's `data-link-for`, which was confusing the linker. Types always need to be defined at top level things (i.e., they are not "for" things), so this should work. 
 