### PR TITLE
refactor: use getElementById whenever possible

### DIFF
--- a/tests/spec/core/best-practices-spec.js
+++ b/tests/spec/core/best-practices-spec.js
@@ -21,8 +21,8 @@ describe("Core — Best Practices", () => {
     const doc = await makeRSDoc(ops);
     const pls = doc.body.querySelectorAll("span.practicelab");
     const bps = doc.getElementById("bp-summary");
-    expect(pls.item(0).textContent).toEqual("Best Practice 1: BP1");
-    expect(pls.item(1).textContent).toEqual("Best Practice 2: BP2");
+    expect(pls[0].textContent).toEqual("Best Practice 1: BP1");
+    expect(pls[1].textContent).toEqual("Best Practice 2: BP2");
     expect(bps.querySelector("h2, h3, h4, h5, h6").textContent).toEqual(
       "Best Practices Summary"
     );

--- a/tests/spec/core/best-practices-spec.js
+++ b/tests/spec/core/best-practices-spec.js
@@ -20,7 +20,7 @@ describe("Core — Best Practices", () => {
     };
     const doc = await makeRSDoc(ops);
     const pls = doc.body.querySelectorAll("span.practicelab");
-    const bps = doc.querySelector("#bp-summary");
+    const bps = doc.getElementById("bp-summary");
     expect(pls.item(0).textContent).toEqual("Best Practice 1: BP1");
     expect(pls.item(1).textContent).toEqual("Best Practice 2: BP2");
     expect(bps.querySelector("h2, h3, h4, h5, h6").textContent).toEqual(

--- a/tests/spec/core/data-cite-spec.js
+++ b/tests/spec/core/data-cite-spec.js
@@ -86,10 +86,10 @@ describe("Core — data-cite attribute", () => {
       `,
     };
     const doc = await makeRSDoc(ops);
-    expect(doc.querySelector("#bib-url").closest("section").id).toEqual(
+    expect(doc.getElementById("bib-url").closest("section").id).toEqual(
       "normative-references"
     );
-    expect(doc.querySelector("#bib-fetch").closest("section").id).toEqual(
+    expect(doc.getElementById("bib-fetch").closest("section").id).toEqual(
       "informative-references"
     );
   });
@@ -111,7 +111,7 @@ describe("Core — data-cite attribute", () => {
     expect(a.textContent).toEqual("inline link");
     expect(a.href).toEqual("https://html.spec.whatwg.org/multipage/#test");
     expect(a.hasAttribute("data-cite")).toEqual(false);
-    expect(doc.querySelector("#bib-whatwg-html").closest("section").id).toEqual(
+    expect(doc.getElementById("bib-whatwg-html").closest("section").id).toEqual(
       "normative-references"
     );
     // Definition part
@@ -121,7 +121,7 @@ describe("Core — data-cite attribute", () => {
     expect(dfnA.textContent).toEqual("inline link");
     expect(dfnA.href).toEqual("https://html.spec.whatwg.org/multipage/#test");
     expect(dfnA.hasAttribute("data-cite")).toEqual(false);
-    expect(doc.querySelector("#bib-whatwg-html").closest("section").id).toEqual(
+    expect(doc.getElementById("bib-whatwg-html").closest("section").id).toEqual(
       "normative-references"
     );
   });
@@ -142,7 +142,7 @@ describe("Core — data-cite attribute", () => {
     expect(a.textContent).toEqual("inline link");
     expect(a.href).toEqual("https://html.spec.whatwg.org/multipage/");
     expect(a.hasAttribute("data-cite")).toEqual(false);
-    expect(doc.querySelector("#bib-whatwg-html").closest("section").id).toEqual(
+    expect(doc.getElementById("bib-whatwg-html").closest("section").id).toEqual(
       "normative-references"
     );
   });
@@ -163,7 +163,7 @@ describe("Core — data-cite attribute", () => {
     expect(a.textContent).toEqual("inline link");
     expect(a.href).toEqual("https://dom.spec.whatwg.org/");
     expect(a.hasAttribute("data-cite")).toEqual(false);
-    expect(doc.querySelector("#bib-whatwg-dom").closest("section").id).toEqual(
+    expect(doc.getElementById("bib-whatwg-dom").closest("section").id).toEqual(
       "informative-references"
     );
   });
@@ -190,10 +190,10 @@ describe("Core — data-cite attribute", () => {
     expect(a1.hasAttribute("data-cite")).toEqual(false);
     expect(a2.hasAttribute("data-cite")).toEqual(false);
     expect(
-      doc.querySelector("#bib-no-exist-inf").closest("section").id
+      doc.getElementById("bib-no-exist-inf").closest("section").id
     ).toEqual("informative-references");
     expect(
-      doc.querySelector("#bib-no-exist-norm").closest("section").id
+      doc.getElementById("bib-no-exist-norm").closest("section").id
     ).toEqual("normative-references");
   });
 
@@ -214,7 +214,7 @@ describe("Core — data-cite attribute", () => {
     expect(a.textContent).toEqual("inline link");
     expect(a.href).toEqual("https://html.spec.whatwg.org/multipage/webappapis.html#test");
     expect(a.hasAttribute("data-cite")).toEqual(false);
-    expect(doc.querySelector("#bib-whatwg-html").closest("section").id).toEqual(
+    expect(doc.getElementById("bib-whatwg-html").closest("section").id).toEqual(
       "normative-references"
     );
   });
@@ -239,7 +239,7 @@ describe("Core — data-cite attribute", () => {
       expect(a.href).toEqual("https://html.spec.whatwg.org/multipage/webappapis.html#pass");
       expect(a.hasAttribute("data-cite")).toEqual(false);
       expect(
-        doc.querySelector("#bib-whatwg-html").closest("section").id
+        doc.getElementById("bib-whatwg-html").closest("section").id
       ).toEqual("informative-references");
     });
 
@@ -263,7 +263,7 @@ describe("Core — data-cite attribute", () => {
       expect(a.href).toEqual("https://html.spec.whatwg.org/multipage/#pass");
       expect(a.hasAttribute("data-cite")).toEqual(false);
       expect(
-        doc.querySelector("#bib-whatwg-html").closest("section").id
+        doc.getElementById("bib-whatwg-html").closest("section").id
       ).toEqual("normative-references");
     });
   });

--- a/tests/spec/core/data-include-spec.js
+++ b/tests/spec/core/data-include-spec.js
@@ -26,9 +26,9 @@ describe("Core — Data Include", function() {
       body: makeDefaultBody(),
     };
     const doc = await makeRSDoc(ops, url);
-    var missing = doc.querySelector("#this-should-be-missing");
+    var missing = doc.getElementById("this-should-be-missing");
     expect(missing).toEqual(null);
-    var included = doc.querySelector("#replacement-test");
+    var included = doc.getElementById("replacement-test");
     expect(included).toBeTruthy();
     var heading = doc.querySelector("#replacement-test > h3");
     expect(heading).toBeTruthy();
@@ -41,7 +41,7 @@ describe("Core — Data Include", function() {
       body: makeDefaultBody(),
     };
     const doc = await makeRSDoc(ops, url);
-    var container = doc.querySelector("#empty-include");
+    var container = doc.getElementById("empty-include");
     expect(container).toBeTruthy();
     expect(container.textContent).toBe("");
   });
@@ -52,7 +52,7 @@ describe("Core — Data Include", function() {
       body: makeDefaultBody(),
     };
     const doc = await makeRSDoc(ops, url);
-    var container = doc.querySelector("#no-replace");
+    var container = doc.getElementById("no-replace");
     expect(container).toBeTruthy();
     expect(container.textContent).toBe("<p>pass</p>");
   });

--- a/tests/spec/core/dfn-spec.js
+++ b/tests/spec/core/dfn-spec.js
@@ -62,7 +62,7 @@ describe("Core — Definitions", function() {
     const doc = await makeRSDoc(ops);
     const code = doc.querySelector("#t1 code");
     expect(code.textContent).toEqual("Test");
-    const t2 = doc.querySelector("#t2");
+    const t2 = doc.getElementById("t2");
     expect(t2.querySelector("code")).toEqual(null);
     expect(t2.querySelector("a").textContent).toEqual("not wrapped in code");
     expect(t2.querySelector("a").getAttribute("href")).toEqual("#idl-def-test");

--- a/tests/spec/core/figures-spec.js
+++ b/tests/spec/core/figures-spec.js
@@ -70,8 +70,8 @@ describe("Core - Figures", function() {
     expect(tofHeader).toBeTruthy();
     expect(tofHeader.textContent).toEqual("1. Table of Figures");
     expect(tofItems.length).toEqual(2);
-    expect(figLinks.item(0).textContent).toEqual("Figure 1 test 1");
-    expect(figLinks.item(1).textContent).toEqual("Figure 2 test 2");
+    expect(figLinks[0].textContent).toEqual("Figure 1 test 1");
+    expect(figLinks[1].textContent).toEqual("Figure 2 test 2");
   });
 
   describe("normalize images", () => {

--- a/tests/spec/core/highlight-spec.js
+++ b/tests/spec/core/highlight-spec.js
@@ -75,7 +75,7 @@ describe("Core — Highlight", () => {
         </section>`,
     };
     const doc = await makeRSDoc(ops);
-    var pre = doc.querySelector("#test");
+    var pre = doc.getElementById("test");
     expect(pre.querySelectorAll("span[class^=hljs-]").length).toBe(0);
   });
 });

--- a/tests/spec/core/highlight-vars-spec.js
+++ b/tests/spec/core/highlight-vars-spec.js
@@ -51,13 +51,13 @@ describe("Core - highlightVars", () => {
     const ops = makeStandardOps({ highlightVars: true }, testBody);
     const doc = await makeRSDoc(ops);
 
-    doc.querySelector("#section1-foo").click();
+    doc.getElementById("section1-foo").click();
     const highlightedSec1 = doc.querySelectorAll("#section1 var.respec-hl");
     let highlightedSec2 = doc.querySelectorAll("#section2 var.respec-hl");
     expect(highlightedSec1.length).toBe(2);
     expect(highlightedSec2.length).toBe(0);
 
-    doc.querySelector("#section2-foo").click();
+    doc.getElementById("section2-foo").click();
     highlightedSec2 = doc.querySelectorAll("#section2 var.respec-hl");
     expect(highlightedSec2.length).toBe(2);
   });

--- a/tests/spec/core/idl-index-spec.js
+++ b/tests/spec/core/idl-index-spec.js
@@ -32,7 +32,7 @@ interface Bar {
       body,
     };
     const doc = await makeRSDoc(ops);
-    var idlIndex = doc.querySelector("#idl-index");
+    var idlIndex = doc.getElementById("idl-index");
     expect(idlIndex).not.toBe(null);
     expect(idlIndex.querySelector("pre").textContent).toEqual(expectedIDL);
     var header = doc.querySelector("#idl-index > h2");
@@ -68,7 +68,7 @@ dictionary PromptResponseObject {
       body,
     };
     const doc = await makeRSDoc(ops);
-    const idlIndex = doc.querySelector("#idl-index");
+    const idlIndex = doc.getElementById("idl-index");
     expect(idlIndex).not.toBe(null);
     expect(idlIndex.querySelector("pre").textContent).toEqual(expectedIDL);
   });
@@ -86,7 +86,7 @@ dictionary PromptResponseObject {
       body,
     };
     const doc = await makeRSDoc(ops);
-    var idlIndex = doc.querySelector("#idl-index");
+    var idlIndex = doc.getElementById("idl-index");
     expect(idlIndex).not.toBe(null);
     expect(idlIndex.querySelector("pre")).toEqual(null);
     var header = doc.querySelector("#idl-index > h2");

--- a/tests/spec/core/link-to-dfn-spec.js
+++ b/tests/spec/core/link-to-dfn-spec.js
@@ -13,7 +13,7 @@ describe("Core — Link to definitions", function() {
       body: makeDefaultBody() + bodyText,
     };
     const doc = await makeRSDoc(ops);
-    const a = doc.body.querySelector("#testAnchor");
+    const a = doc.body.getElementById("testAnchor");
     expect(a).toBeTruthy();
     expect(a.hash).toEqual("#dfn-test");
     const decodedHash = decodeURIComponent(a.hash);

--- a/tests/spec/core/link-to-dfn-spec.js
+++ b/tests/spec/core/link-to-dfn-spec.js
@@ -13,7 +13,7 @@ describe("Core — Link to definitions", function() {
       body: makeDefaultBody() + bodyText,
     };
     const doc = await makeRSDoc(ops);
-    const a = doc.body.getElementById("testAnchor");
+    const a = doc.getElementById("testAnchor");
     expect(a).toBeTruthy();
     expect(a.hash).toEqual("#dfn-test");
     const decodedHash = decodeURIComponent(a.hash);

--- a/tests/spec/core/list-sorter-spec.js
+++ b/tests/spec/core/list-sorter-spec.js
@@ -89,13 +89,13 @@ describe("Core — list-sorter", () => {
     });
     
     it("defaults to sorting in ascending order", () => {
-      const list = doc.querySelector("#ol-default");
+      const list = doc.getElementById("ol-default");
       expect(list.firstElementChild.textContent).toEqual("a");
       expect(list.lastElementChild.textContent).toEqual("Z");
     });
     
     it("sorts nested lists", ()=>{
-      const list = doc.querySelector("#nested-list");
+      const list = doc.getElementById("nested-list");
       const first = list.querySelector("li:first-of-type");
       const last = list.querySelector("li:last-of-type");
       expect(first.textContent).toEqual("z");
@@ -128,13 +128,13 @@ describe("Core — list-sorter", () => {
     });
 
     it("defaults to sorting in definition lists in ascending order", () => {
-      const list = doc.querySelector("#default-sort");
+      const list = doc.getElementById("default-sort");
       expect(list.firstElementChild.textContent).toEqual("1");
       expect(list.lastElementChild.textContent).toEqual("9");
     });
 
     it("leaves unmarked lists alone", () => {
-      const list = doc.querySelector("#dont-sort");
+      const list = doc.getElementById("dont-sort");
       expect(list.firstElementChild.textContent).toEqual("dont");
       expect(list.lastElementChild.textContent).toEqual("me");
     });

--- a/tests/spec/core/markdown-spec.js
+++ b/tests/spec/core/markdown-spec.js
@@ -61,7 +61,7 @@ describe("Core - Markdown", function() {
     ops.config.format = "markdown";
     const doc = await makeRSDoc(ops);
     expect(doc.querySelector("code")).toBeFalsy();
-    expect(doc.getElementById("foo").textContent).toBe("Foo");
+    expect(doc.getElementById("foo").textContent).toBe("1. Foo");
     var listItems = doc.querySelectorAll("section > ul:not([class=toc]) > li");
     expect(listItems.length).toEqual(2);
     expect(listItems[0].textContent).toEqual("list item 1");

--- a/tests/spec/core/markdown-spec.js
+++ b/tests/spec/core/markdown-spec.js
@@ -217,8 +217,8 @@ describe("Core - Markdown", function() {
       const doc = await makeRSDoc(ops);
       var anchors = doc.querySelectorAll("#testElem a");
       expect(anchors.length).toEqual(2);
-      expect(anchors.item(0).href).toEqual("http://no-links-foo.com/");
-      expect(anchors.item(1).href).toEqual("http://no-links-bar.com/");
+      expect(anchors[0].href).toEqual("http://no-links-foo.com/");
+      expect(anchors[1].href).toEqual("http://no-links-bar.com/");
     });
 
     it("replaces HTMLAnchors when present", async () => {

--- a/tests/spec/core/markdown-spec.js
+++ b/tests/spec/core/markdown-spec.js
@@ -61,7 +61,7 @@ describe("Core - Markdown", function() {
     ops.config.format = "markdown";
     const doc = await makeRSDoc(ops);
     expect(doc.querySelector("code")).toBeFalsy();
-    expect(doc.getElementById("foo").textContent === "Foo");
+    expect(doc.getElementById("foo").textContent).toBe("Foo");
     var listItems = doc.querySelectorAll("section > ul:not([class=toc]) > li");
     expect(listItems.length).toEqual(2);
     expect(listItems[0].textContent).toEqual("list item 1");

--- a/tests/spec/core/markdown-spec.js
+++ b/tests/spec/core/markdown-spec.js
@@ -61,7 +61,7 @@ describe("Core - Markdown", function() {
     ops.config.format = "markdown";
     const doc = await makeRSDoc(ops);
     expect(doc.querySelector("code")).toBeFalsy();
-    expect(doc.querySelector("#foo").textContent === "Foo");
+    expect(doc.getElementById("foo").textContent === "Foo");
     var listItems = doc.querySelectorAll("section > ul:not([class=toc]) > li");
     expect(listItems.length).toEqual(2);
     expect(listItems[0].textContent).toEqual("list item 1");
@@ -300,7 +300,7 @@ describe("Core - Markdown", function() {
       expect(anotherH3.localName).toEqual("h3");
       expect(anotherH3.textContent.trim()).toEqual("1.2 another h3");
       expect(doc.querySelector("#markdown1 code")).toBeTruthy();
-      const dontChange = doc.querySelector("#dontTouch").textContent.trim();
+      const dontChange = doc.getElementById("dontTouch").textContent.trim();
       expect(dontChange).toEqual("## this should not change");
     });
   });

--- a/tests/spec/core/pre-process-spec.html
+++ b/tests/spec/core/pre-process-spec.html
@@ -5,26 +5,26 @@
 function noOp() {}
 
 function preSyncFunc() {
-  document.querySelector("#pre-sync").innerHTML = "pass";
+  document.getElementById("pre-sync").innerHTML = "pass";
 }
 
 function preAsyncFunc() {
   return new Promise(resolve => {
     setTimeout(() => {
-      document.querySelector("#pre-async").innerHTML = "pass";
+      document.getElementById("pre-async").innerHTML = "pass";
       resolve();
     }, 4);
   });
 }
 
 function postSyncFunc() {
-  document.querySelector("#post-sync").innerHTML = "pass";
+  document.getElementById("post-sync").innerHTML = "pass";
 }
 
 function postAsyncFunc() {
   return new Promise(resolve => {
     setTimeout(() => {
-      document.querySelector("#post-async").innerHTML = "pass";
+      document.getElementById("post-async").innerHTML = "pass";
       resolve();
     }, 4);
   });
@@ -33,7 +33,7 @@ function postAsyncFunc() {
 function afterEnd() {
   return new Promise(resolve => {
     setTimeout(() => {
-      document.querySelector("#afterend").innerHTML = "pass";
+      document.getElementById("afterend").innerHTML = "pass";
       resolve();
     }, 4);
   });

--- a/tests/spec/core/pre-process-spec.js
+++ b/tests/spec/core/pre-process-spec.js
@@ -10,13 +10,13 @@ describe("Core - preProcess, postProcess, afterEnd", () => {
   });
 
   it("runs the preProcess and postProces arrays", () => {
-    expect(doc.querySelector("#pre-sync").innerHTML).toEqual("pass");
-    expect(doc.querySelector("#pre-async").innerHTML).toEqual("pass");
-    expect(doc.querySelector("#post-sync").innerHTML).toEqual("pass");
-    expect(doc.querySelector("#post-async").innerHTML).toEqual("pass");
+    expect(doc.getElementById("pre-sync").innerHTML).toEqual("pass");
+    expect(doc.getElementById("pre-async").innerHTML).toEqual("pass");
+    expect(doc.getElementById("post-sync").innerHTML).toEqual("pass");
+    expect(doc.getElementById("post-async").innerHTML).toEqual("pass");
   });
 
   it("runs afterEnd method", () => {
-    expect(doc.querySelector("#afterend").innerHTML).toEqual("pass");
+    expect(doc.getElementById("afterend").innerHTML).toEqual("pass");
   });
 });

--- a/tests/spec/core/ui-spec.js
+++ b/tests/spec/core/ui-spec.js
@@ -6,7 +6,7 @@ describe("Core - UI", () => {
   it("shows and hides the UI", async () => {
     const doc = await makeRSDoc(makeStandardOps());
     const ui = doc.defaultView.respecUI;
-    const pillContainer = doc.querySelector("#respec-ui");
+    const pillContainer = doc.getElementById("respec-ui");
     ui.show();
     // showing it doesn't change it from showing
     expect(pillContainer.hidden).toBe(false);
@@ -18,9 +18,9 @@ describe("Core - UI", () => {
 
   it("hides the UI when document is clicked", async () => {
     const doc = await makeRSDoc(makeStandardOps(), null, "display: block");
-    const menu = doc.querySelector("#respec-menu");
+    const menu = doc.getElementById("respec-menu");
     expect(window.getComputedStyle(menu).display).toEqual("none");
-    doc.querySelector("#respec-pill").click();
+    doc.getElementById("respec-pill").click();
     // spin the event loop
     await new Promise(resolve => {
       setTimeout(() => {

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -615,7 +615,7 @@ enum EnumBasic {
     expect(target.querySelector(".idlEnumID a").getAttribute("href")).toEqual(
       "#dom-enumbasic"
     );
-    expect(target.querySelector("#idl-def-enumbasic")).toBeTruthy();
+    expect(target.getElementById("idl-def-enumbasic")).toBeTruthy();
   });
 
   it("should handle enumeration value definitions", () => {
@@ -641,7 +641,7 @@ enum EnumBasic {
     const links = doc.querySelector(
       `#enum-empty-sec a[href="#dom-emptyenum-the-empty-string"]`
     );
-    const dfn = doc.querySelector("#dom-emptyenum-the-empty-string");
+    const dfn = doc.getElementById("dom-emptyenum-the-empty-string");
     const smokeDfn = doc.querySelector(
       `#enum-empty-sec a[href="#dom-emptyenum-not-empty"]`
     );

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -615,7 +615,7 @@ enum EnumBasic {
     expect(target.querySelector(".idlEnumID a").getAttribute("href")).toEqual(
       "#dom-enumbasic"
     );
-    expect(target.getElementById("idl-def-enumbasic")).toBeTruthy();
+    expect(doc.getElementById("idl-def-enumbasic")).toBeTruthy();
   });
 
   it("should handle enumeration value definitions", () => {

--- a/tests/spec/core/xref-spec.js
+++ b/tests/spec/core/xref-spec.js
@@ -176,7 +176,7 @@ describe("Core — xref", () => {
     const ops = makeStandardOps(config, body);
     const doc = await makeRSDoc(ops);
 
-    const localDfn1 = doc.querySelector("#local-dfn-1");
+    const localDfn1 = doc.getElementById("local-dfn-1");
     expect(localDfn1.querySelector("a")).toBeFalsy();
     expect(localDfn1.querySelector("dfn").id).toEqual("dfn-local-one");
     const localDfn2 = doc.querySelector("#local-dfn-2 a");

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -558,8 +558,8 @@ describe("W3C — Headers", function() {
       const doc = await makeRSDoc(ops);
       var licenses = doc.querySelectorAll("div.head a[rel=license]");
       expect(licenses.length).toEqual(1);
-      expect(licenses.item(0).tagName).toEqual("A");
-      expect(licenses.item(0).href).toEqual(
+      expect(licenses[0].tagName).toEqual("A");
+      expect(licenses[0].href).toEqual(
         "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"
       );
     });

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -1094,11 +1094,11 @@ describe("W3C — Headers", function() {
 
       expect(sotd.classList.contains("introductory")).toBe(true);
 
-      const p1 = sotd.getElementById("p1");
+      const p1 = doc.getElementById("p1");
       expect(p1).toBeTruthy();
       expect(p1.textContent.trim()).toEqual("CUSTOM PARAGRAPH 1");
 
-      const p2 = sotd.getElementById("p2");
+      const p2 = doc.getElementById("p2");
       expect(p2).toBeTruthy();
       expect(p2.textContent.trim()).toEqual("CUSTOM PARAGRAPH 2");
 
@@ -1108,18 +1108,18 @@ describe("W3C — Headers", function() {
       const textNode = commentNode.nextSibling;
       expect(textNode.nodeType).toEqual(Node.TEXT_NODE);
 
-      const ol = sotd.getElementById("ol");
+      const ol = doc.getElementById("ol");
       expect(ol).toBeTruthy();
       expect(ol.querySelectorAll("li").length).toEqual(2);
 
-      const firstSection = sotd.getElementById("first-sub-section");
+      const firstSection = doc.getElementById("first-sub-section");
       expect(sotd.lastElementChild).not.toEqual(firstSection);
 
-      const lastSection = sotd.getElementById("last-sub-section");
+      const lastSection = doc.getElementById("last-sub-section");
       expect(sotd.lastElementChild).toEqual(lastSection);
 
       // p3 is sadwiched in between the sections
-      const p3 = sotd.getElementById("p3");
+      const p3 = doc.getElementById("p3");
       expect(p3).toBeTruthy();
       expect(p3.previousElementSibling).toEqual(firstSection);
       expect(p3.nextElementSibling).toEqual(lastSection);

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -1094,11 +1094,11 @@ describe("W3C — Headers", function() {
 
       expect(sotd.classList.contains("introductory")).toBe(true);
 
-      const p1 = sotd.querySelector("#p1");
+      const p1 = sotd.getElementById("p1");
       expect(p1).toBeTruthy();
       expect(p1.textContent.trim()).toEqual("CUSTOM PARAGRAPH 1");
 
-      const p2 = sotd.querySelector("#p2");
+      const p2 = sotd.getElementById("p2");
       expect(p2).toBeTruthy();
       expect(p2.textContent.trim()).toEqual("CUSTOM PARAGRAPH 2");
 
@@ -1108,18 +1108,18 @@ describe("W3C — Headers", function() {
       const textNode = commentNode.nextSibling;
       expect(textNode.nodeType).toEqual(Node.TEXT_NODE);
 
-      const ol = sotd.querySelector("#ol");
+      const ol = sotd.getElementById("ol");
       expect(ol).toBeTruthy();
       expect(ol.querySelectorAll("li").length).toEqual(2);
 
-      const firstSection = sotd.querySelector("#first-sub-section");
+      const firstSection = sotd.getElementById("first-sub-section");
       expect(sotd.lastElementChild).not.toEqual(firstSection);
 
-      const lastSection = sotd.querySelector("#last-sub-section");
+      const lastSection = sotd.getElementById("last-sub-section");
       expect(sotd.lastElementChild).toEqual(lastSection);
 
       // p3 is sadwiched in between the sections
-      const p3 = sotd.querySelector("#p3");
+      const p3 = sotd.getElementById("p3");
       expect(p3).toBeTruthy();
       expect(p3.previousElementSibling).toEqual(firstSection);
       expect(p3.nextElementSibling).toEqual(lastSection);

--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -172,7 +172,7 @@ async function isRespec() {
     await new Promise(resolve => {
       setTimeout(resolve, 2000);
     });
-    return Boolean(document.querySelector("#respec-ui"));
+    return Boolean(document.getElementById("respec-ui"));
   } catch (err) {
     throw err.stack;
   }


### PR DESCRIPTION
Maybe someone batch-converted jQuery into querySelector?