### PR TITLE
 refactor(core/jquery-enhanced): migrate $linkTargets to vanilla js

### DIFF
--- a/src/core/jquery-enhanced.js
+++ b/src/core/jquery-enhanced.js
@@ -1,5 +1,5 @@
 import { pub } from "core/pubsubhub";
-import { addId, getTextNodes, getDfnTitles } from "core/utils";
+import { addId, getTextNodes, getDfnTitles, getLinkTargets } from "core/utils";
 import "deps/jquery";
 
 export const name = "core/jquery-enhanced";
@@ -64,30 +64,7 @@ window.$.fn.getDfnTitles = function(args) {
 //  * {for: "int3", title: "member"}
 //  * {for: "", title: "int3.member"}
 window.$.fn.linkTargets = function() {
-  var linkForElem = this[0].closest("[data-link-for]");
-  var linkFor = linkForElem ? linkForElem.dataset.linkFor.toLowerCase() : "";
-  var titles = getDfnTitles(this[0]);
-  var result = [];
-  for (const title of titles) {
-    result.push({
-      for: linkFor,
-      title,
-    });
-    const split = title.split(".");
-    if (split.length === 2) {
-      // If there are multiple '.'s, this won't match an
-      // Interface/member pair anyway.
-      result.push({
-        for: split[0],
-        title: split[1],
-      });
-    }
-    result.push({
-      for: "",
-      title,
-    });
-  }
-  return result;
+  return getLinkTargets(this[0]);
 };
 
 // Applied to an element, sets an ID for it (and returns it), using a specific prefix

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -4,6 +4,7 @@
 import { linkInlineCitations } from "core/data-cite";
 import { pub } from "core/pubsubhub";
 import { lang as defaultLang } from "./l10n";
+import { getLinkTargets } from "core/utils";
 import { run as addExternalReferences } from "core/xref";
 export const name = "core/link-to-dfn";
 const l10n = {
@@ -76,7 +77,7 @@ export async function run(conf, doc, cb) {
     const $ant = $(this);
     const ant = $ant[0];
     if (ant.classList.contains("externalDFN")) return;
-    const linkTargets = $ant.linkTargets();
+    const linkTargets = getLinkTargets(ant);
     const foundDfn = linkTargets.some(target => {
       if (titles[target.title] && titles[target.title][target.for]) {
         const $dfn = titles[target.title][target.for];

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -686,3 +686,35 @@ export function getDfnTitles(elem, args) {
     .reduce((collector, item) => collector.add(item), new Set());
   return [...titles];
 }
+
+/**
+ * For an element (usually <a>), returns an array of targets that
+ * element might refer to, of the form
+ * @typedef {for: 'interfacename', title: 'membername'} LinkTarget
+ *
+ * For an element like:
+ *  <p link-for="Int1"><a for="Int2">Int3.member</a></p>
+ * we'll return:
+ *  * {for: "int2", title: "int3.member"}
+ *  * {for: "int3", title: "member"}
+ *  * {for: "", title: "int3.member"}
+ * @param {Element} elem
+ * @returns {LinkTarget[]}
+ */
+export function getLinkTargets(elem) {
+  const linkForElem = elem.closest("[data-link-for]");
+  const linkFor = linkForElem ? linkForElem.dataset.linkFor.toLowerCase() : "";
+  const titles = getDfnTitles(elem);
+
+  return titles.reduce((result, title) => {
+    result.push({ for: linkFor, title });
+    const split = title.split(".");
+    if (split.length === 2) {
+      // If there are multiple '.'s, this won't match an
+      // Interface/member pair anyway.
+      result.push({ for: split[0], title: split[1] });
+    }
+    result.push({ for: "", title });
+    return result;
+  }, []);
+}


### PR DESCRIPTION
As a part of https://github.com/w3c/respec/issues/1699