### PR TITLE
fix(karma.conf.js): grep causes incorrect skips

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -122,7 +122,7 @@ module.exports = function(config) {
     browserNoActivityTimeout: 100000,
 
     client: {
-      args: ["--grep", config.grep],
+      args: ["--grep", config.grep || ""],
     },
   };
   if (process.env.TRAVIS) {


### PR DESCRIPTION
Currently only tests including "null" in their title are running because of this.