### PR TITLE
Force eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,7 +17,8 @@
     "indent": 0,
     "quotes": 0,
     "semi": ["error", "always"],
-    "no-console": 0
+    "no-console": 0,
+    "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
   },
   "globals": {
     "flushIframes": true,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,7 +15,6 @@
   },
   "rules": {
     "indent": 0,
-    "linebreak-style": ["error", "unix"],
     "quotes": 0,
     "semi": ["error", "always"],
     "no-console": 0

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ jobs:
   include:
     - stage: Run eslint
       script:
-        - npx eslint src/**/*.js
+        - npm run lint
     - stage: Run headless
       script:
         - npm run test:headless

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,13 @@ addons:
 
 cache:
   directories:
-  - node_modules # NPM packages
+    - node_modules # NPM packages
 
 jobs:
   include:
+    - stage: Run eslint
+      script:
+        - npx eslint src/**/*.js
     - stage: Run headless
       script:
         - npm run test:headless

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "copydeps": "node ./tools/copydeps.js",
     "handlebars": "handlebars",
     "karma": "karma start --single-run",
+    "lint": "npx eslint src/**/*.js",
     "release": "node ./tools/release.js",
     "server": "npm start",
     "snyk": "snyk",

--- a/src/core/best-practices.js
+++ b/src/core/best-practices.js
@@ -15,13 +15,21 @@ export function run() {
   for (const bp of bps) {
     num++;
     const id = window.$.fn.makeID.call([bp], "bp");
-    const li = hyperHTML`<li><a href="${`#${id}`}">Best Practice ${num}</a>: ${bp.textContent}</li>`;
+    const li = hyperHTML`<li><a href="${`#${id}`}">Best Practice ${num}</a>: ${
+      bp.textContent
+    }</li>`;
     ul.appendChild(li);
-    bp.insertBefore(document.createTextNode(`Best Practice ${num}: `), bp.firstChild);
+    bp.insertBefore(
+      document.createTextNode(`Best Practice ${num}: `),
+      bp.firstChild
+    );
   }
   const bpSummary = document.getElementById("bp-summary");
   if (bps.length) {
-    document.head.insertBefore(hyperHTML`<style>${[css]}</style>`, document.head.querySelector("link"));
+    document.head.insertBefore(
+      hyperHTML`<style>${[css]}</style>`,
+      document.head.querySelector("link")
+    );
     if (bpSummary) {
       bpSummary.appendChild(hyperHTML`<h2>Best Practices Summary</h2>`);
       bpSummary.appendChild(ul);

--- a/src/core/caniuse.js
+++ b/src/core/caniuse.js
@@ -195,7 +195,7 @@ function createTableHTML(conf, stats) {
       .slice(-numVersions)
       .reverse();
     const { support, title } = getSupport(latestVersion);
-    const cssClass= `caniuse-cell ${support}`;
+    const cssClass = `caniuse-cell ${support}`;
     return hyperHTML`
       <div class="caniuse-browser">
         <button class="${cssClass}" title="${title}">

--- a/src/core/data-include.js
+++ b/src/core/data-include.js
@@ -75,7 +75,9 @@ export function run(conf, doc, cb) {
       const text = await response.text();
       processResponse(text, id, url);
     } catch (err) {
-      const msg = `\`data-include\` failed: \`${url}\` (${err.message}). See console for details.`;
+      const msg = `\`data-include\` failed: \`${url}\` (${
+        err.message
+      }). See console for details.`;
       console.error("data-include failed for element: ", el, err);
       pub("error", msg);
     }

--- a/src/core/examples.js
+++ b/src/core/examples.js
@@ -10,9 +10,9 @@ import css from "deps/text!core/css/examples.css";
 
 export const name = "core/examples";
 
-var makeTitle = function(conf, $el, num, report) {
-  var txt = num > 0 ? " " + num : "";
-  var $tit = $(
+function makeTitle(conf, $el, num, report) {
+  const txt = num > 0 ? " " + num : "";
+  const $tit = $(
     `<div class='example-title'><span>${conf.l10n.example}${txt}</span></div>`
   );
   report.title = $el.attr("title");
@@ -24,36 +24,36 @@ var makeTitle = function(conf, $el, num, report) {
   }
   $tit.addClass("marker");
   return $tit;
-};
+}
 
 export function run(conf, doc, cb) {
-  var $exes = $("pre.example, pre.illegal-example, aside.example"),
-    num = 0;
+  const $exes = $("pre.example, pre.illegal-example, aside.example");
+  let num = 0;
   if ($exes.length) {
     $(doc)
       .find("head link")
       .first()
       .before($("<style/>").text(css));
-    $exes.each(function(i, ex) {
-      var $ex = $(ex),
+    $exes.each((i, ex) => {
+      const $ex = $(ex),
         report = { number: num, illegal: $ex.hasClass("illegal-example") };
       if ($ex.is("aside")) {
         num++;
-        var $tit = makeTitle(conf, $ex, num, report);
+        const $tit = makeTitle(conf, $ex, num, report);
         $ex.prepend($tit);
         pub("example", report);
       } else {
-        var inAside = !!$ex.parents("aside").length;
+        let inAside = !!$ex.parents("aside").length;
         if (!inAside) num++;
         // reindent
-        var lines = $ex.html().split("\n");
+        let lines = $ex.html().split("\n");
         while (lines.length && /^\s*$/.test(lines[0])) lines.shift();
         while (lines.length && /^\s*$/.test(lines[lines.length - 1]))
           lines.pop();
-        var matches = /^(\s+)/.exec(lines[0]);
+        const matches = /^(\s+)/.exec(lines[0]);
         if (matches) {
-          var rep = new RegExp("^" + matches[1]);
-          for (var j = 0; j < lines.length; j++) {
+          const rep = new RegExp("^" + matches[1]);
+          for (let j = 0; j < lines.length; j++) {
             lines[j] = lines[j].replace(rep, "");
           }
         }
@@ -61,8 +61,8 @@ export function run(conf, doc, cb) {
         $ex.html(lines.join("\n"));
         $ex.removeClass("example illegal-example");
         // wrap
-        var $div = $("<div class='example'></div>"),
-          $tit = makeTitle(conf, $ex, inAside ? 0 : num, report);
+        const $div = $("<div class='example'></div>");
+        const $tit = makeTitle(conf, $ex, inAside ? 0 : num, report);
         $div.append($tit);
         $div.append($ex.clone());
         $ex.replaceWith($div);

--- a/src/core/examples.js
+++ b/src/core/examples.js
@@ -30,7 +30,10 @@ export function run(conf, doc, cb) {
   var $exes = $("pre.example, pre.illegal-example, aside.example"),
     num = 0;
   if ($exes.length) {
-    $(doc).find("head link").first().before($("<style/>").text(css));
+    $(doc)
+      .find("head link")
+      .first()
+      .before($("<style/>").text(css));
     $exes.each(function(i, ex) {
       var $ex = $(ex),
         report = { number: num, illegal: $ex.hasClass("illegal-example") };

--- a/src/core/github.js
+++ b/src/core/github.js
@@ -4,7 +4,6 @@
  * @see https://github.com/w3c/respec/wiki/github
  */
 
-import l10n from "core/l10n";
 import { pub } from "core/pubsubhub";
 
 export const name = "core/github";

--- a/src/core/github.js
+++ b/src/core/github.js
@@ -74,7 +74,8 @@ export async function run(conf) {
   }
   const [org, repo] = ghURL.pathname.split("/").filter(item => item);
   if (!org || !repo) {
-    const msg = "`respecConf.github` URL needs a path with, for example, w3c/my-spec";
+    const msg =
+      "`respecConf.github` URL needs a path with, for example, w3c/my-spec";
     pub("error", msg);
     return;
   }

--- a/src/core/highlight.js
+++ b/src/core/highlight.js
@@ -53,7 +53,7 @@ export async function run(conf) {
       };
       worker.addEventListener("message", function listener(ev) {
         const {
-          data: { id, code, language, value },
+          data: { id, language, value },
         } = ev;
         if (id !== msg.id) {
           return; // not for us!

--- a/src/core/highlight.js
+++ b/src/core/highlight.js
@@ -52,7 +52,9 @@ export async function run(conf) {
         languages: getLanguageHint(element.classList),
       };
       worker.addEventListener("message", function listener(ev) {
-        const { data: { id, code, language, value } } = ev;
+        const {
+          data: { id, code, language, value },
+        } = ev;
         if (id !== msg.id) {
           return; // not for us!
         }

--- a/src/core/issues-notes.js
+++ b/src/core/issues-notes.js
@@ -112,9 +112,9 @@ function handleIssues(ins, ghIssues, conf) {
           // Add entry to #issue-summary.
           var $li = $("<li><a></a></li>");
           var $a = $li.find("a");
-          $a
-            .attr("href", "#" + $div[0].id)
-            .text(conf.l10n.issue + " " + report.number);
+          $a.attr("href", "#" + $div[0].id).text(
+            conf.l10n.issue + " " + report.number
+          );
           if (report.title) {
             $li.append(
               $(

--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -42,13 +42,20 @@ function makeTOCAtLevel($parent, doc, current, level, conf) {
       continue;
     }
     var title = h.textContent,
-      $kidsHolder = $("<div></div>").append($(h).contents().clone());
+      $kidsHolder = $("<div></div>").append(
+        $(h)
+          .contents()
+          .clone()
+      );
     $kidsHolder
       .find("a")
       .renameElement("span")
       .attr("class", "formerLink")
       .removeAttr("href");
-    $kidsHolder.find("dfn").renameElement("span").removeAttr("id");
+    $kidsHolder
+      .find("dfn")
+      .renameElement("span")
+      .removeAttr("id");
     var id = h.id ? h.id : $sec.makeID(null, title);
 
     if (!isIntro) {

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -12,9 +12,9 @@ marked.setOptions({
   gfm: true,
 });
 
-const spaceOrTab = /^[\ |\t]*/;
+const spaceOrTab = /^[ |\t]*/;
 const endsWithSpace = /\s+$/gm;
-const dashes = /\-/g;
+const dashes = /-/g;
 const gtEntity = /&gt;/gm;
 const ampEntity = /&amp;/gm;
 
@@ -232,10 +232,10 @@ export function normalizePadding(text = "") {
   doc.normalize();
   // use the first space as an indicator of how much to chop off the front
   const firstSpace = doc.body.innerText
-    .replace(/^\ *\n/, "")
+    .replace(/^ *\n/, "")
     .split("\n")
     .filter(item => item && item.startsWith(" "))[0];
-  var chop = firstSpace ? firstSpace.match(/\ +/)[0].length : 0;
+  var chop = firstSpace ? firstSpace.match(/ +/)[0].length : 0;
   if (chop) {
     // Chop chop from start, but leave pre elem alone
     Array.from(doc.body.childNodes)
@@ -259,7 +259,7 @@ export function normalizePadding(text = "") {
         const nextTo = prevSib
           ? prevSib.localName
           : node.parentElement.localName;
-        if (/^[\t\ ]/.test(node.textContent) && inlineElems.has(nextTo)) {
+        if (/^[\t ]/.test(node.textContent) && inlineElems.has(nextTo)) {
           padding = node.textContent.match(/^\s+/)[0];
         }
         node.textContent = padding + node.textContent.replace(replacer, "");
@@ -323,11 +323,12 @@ export function joinAnd(array = [], mapper = item => item) {
       return items.toString();
     case 2: // x and y
       return items.join(" and ");
-    default:
+    default: {
       // x, y, and z
       const str = items.join(", ");
       const lastComma = str.lastIndexOf(",");
       return `${str.substr(0, lastComma + 1)} and ${str.slice(lastComma + 2)}`;
+    }
   }
 }
 

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -553,7 +553,9 @@ export function flatten(collector, item) {
     Object(item)[Symbol.iterator] && typeof item.values === "function";
   const items = !isObject
     ? [item]
-    : isIterable ? [...item.values()].reduce(flatten, []) : Object.values(item);
+    : isIterable
+      ? [...item.values()].reduce(flatten, [])
+      : Object.values(item);
   return [...collector, ...items];
 }
 

--- a/src/core/webidl-clipboard.js
+++ b/src/core/webidl-clipboard.js
@@ -19,8 +19,8 @@ const clipboardOps = {
   text: trigger => {
     return document
       .querySelector(trigger.dataset.clipboardTarget)
-      .textContent.replace(/\ +/gm, " ")
-      .replace(/^\ /gm, "  ")
+      .textContent.replace(/ +/gm, " ")
+      .replace(/^ /gm, "  ")
       .replace(/^};\n/gm, "};\n")
       .trim();
   },

--- a/src/ui/dfn-list.js
+++ b/src/ui/dfn-list.js
@@ -23,7 +23,7 @@ ul.addEventListener("click", ev => {
 function show() {
   const definitionLinks = Object.entries(respecConfig.definitionMap)
     .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
-    .map(([key, $dfns]) => {
+    .map(([_key, $dfns]) => {
       const [dfn] = $dfns[0];
       return window.hyperHTML.wire(dfn, ":li>a")`
         <li>

--- a/src/ui/search-specref.js
+++ b/src/ui/search-specref.js
@@ -154,9 +154,9 @@ function render({ state, results, timeTaken, query } = { state: "" }) {
     <p class="state" hidden="${!state}">
       ${state}
     </p>
-    <section hidden="${!results}">${results
-    ? renderResults(results, query, timeTaken)
-    : []}</section>
+    <section hidden="${!results}">${
+    results ? renderResults(results, query, timeTaken) : []
+  }</section>
   `;
 }
 

--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -259,7 +259,9 @@ export function run(conf) {
       const msg =
         "Web Platform Tests have moved to a new Github Organization at https://github.com/web-platform-tests. " +
         "Please update your [`testSuiteURI`](https://github.com/w3c/respec/wiki/testSuiteURI) to point to the " +
-        `new tests repository (e.g., https://github.com/web-platform-tests/${conf.shortName} ).`;
+        `new tests repository (e.g., https://github.com/web-platform-tests/${
+          conf.shortName
+        } ).`;
       pub("warn", msg);
     }
   }

--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -1,7 +1,6 @@
 /*jshint
     forin: false
 */
-/*global hb*/
 
 // Module w3c/headers
 // Generate the headers material based on the provided configuration.
@@ -93,9 +92,7 @@
 //      - "w3c-software-doc", the W3C Software and Document License
 //            https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
 import { concatDate, joinAnd, ISODate } from "core/utils";
-import hb from "handlebars.runtime";
 import { pub } from "core/pubsubhub";
-import tmpls from "templates";
 import cgbgSotdTmpl from "w3c/templates/cgbg-sotd";
 import sotdTmpl from "w3c/templates/sotd";
 import cgbgHeadersTmpl from "w3c/templates/cgbg-headers";

--- a/src/w3c/linter-rules/privsec-section.js
+++ b/src/w3c/linter-rules/privsec-section.js
@@ -23,13 +23,13 @@ const meta = {
 const lang = defaultLang in meta ? defaultLang : "en";
 
 function hasPriSecConsiderations(doc) {
-  return Array.from(
-    doc.querySelectorAll("h2, h3, h4, h5, h6")
-  ).some(({ textContent: text }) => {
-    const saysPrivOrSec = /(privacy|security)/im.test(text);
-    const saysConsiderations = /(considerations)/im.test(text);
-    return (saysPrivOrSec && saysConsiderations) || saysPrivOrSec;
-  });
+  return Array.from(doc.querySelectorAll("h2, h3, h4, h5, h6")).some(
+    ({ textContent: text }) => {
+      const saysPrivOrSec = /(privacy|security)/im.test(text);
+      const saysConsiderations = /(considerations)/im.test(text);
+      return (saysPrivOrSec && saysConsiderations) || saysPrivOrSec;
+    }
+  );
 }
 
 function lintingFunction(conf, doc) {

--- a/src/w3c/permalinks.js
+++ b/src/w3c/permalinks.js
@@ -25,7 +25,10 @@ export function run(conf, doc, cb) {
   var symbol = conf.permalinkSymbol || "§";
   var style = "<style>" + css(conf) + "</style>";
 
-  $(doc).find("head link").first().before(style);
+  $(doc)
+    .find("head link")
+    .first()
+    .before(style);
   var $secs = $(doc).find("h2, h3, h4, h5, h6");
   $secs.each(function(i, item) {
     var $item = $(item);

--- a/src/w3c/rfc2119.js
+++ b/src/w3c/rfc2119.js
@@ -26,9 +26,9 @@ export function run(conf, doc, cb) {
     item => `<em class="rfc2119">${item}</em>`
   );
   const plural = terms.length > 1;
-  const str = `The key word${plural ? "s " : " "} ${html} ${plural
-    ? "are"
-    : "is"} ${confo.innerHTML}`;
+  const str = `The key word${plural ? "s " : " "} ${html} ${
+    plural ? "are" : "is"
+  } ${confo.innerHTML}`;
   confo.innerHTML = str;
   cb();
 }

--- a/src/w3c/seo.js
+++ b/src/w3c/seo.js
@@ -56,7 +56,7 @@ export function run(conf, doc, cb) {
   }
 }
 
-async function addJSONLDInfo (conf, doc) {
+async function addJSONLDInfo(conf, doc) {
   await doc.respecIsReady;
   // Content for JSON
   const type = ["TechArticle"];
@@ -126,7 +126,6 @@ async function addJSONLDInfo (conf, doc) {
   script.type = "application/ld+json";
   script.textContent = JSON.stringify(jsonld, null, 2);
   doc.head.appendChild(script);
-  
 }
 
 // Turn editors and authors into a list of JSON-LD relationships

--- a/src/w3c/style.js
+++ b/src/w3c/style.js
@@ -36,7 +36,7 @@ function createMetaViewport() {
     "initial-scale": "1",
     "shrink-to-fit": "no",
   };
-  meta.content = toKeyValuePairs(contentProps).replace(/\"/g, "");
+  meta.content = toKeyValuePairs(contentProps).replace(/"/g, "");
   return meta;
 }
 

--- a/src/w3c/templates/cgbg-headers.js
+++ b/src/w3c/templates/cgbg-headers.js
@@ -8,78 +8,146 @@ export default conf => {
   return html`<div class='head'>
   ${conf.logos.map(showLogo)}
   <h1 class='title p-name' id='title'>${conf.title}</h1>
-  ${conf.subtitle ? html`
+  ${
+    conf.subtitle
+      ? html`
     <h2 id='subtitle'>${conf.subtitle}</h2>
-  ` : ""}
-  <h2>${conf.longStatus} <time class='dt-published' datetime='${conf.dashDate}'>${conf.publishHumanDate}</time></h2>
+  `
+      : ""
+  }
+  <h2>${conf.longStatus} <time class='dt-published' datetime='${
+    conf.dashDate
+  }'>${conf.publishHumanDate}</time></h2>
   <dl>
-    ${conf.thisVersion ? html`
+    ${
+      conf.thisVersion
+        ? html`
       <dt>${conf.l10n.this_version}</dt>
-      <dd><a class='u-url' href='${conf.thisVersion}'>${conf.thisVersion}</a></dd>
-    ` : ""}
-    ${conf.latestVersion ? html`
+      <dd><a class='u-url' href='${conf.thisVersion}'>${
+            conf.thisVersion
+          }</a></dd>
+    `
+        : ""
+    }
+    ${
+      conf.latestVersion
+        ? html`
       <dt>${conf.l10n.latest_published_version}</dt>
       <dd><a href='${conf.latestVersion}'>${conf.latestVersion}</a></dd>
-    ` : ""}
-    ${conf.edDraftURI ? html`
+    `
+        : ""
+    }
+    ${
+      conf.edDraftURI
+        ? html`
       <dt>${conf.l10n.latest_editors_draft}</dt>
       <dd><a href='${conf.edDraftURI}'>${conf.edDraftURI}</a></dd>
-    ` : ""}
-    ${conf.testSuiteURI ? html`
+    `
+        : ""
+    }
+    ${
+      conf.testSuiteURI
+        ? html`
       <dt>Test suite:</dt>
       <dd><a href='${conf.testSuiteURI}'>${conf.testSuiteURI}</a></dd>
-    ` : ""}
-    ${conf.implementationReportURI ? html`
+    `
+        : ""
+    }
+    ${
+      conf.implementationReportURI
+        ? html`
       <dt>Implementation report:</dt>
-      <dd><a href='${conf.implementationReportURI}'>${conf.implementationReportURI}</a></dd>
-    ` : ""}
-    ${conf.bugTrackerHTML ? html`
+      <dd><a href='${conf.implementationReportURI}'>${
+            conf.implementationReportURI
+          }</a></dd>
+    `
+        : ""
+    }
+    ${
+      conf.bugTrackerHTML
+        ? html`
       <dt>${conf.l10n.bug_tracker}</dt>
       <dd>${[conf.bugTrackerHTML]}</dd>
-    ` : ""}
-    ${conf.prevVersion ? html`
+    `
+        : ""
+    }
+    ${
+      conf.prevVersion
+        ? html`
       <dt>Previous version:</dt>
       <dd><a href='${conf.prevVersion}'>${conf.prevVersion}</a></dd>
-    ` : ""}
-    ${!conf.isCGFinal ? html`
-      ${conf.prevED ? html`
+    `
+        : ""
+    }
+    ${
+      !conf.isCGFinal
+        ? html`
+      ${
+        conf.prevED
+          ? html`
         <dt>Previous editor's draft:</dt>
         <dd><a href='${conf.prevED}'>${conf.prevED}</a></dd>
-      ` : ""}
-    ` : ""}
+      `
+          : ""
+      }
+    `
+        : ""
+    }
     <dt>${conf.multipleEditors ? conf.l10n.editors : conf.l10n.editor}</dt>
     ${showPeople(conf, "Editor", conf.editors)}
-    ${Array.isArray(conf.formerEditors) && conf.formerEditors.length > 0 ? html`
-      <dt>${conf.multipleFormerEditors ? conf.l10n.former_editors : conf.l10n.former_editor}</dt>
+    ${
+      Array.isArray(conf.formerEditors) && conf.formerEditors.length > 0
+        ? html`
+      <dt>${
+        conf.multipleFormerEditors
+          ? conf.l10n.former_editors
+          : conf.l10n.former_editor
+      }</dt>
       ${showPeople(conf, "Editor", conf.formerEditors)}
-    ` : ""}
-    ${conf.authors ? html`
+    `
+        : ""
+    }
+    ${
+      conf.authors
+        ? html`
       <dt>${conf.multipleAuthors ? conf.l10n.authors : conf.l10n.author}</dt>
       ${showPeople(conf, "Author", conf.authors)}
-    ` : ""}
+    `
+        : ""
+    }
     ${conf.otherLinks ? conf.otherLinks.map(showLink) : ""}
   </dl>
-  ${conf.alternateFormats ? html`
+  ${
+    conf.alternateFormats
+      ? html`
     <p>
-      ${conf.multipleAlternates ?
-        "This document is also available in these non-normative formats:" :
-        "This document is also available in this non-normative format:"}
+      ${
+        conf.multipleAlternates
+          ? "This document is also available in these non-normative formats:"
+          : "This document is also available in this non-normative format:"
+      }
       ${[conf.alternatesHTML]}
     </p>
-  ` : ""}
+  `
+      : ""
+  }
   <p class='copyright'>
     <a href='https://www.w3.org/Consortium/Legal/ipr-notice#Copyright'>Copyright</a> &copy;
     ${conf.copyrightStart ? `${conf.copyrightStart}-` : ""}${conf.publishYear}
     the Contributors to the ${conf.title} Specification, published by the
     <a href='${conf.wgURI}'>${conf.wg}</a> under the
-    ${conf.isCGFinal ? html`
+    ${
+      conf.isCGFinal
+        ? html`
       <a href="https://www.w3.org/community/about/agreements/fsa/">W3C Community Final Specification Agreement (FSA)</a>. 
       A human-readable <a href="https://www.w3.org/community/about/agreements/fsa-deed/">summary</a> is available.
-    ` : html`
+    `
+        : html`
       <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
       A human-readable <a href="https://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available.
-    `}
+    `
+    }
   </p>
   <hr title="Separator for header">
 </div>`;
-}
+};

--- a/src/w3c/templates/cgbg-sotd.js
+++ b/src/w3c/templates/cgbg-sotd.js
@@ -3,43 +3,73 @@ import "deps/hyperhtml";
 export default conf => {
   const html = hyperHTML;
   return html`<h2>${conf.l10n.sotd}</h2>
-${conf.isPreview ? html`
+${
+    conf.isPreview
+      ? html`
   <details class="annoying-warning" open="">
     <summary>This is a preview</summary>
     <p>
       Do not attempt to implement this version of the specification. Do not reference this
       version as authoritative in any way.
-      ${conf.edDraftURI ? html`
-        Instead, see <a href="${conf.edDraftURI}">${conf.edDraftURI}</a> for the Editor's draft.
-      ` : ""}
+      ${
+        conf.edDraftURI
+          ? html`
+        Instead, see <a href="${conf.edDraftURI}">${
+              conf.edDraftURI
+            }</a> for the Editor's draft.
+      `
+          : ""
+      }
     </p>
   </details>
-` : ""}
+`
+      : ""
+  }
 <p>
-  This specification was published by the <a href='${conf.wgURI}'>${conf.wg}</a>.
+  This specification was published by the <a href='${conf.wgURI}'>${
+    conf.wg
+  }</a>.
   It is not a W3C Standard nor is it on the W3C Standards Track.
-  ${conf.isCGFinal ? html`
+  ${
+    conf.isCGFinal
+      ? html`
     Please note that under the
     <a href="https://www.w3.org/community/about/agreements/final/">W3C Community Final Specification Agreement (FSA)</a>
     other conditions apply.
-  ` : html`
+  `
+      : html`
     Please note that under the
     <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>
     there is a limited opt-out and other conditions apply.
-  `}
+  `
+  }
   Learn more about
   <a href="https://www.w3.org/community/">W3C Community and Business Groups</a>.
 </p>
 ${!conf.sotdAfterWGinfo ? [conf.additionalContent] : ""}
-  ${conf.wgPublicList ? html`
+  ${
+    conf.wgPublicList
+      ? html`
     <p>If you wish to make comments regarding this document, please send them to
-    <a href='${`mailto:${conf.wgPublicList}@w3.org${conf.subjectPrefix ? `?subject=${conf.subjectPrefixEnc}` : ""}`}'>${conf.wgPublicList}@w3.org</a>
-    (<a href='${`mailto:${conf.wgPublicList}-request@w3.org?subject=subscribe`}'>subscribe</a>,
+    <a href='${`mailto:${conf.wgPublicList}@w3.org${
+      conf.subjectPrefix ? `?subject=${conf.subjectPrefixEnc}` : ""
+    }`}'>${conf.wgPublicList}@w3.org</a>
+    (<a href='${`mailto:${
+      conf.wgPublicList
+    }-request@w3.org?subject=subscribe`}'>subscribe</a>,
     <a
-      href='${`https://lists.w3.org/Archives/Public/${conf.wgPublicList}/`}'>archives</a>)${conf.subjectPrefix ? html`
+      href='${`https://lists.w3.org/Archives/Public/${
+        conf.wgPublicList
+      }/`}'>archives</a>)${
+          conf.subjectPrefix
+            ? html`
     with <code>${conf.subjectPrefix}</code> at the start of your
-    email's subject` : ""}.</p>
-  ` : ""}
+    email's subject`
+            : ""
+        }.</p>
+  `
+      : ""
+  }
 ${conf.sotdAfterWGinfo ? [conf.additionalContent] : ""}
 ${[conf.additionalSections]}`;
-}
+};

--- a/src/w3c/templates/conformance.js
+++ b/src/w3c/templates/conformance.js
@@ -11,4 +11,4 @@ export default () => {
 <p id='respecRFC2119'>
   to be interpreted as described in [[!RFC2119]].
 </p>`;
-}
+};

--- a/src/w3c/templates/headers.js
+++ b/src/w3c/templates/headers.js
@@ -4,7 +4,7 @@ import showPeople from "./show-people";
 import showLink from "./show-link";
 import { pub } from "core/pubsubhub";
 
-function getSpecTitleElem (conf) {
+function getSpecTitleElem(conf) {
   const specTitleElem =
     document.querySelector("h1#title") || document.createElement("h1");
   if (specTitleElem.parentElement) {
@@ -23,147 +23,263 @@ function getSpecTitleElem (conf) {
   return specTitleElem;
 }
 
-function getSpecSubTitleElem (conf) {
+function getSpecSubTitleElem(conf) {
   let specSubTitleElem = document.querySelector("h2#subtitle");
-  
+
   if (specSubTitleElem && specSubTitleElem.parentElement) {
     specSubTitleElem.remove();
     conf.subtitle = specSubTitleElem.textContent.trim();
   } else if (conf.subtitle) {
-    specSubTitleElem = document.createElement ("h2");
+    specSubTitleElem = document.createElement("h2");
     specSubTitleElem.textContent = conf.subtitle;
     specSubTitleElem.id = "subtitle";
   }
   if (specSubTitleElem) {
-    specSubTitleElem.classList.add ("subtitle");
+    specSubTitleElem.classList.add("subtitle");
   }
   return specSubTitleElem;
 }
 
 export default conf => {
   const html = hyperHTML;
-  
+
   return html`<div class='head'>
   ${conf.logos.map(showLogo)}
   ${getSpecTitleElem(conf)}
   ${getSpecSubTitleElem(conf)}
-  <h2>${conf.prependW3C ? "W3C " : ""}${conf.textStatus} <time class='dt-published' datetime='${conf.dashDate}'>${conf.publishHumanDate}</time></h2>
+  <h2>${conf.prependW3C ? "W3C " : ""}${
+    conf.textStatus
+  } <time class='dt-published' datetime='${conf.dashDate}'>${
+    conf.publishHumanDate
+  }</time></h2>
   <dl>
-    ${!conf.isNoTrack ? html`
+    ${
+      !conf.isNoTrack
+        ? html`
       <dt>${conf.l10n.this_version}</dt>
-      <dd><a class='u-url' href='${conf.thisVersion}'>${conf.thisVersion}</a></dd>
+      <dd><a class='u-url' href='${conf.thisVersion}'>${
+            conf.thisVersion
+          }</a></dd>
       <dt>${conf.l10n.latest_published_version}</dt>
-      <dd>${conf.latestVersion ? html`<a href='${conf.latestVersion}'>${conf.latestVersion}</a>` : "none"}</dd>
-    ` : ""}
-    ${conf.edDraftURI ? html`
+      <dd>${
+        conf.latestVersion
+          ? html`<a href='${conf.latestVersion}'>${conf.latestVersion}</a>`
+          : "none"
+      }</dd>
+    `
+        : ""
+    }
+    ${
+      conf.edDraftURI
+        ? html`
       <dt>${conf.l10n.latest_editors_draft}</dt>
       <dd><a href='${conf.edDraftURI}'>${conf.edDraftURI}</a></dd>
-    ` : ""}
-    ${conf.testSuiteURI ? html`
+    `
+        : ""
+    }
+    ${
+      conf.testSuiteURI
+        ? html`
       <dt>Test suite:</dt>
       <dd><a href='${conf.testSuiteURI}'>${conf.testSuiteURI}</a></dd>
-    ` : ""}
-    ${conf.implementationReportURI ? html`
+    `
+        : ""
+    }
+    ${
+      conf.implementationReportURI
+        ? html`
       <dt>Implementation report:</dt>
-      <dd><a href='${conf.implementationReportURI}'>${conf.implementationReportURI}</a></dd>
-    ` : ""}
-    ${conf.bugTrackerHTML ? html`
+      <dd><a href='${conf.implementationReportURI}'>${
+            conf.implementationReportURI
+          }</a></dd>
+    `
+        : ""
+    }
+    ${
+      conf.bugTrackerHTML
+        ? html`
       <dt>${conf.l10n.bug_tracker}</dt>
       <dd>${[conf.bugTrackerHTML]}</dd>
-    ` : ""}
-    ${conf.isED ? html`
-      ${conf.prevED ? html`
+    `
+        : ""
+    }
+    ${
+      conf.isED
+        ? html`
+      ${
+        conf.prevED
+          ? html`
         <dt>Previous editor's draft:</dt>
         <dd><a href='${conf.prevED}'>${conf.prevED}</a></dd>
-      ` : ""}
-    ` : ""}
-    ${conf.showPreviousVersion ? html`
+      `
+          : ""
+      }
+    `
+        : ""
+    }
+    ${
+      conf.showPreviousVersion
+        ? html`
       <dt>Previous version:</dt>
       <dd><a href='${conf.prevVersion}'>${conf.prevVersion}</a></dd>
-    ` : ""}
-    ${conf.prevRecURI ? html`
-      ${conf.isRec ? html`
+    `
+        : ""
+    }
+    ${
+      conf.prevRecURI
+        ? html`
+      ${
+        conf.isRec
+          ? html`
           <dt>Previous Recommendation:</dt>
           <dd><a href='${conf.prevRecURI}'>${conf.prevRecURI}</a></dd>
-      ` : html`
+      `
+          : html`
           <dt>Latest Recommendation:</dt>
           <dd><a href='${conf.prevRecURI}'>${conf.prevRecURI}</a></dd>
-      `}
-    ` : ""}
+      `
+      }
+    `
+        : ""
+    }
     <dt>${conf.multipleEditors ? conf.l10n.editors : conf.l10n.editor}</dt>
     ${showPeople(conf, "Editor", conf.editors)}
-    ${Array.isArray(conf.formerEditors) && conf.formerEditors.length > 0 ? html`
-      <dt>${conf.multipleFormerEditors ? conf.l10n.former_editors : conf.l10n.former_editor}</dt>
+    ${
+      Array.isArray(conf.formerEditors) && conf.formerEditors.length > 0
+        ? html`
+      <dt>${
+        conf.multipleFormerEditors
+          ? conf.l10n.former_editors
+          : conf.l10n.former_editor
+      }</dt>
       ${showPeople(conf, "Editor", conf.formerEditors)}
-    ` : ""}
-    ${conf.authors ? html`
+    `
+        : ""
+    }
+    ${
+      conf.authors
+        ? html`
       <dt>${conf.multipleAuthors ? conf.l10n.authors : conf.l10n.author}</dt>
       ${showPeople(conf, "Author", conf.authors)}
-    ` : ""}
+    `
+        : ""
+    }
     ${conf.otherLinks ? conf.otherLinks.map(showLink) : ""}
   </dl>
-  ${conf.errata ? html`
+  ${
+    conf.errata
+      ? html`
     <p>
-      Please check the <a href="${conf.errata}"><strong>errata</strong></a> for any errors or issues
+      Please check the <a href="${
+        conf.errata
+      }"><strong>errata</strong></a> for any errors or issues
       reported since publication.
     </p>
-  ` : ""}
-  ${conf.isRec ? html`
+  `
+      : ""
+  }
+  ${
+    conf.isRec
+      ? html`
     <p>
-      See also <a href="${`http://www.w3.org/2003/03/Translations/byTechnology?technology=${conf.shortName}`}">
+      See also <a href="${`http://www.w3.org/2003/03/Translations/byTechnology?technology=${
+        conf.shortName
+      }`}">
       <strong>translations</strong></a>.
     </p>
-  ` : ""}
-  ${conf.alternateFormats ? html`
+  `
+      : ""
+  }
+  ${
+    conf.alternateFormats
+      ? html`
     <p>
-      ${conf.multipleAlternates ?
-        "This document is also available in these non-normative formats:" :
-        "This document is also available in this non-normative format:"}
+      ${
+        conf.multipleAlternates
+          ? "This document is also available in these non-normative formats:"
+          : "This document is also available in this non-normative format:"
+      }
       ${[conf.alternatesHTML]}
     </p>
-  ` : ""}
-  ${conf.isUnofficial ? html`
-    ${conf.additionalCopyrightHolders ? html`
+  `
+      : ""
+  }
+  ${
+    conf.isUnofficial
+      ? html`
+    ${
+      conf.additionalCopyrightHolders
+        ? html`
       <p class='copyright'>${[conf.additionalCopyrightHolders]}</p>
-    ` : html`
-      ${conf.overrideCopyright ? [conf.overrideCopyright] : html`
+    `
+        : html`
+      ${
+        conf.overrideCopyright
+          ? [conf.overrideCopyright]
+          : html`
         <p class='copyright'>
           This document is licensed under a
           <a class='subfoot' href='https://creativecommons.org/licenses/by/3.0/' rel='license'>Creative Commons
           Attribution 3.0 License</a>.
         </p>
-      `}
-    `}
-  ` : html`
-    ${conf.overrideCopyright ? [conf.overrideCopyright] : html`
+      `
+      }
+    `
+    }
+  `
+      : html`
+    ${
+      conf.overrideCopyright
+        ? [conf.overrideCopyright]
+        : html`
       <p class='copyright'>
         <a href='https://www.w3.org/Consortium/Legal/ipr-notice#Copyright'>Copyright</a> &copy;
-        ${conf.copyrightStart ? `${conf.copyrightStart}-` : ""}${conf.publishYear}
-        ${conf.additionalCopyrightHolders ? html` ${[conf.additionalCopyrightHolders]} &amp;` : ""}
+        ${conf.copyrightStart ? `${conf.copyrightStart}-` : ""}${
+            conf.publishYear
+          }
+        ${
+          conf.additionalCopyrightHolders
+            ? html` ${[conf.additionalCopyrightHolders]} &amp;`
+            : ""
+        }
         <a href='https://www.w3.org/'><abbr title='World Wide Web Consortium'>W3C</abbr></a><sup>&reg;</sup>
         (<a href='https://www.csail.mit.edu/'><abbr title='Massachusetts Institute of Technology'>MIT</abbr></a>,
         <a href='https://www.ercim.eu/'><abbr title='European Research Consortium for Informatics and Mathematics'>ERCIM</abbr></a>,
         <a href='https://www.keio.ac.jp/'>Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>).
-        ${conf.isCCBY ? html`
+        ${
+          conf.isCCBY
+            ? html`
           Some Rights Reserved: this document is dual-licensed,
           <a rel="license" href="https://creativecommons.org/licenses/by/3.0/">CC-BY</a> and
           <a rel="license" href="https://www.w3.org/Consortium/Legal/copyright-documents">W3C Document License</a>.
-        ` : ""}
+        `
+            : ""
+        }
         W3C <a href='https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer'>liability</a>,
         <a href='https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks'>trademark</a> and
-        ${conf.isCCBY ? html`
+        ${
+          conf.isCCBY
+            ? html`
           <a rel="license" href='https://www.w3.org/Consortium/Legal/2013/copyright-documents-dual.html'>document use</a>
-        ` : html`
-          ${conf.isW3CSoftAndDocLicense ? html`
+        `
+            : html`
+          ${
+            conf.isW3CSoftAndDocLicense
+              ? html`
             <a rel="license" href='https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document'>permissive document license</a>
-          ` : html`
+          `
+              : html`
             <a rel="license" href='https://www.w3.org/Consortium/Legal/copyright-documents'>document use</a>
-          `}
-        `}
+          `
+          }
+        `
+        }
         rules apply.
       </p>
-    `}
-  `}
+    `
+    }
+  `
+  }
   <hr title="Separator for header">
 </div>`;
-}
+};

--- a/src/w3c/templates/show-link.js
+++ b/src/w3c/templates/show-link.js
@@ -4,7 +4,8 @@ const html = hyperHTML;
 
 export default link => {
   if (!link.key) {
-    const msg = "Found a link without `key` attribute in the configuration. See dev console.";
+    const msg =
+      "Found a link without `key` attribute in the configuration. See dev console.";
     pub("warn", msg);
     console.warn("warn", msg, link);
     return;
@@ -13,14 +14,18 @@ export default link => {
     <dt class="${link.class ? link.class : null}">${link.key}:</dt>
     ${link.data ? link.data.map(showLinkData) : showLinkData(link)}
   `;
-}
+};
 
 function showLinkData(data) {
   return html`
     <dd class="${data.class ? data.class : null}">
-      ${data.href ? html`
+      ${
+        data.href
+          ? html`
         <a href="${data.href}">${data.value || data.href}</a>
-      ` : ""}
+      `
+          : ""
+      }
     </dd>
-  `
+  `;
 }

--- a/src/w3c/templates/show-logo.js
+++ b/src/w3c/templates/show-logo.js
@@ -11,7 +11,7 @@ export default obj => {
   }
   a.href = obj.url || "";
   a.classList.add("logo");
-  hyperHTML.bind(a) `
+  hyperHTML.bind(a)`
       <img
         id="${obj.id}"
         alt="${obj.alt}"
@@ -22,4 +22,4 @@ export default obj => {
   // hyperHTML attribute values
   a.querySelector("img").src = obj.src;
   return a;
-}
+};

--- a/src/w3c/templates/show-people.js
+++ b/src/w3c/templates/show-people.js
@@ -1,12 +1,12 @@
 export default (conf, name, items = []) => {
   const html = hyperHTML;
   const results = [];
-  for (let i = 0; i < items.length; i++) {
-    results.push(getItem(items[i], i));
+  for (const item of items) {
+    results.push(getItem(item));
   }
   return results;
 
-  function getItem(p, i) {
+  function getItem(p) {
     const personName = [p.name]; // treated as opt-in HTML by hyperHTML
     const editorid = p.w3cid ? parseInt(p.w3cid, 10) : null;
     const dd = html`<dd class='p-author h-card vcard'

--- a/src/w3c/templates/show-people.js
+++ b/src/w3c/templates/show-people.js
@@ -8,10 +8,10 @@ export default (conf, name, items = []) => {
 
   function getItem(p, i) {
     const personName = [p.name]; // treated as opt-in HTML by hyperHTML
-    const editorid = p.w3cid ? parseInt(p.w3cid, 10): null;
+    const editorid = p.w3cid ? parseInt(p.w3cid, 10) : null;
     const dd = html`<dd class='p-author h-card vcard'
       data-editor-id='${editorid}'></dd>`;
-      const span = document.createDocumentFragment();
+    const span = document.createDocumentFragment();
     const contents = [];
     if (p.mailto) {
       contents.push(html`<a class='ed_mailto u-email email p-name'
@@ -24,7 +24,11 @@ export default (conf, name, items = []) => {
     }
     if (p.company) {
       if (p.companyURL) {
-        contents.push(html` (<a class='p-org org h-org h-card' href='${p.companyURL}'>${p.company}</a>)`);
+        contents.push(
+          html` (<a class='p-org org h-org h-card' href='${p.companyURL}'>${
+            p.company
+          }</a>)`
+        );
       } else {
         contents.push(html` (${p.company})`);
       }
@@ -46,7 +50,7 @@ export default (conf, name, items = []) => {
   }
 
   function getExtra(extra) {
-    const span = html`<span class='${extra.class || null}'></span>`
+    const span = html`<span class='${extra.class || null}'></span>`;
     let textContainer = span;
     if (extra.href) {
       textContainer = html`<a href='${extra.href}'></a>`;
@@ -55,4 +59,4 @@ export default (conf, name, items = []) => {
     textContainer.textContent = extra.name;
     return span;
   }
-}
+};

--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -3,62 +3,77 @@ import "deps/hyperhtml";
 export default conf => {
   const html = hyperHTML;
   return html`<h2>${conf.l10n.sotd}</h2>
-${conf.isPreview
-    ? html`
+${
+    conf.isPreview
+      ? html`
   <details class="annoying-warning" open="">
     <summary>This is a preview</summary>
     <p>
       Do not attempt to implement this version of the specification. Do not reference this
       version as authoritative in any way.
-      ${conf.edDraftURI
-        ? html`
-        Instead, see <a href="${conf.edDraftURI}">${conf.edDraftURI}</a> for the Editor's draft.
+      ${
+        conf.edDraftURI
+          ? html`
+        Instead, see <a href="${conf.edDraftURI}">${
+              conf.edDraftURI
+            }</a> for the Editor's draft.
       `
-        : ""}
+          : ""
+      }
     </p>
   </details>
 `
-    : ""}
-${conf.isUnofficial
-    ? html`
+      : ""
+  }
+${
+    conf.isUnofficial
+      ? html`
   <p>
     This document is draft of a potential specification. It has no official standing of
     any kind and does not represent the support or consensus of any standards organisation.
   </p>
   ${[conf.additionalContent]}
 `
-    : html`
-  ${conf.isTagFinding
-    ? [conf.additionalContent]
-    : html`
-    ${conf.isNoTrack
-      ? html`
+      : html`
+  ${
+    conf.isTagFinding
+      ? [conf.additionalContent]
+      : html`
+    ${
+      conf.isNoTrack
+        ? html`
       <p>
-        This document is merely a W3C-internal ${conf.isMO
-          ? "member-confidential"
-          : ""} document. It
+        This document is merely a W3C-internal ${
+          conf.isMO ? "member-confidential" : ""
+        } document. It
         has no official standing of any kind and does not represent consensus of the W3C
         Membership.
       </p>
       ${[conf.additionalContent]}
     `
-      : html`
+        : html`
       <p>
         <em>${[conf.l10n.status_at_publication]}</em>
       </p>
-      ${conf.isSubmission
-        ? html`
-        ${[conf.additionalContent]}
-        ${conf.isMemberSubmission
+      ${
+        conf.isSubmission
           ? html`
+        ${[conf.additionalContent]}
+        ${
+          conf.isMemberSubmission
+            ? html`
           <p>
-            By publishing this document, W3C acknowledges that the <a href="${conf.thisVersion}">Submitting Members</a>
+            By publishing this document, W3C acknowledges that the <a href="${
+              conf.thisVersion
+            }">Submitting Members</a>
             have made a formal Submission request to W3C for discussion. Publication of this document
             by W3C indicates no endorsement of its content by W3C, nor that W3C has, is, or will be
             allocating any resources to the issues addressed by it. This document is not the product
             of a chartered W3C group, but is published as potential input to
             the <a href="https://www.w3.org/Consortium/Process">W3C Process</a>.
-            A <a href="${`https://www.w3.org/Submission/${conf.publishDate.getUTCFullYear()}/${conf.submissionCommentNumber}/Comment/`}">W3C Team Comment</a> has been
+            A <a href="${`https://www.w3.org/Submission/${conf.publishDate.getUTCFullYear()}/${
+              conf.submissionCommentNumber
+            }/Comment/`}">W3C Team Comment</a> has been
             published in conjunction with this Member Submission. Publication of acknowledged Member Submissions
             at the W3C site is one of the benefits of <a href="https://www.w3.org/Consortium/Prospectus/Joining">
             W3C Membership</a>. Please consult the requirements associated with Member Submissions of
@@ -67,59 +82,86 @@ ${conf.isUnofficial
             of acknowledged W3C Member Submissions</a>.
           </p>
         `
-          : html`
-          ${conf.isTeamSubmission
-            ? html`
+            : html`
+          ${
+            conf.isTeamSubmission
+              ? html`
             <p>If you wish to make comments regarding this document, please send them to
-            <a href='${`mailto:${conf.wgPublicList}@w3.org${conf.subjectPrefix
-              ? `?subject=${conf.subjectPrefixEnc}`
-              : [""]}`}'>${conf.wgPublicList}@w3.org</a>
-            (<a href='${`mailto:${conf.wgPublicList}-request@w3.org?subject=subscribe`}'>subscribe</a>,
+            <a href='${`mailto:${conf.wgPublicList}@w3.org${
+              conf.subjectPrefix ? `?subject=${conf.subjectPrefixEnc}` : [""]
+            }`}'>${conf.wgPublicList}@w3.org</a>
+            (<a href='${`mailto:${
+              conf.wgPublicList
+            }-request@w3.org?subject=subscribe`}'>subscribe</a>,
             <a
-              href='${`https://lists.w3.org/Archives/Public/${conf.wgPublicList}/`}'>archives</a>)${conf.subjectPrefix
-                ? html`
-              with <code>${conf.subjectPrefix}</code> at the start of your email's subject`
-                : ""}.</p>
+              href='${`https://lists.w3.org/Archives/Public/${
+                conf.wgPublicList
+              }/`}'>archives</a>)${
+                  conf.subjectPrefix
+                    ? html`
+              with <code>${
+                conf.subjectPrefix
+              }</code> at the start of your email's subject`
+                    : ""
+                }.</p>
             <p>Please consult the complete <a href="https://www.w3.org/TeamSubmission/">list of Team Submissions</a>.</p>
           `
-            : ""}
-        `}
+              : ""
+          }
+        `
+        }
       `
-        : html`
+          : html`
         ${!conf.sotdAfterWGinfo ? [conf.additionalContent] : ""}
-        ${!conf.overrideStatus
-          ? html`
-        <p>
-          This document was published by ${[
-            conf.wgHTML,
-          ]} as ${conf.anOrA} ${conf.longStatus}.
-          ${conf.notYetRec
-            ? "This document is intended to become a W3C Recommendation."
-            : ""}
-          ${conf.wgPublicList
+        ${
+          !conf.overrideStatus
             ? html`
+        <p>
+          This document was published by ${[conf.wgHTML]} as ${conf.anOrA} ${
+                conf.longStatus
+              }.
+          ${
+            conf.notYetRec
+              ? "This document is intended to become a W3C Recommendation."
+              : ""
+          }
+          ${
+            conf.wgPublicList
+              ? html`
             Comments regarding this document are welcome. Please send them to
-            <a href='${`mailto:${conf.wgPublicList}@w3.org${conf.subjectPrefix
-              ? `?subject=${conf.subjectPrefixEnc}`
-              : [""]}`}'>${conf.wgPublicList}@w3.org</a>
-            (<a href='${`mailto:${conf.wgPublicList}-request@w3.org?subject=subscribe`}'>subscribe</a>,
+            <a href='${`mailto:${conf.wgPublicList}@w3.org${
+              conf.subjectPrefix ? `?subject=${conf.subjectPrefixEnc}` : [""]
+            }`}'>${conf.wgPublicList}@w3.org</a>
+            (<a href='${`mailto:${
+              conf.wgPublicList
+            }-request@w3.org?subject=subscribe`}'>subscribe</a>,
             <a
-              href='${`https://lists.w3.org/Archives/Public/${conf.wgPublicList}/`}'>archives</a>)${conf.subjectPrefix
-                ? html`
-              with <code>${conf.subjectPrefix}</code> at the start of your email's subject`
-                : ""}.
+              href='${`https://lists.w3.org/Archives/Public/${
+                conf.wgPublicList
+              }/`}'>archives</a>)${
+                  conf.subjectPrefix
+                    ? html`
+              with <code>${
+                conf.subjectPrefix
+              }</code> at the start of your email's subject`
+                    : ""
+                }.
           `
-            : ""}
-          ${conf.isCR
-            ? `
+              : ""
+          }
+          ${
+            conf.isCR
+              ? `
             W3C publishes a Candidate Recommendation to indicate that the document is believed to be
             stable and to encourage implementation by the developer community. This Candidate
             Recommendation is expected to advance to Proposed Recommendation no earlier than
             ${conf.humanCREnd}.
           `
-            : ""}
-          ${conf.isPER
-            ? html`
+              : ""
+          }
+          ${
+            conf.isPER
+              ? html`
               W3C Advisory Committee Members are invited to
               send formal review comments on this Proposed
               Edited Recommendation to the W3C Team until
@@ -129,44 +171,65 @@ ${conf.isUnofficial
               consulting their list of current
               <a href='https://www.w3.org/2002/09/wbs/myQuestionnaires'>WBS questionnaires</a>.
           `
-            : ""}
-          ${conf.isPR
-            ? html`
+              : ""
+          }
+          ${
+            conf.isPR
+              ? html`
               The W3C Membership and other interested parties are invited to review the document and
               send comments to
-              <a rel='discussion' href='${`mailto:${conf.wgPublicList}@w3.org`}'>${conf.wgPublicList}@w3.org</a>
-              (<a href='${`mailto:${conf.wgPublicList}-request@w3.org?subject=subscribe`}'>subscribe</a>,
-              <a href='${`https://lists.w3.org/Archives/Public/${conf.wgPublicList}/`}'>archives</a>)
-              through ${conf.humanPREnd}. Advisory Committee Representatives should consult their
+              <a rel='discussion' href='${`mailto:${
+                conf.wgPublicList
+              }@w3.org`}'>${conf.wgPublicList}@w3.org</a>
+              (<a href='${`mailto:${
+                conf.wgPublicList
+              }-request@w3.org?subject=subscribe`}'>subscribe</a>,
+              <a href='${`https://lists.w3.org/Archives/Public/${
+                conf.wgPublicList
+              }/`}'>archives</a>)
+              through ${
+                conf.humanPREnd
+              }. Advisory Committee Representatives should consult their
               <a href='https://www.w3.org/2002/09/wbs/myQuestionnaires'>WBS questionnaires</a>.
               Note that substantive technical comments were expected during the Candidate Recommendation
               review period that ended ${conf.humanCREnd}.
           `
-            : ""}
+              : ""
+          }
         </p>
         `
-          : ""}
-        ${conf.implementationReportURI
-          ? html`
+            : ""
+        }
+        ${
+          conf.implementationReportURI
+            ? html`
           <p>
-            Please see the Working Group's  <a href='${conf.implementationReportURI}'>implementation
+            Please see the Working Group's  <a href='${
+              conf.implementationReportURI
+            }'>implementation
             report</a>.
           </p>
         `
-          : ""}
+            : ""
+        }
         ${conf.sotdAfterWGinfo ? [conf.additionalContent] : ""}
-        ${conf.notRec
-          ? html`
+        ${
+          conf.notRec
+            ? html`
           <p>
-            Publication as ${conf.anOrA} ${conf.textStatus} does not imply endorsement by the W3C
+            Publication as ${conf.anOrA} ${
+                conf.textStatus
+              } does not imply endorsement by the W3C
             Membership. This is a draft document and may be updated, replaced or obsoleted by other
             documents at any time. It is inappropriate to cite this document as other than work in
             progress.
           </p>
         `
-          : ""}
-        ${conf.isRec
-          ? html`
+            : ""
+        }
+        ${
+          conf.isRec
+            ? html`
           <p>
             This document has been reviewed by W3C Members, by software developers, and by other W3C
             groups and interested parties, and is endorsed by the Director as a W3C Recommendation.
@@ -176,33 +239,43 @@ ${conf.isUnofficial
             and interoperability of the Web.
           </p>
         `
-          : ""}
+            : ""
+        }
         <p data-deliverer="${conf.isNote ? conf.wgId : null}">
-          ${!conf.isIGNote
-            ? html`
+          ${
+            !conf.isIGNote
+              ? html`
             This document was produced by
             ${conf.multipleWGs ? "groups" : "a group"}
             operating under the
             <a href='https://www.w3.org/Consortium/Patent-Policy/'>W3C Patent Policy</a>.
           `
-            : ""}
-          ${conf.recNotExpected
-            ? "The group does not expect this document to become a W3C Recommendation."
-            : ""}
-          ${!conf.isIGNote
-            ? html`
-            ${conf.multipleWGs
-              ? html`W3C maintains ${[conf.wgPatentHTML]}`
-              : html`
+              : ""
+          }
+          ${
+            conf.recNotExpected
+              ? "The group does not expect this document to become a W3C Recommendation."
+              : ""
+          }
+          ${
+            !conf.isIGNote
+              ? html`
+            ${
+              conf.multipleWGs
+                ? html`W3C maintains ${[conf.wgPatentHTML]}`
+                : html`
               W3C maintains a <a href='${[
                 conf.wgPatentURI,
               ]}' rel='disclosure'>public list of any patent
               disclosures</a>
-            `}
+            `
+            }
             made in connection with the deliverables of
-            ${conf.multipleWGs
-              ? "each group; these pages also include"
-              : "the group; that page also includes"}
+            ${
+              conf.multipleWGs
+                ? "each group; these pages also include"
+                : "the group; that page also includes"
+            }
             instructions for disclosing a patent. An individual who has actual knowledge of a patent
             which the individual believes contains
             <a href='https://www.w3.org/Consortium/Patent-Policy/#def-essential'>Essential
@@ -210,21 +283,28 @@ ${conf.isUnofficial
             <a href='https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure'>section
             6 of the W3C Patent Policy</a>.
           `
-            : ""}
-          ${conf.isIGNote
-            ? html`
+              : ""
+          }
+          ${
+            conf.isIGNote
+              ? html`
             The disclosure obligations of the Participants of this group are described in the
             <a href='${conf.charterDisclosureURI}'>charter</a>.
           `
-            : ""}
+              : ""
+          }
         </p>
         <p>This document is governed by the <a id="w3c_process_revision"
           href="https://www.w3.org/2018/Process-20180201/">1 February 2018 W3C Process Document</a>.
         </p>
         ${conf.addPatentNote ? html`<p>${[conf.addPatentNote]}</p>` : ""}
-      `}
-    `}
-  `}
-`}
+      `
+      }
+    `
+    }
+  `
+  }
+`
+  }
 ${[conf.additionalSections]}`;
 };


### PR DESCRIPTION
This PR introduces `npm run lint` so that any Codacy errors can be prevented before opening a PR.

If you don't like some of the changes, now is the time to do a fine tune.