### PR TITLE
fix(core/webidl): only set pre id when needed

### DIFF
--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -759,7 +759,7 @@ export function run(conf) {
     }
     linkDefinitions(parse, conf.definitionMap, "", idlElement);
     const newElement = makeMarkup(parse);
-    if (idlElement.id) newElement.setAttribute("id", idlElement.id);
+    if (idlElement.id) newElement.id = idlElement.id;
     newElement
       .querySelectorAll(
         ".idlAttribute,.idlCallback,.idlConst,.idlDictionary,.idlEnum,.idlException,.idlField,.idlInterface,.idlMember,.idlMethod,.idlMaplike,.idlIterable,.idlTypedef"

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -759,7 +759,7 @@ export function run(conf) {
     }
     linkDefinitions(parse, conf.definitionMap, "", idlElement);
     const newElement = makeMarkup(parse);
-    newElement.setAttribute("id", idlElement.id);
+    if (idlElement.id) newElement.setAttribute("id", idlElement.id);
     newElement
       .querySelectorAll(
         ".idlAttribute,.idlCallback,.idlConst,.idlDictionary,.idlEnum,.idlException,.idlField,.idlInterface,.idlMember,.idlMethod,.idlMaplike,.idlIterable,.idlTypedef"


### PR DESCRIPTION
We were accidentally setting the id of the `<pre>` element to `""`, which is causing the HTML validator to say the document is invalid (empty id values are invalid, apparently... which makes sense, I guess). 