### PR TITLE
fix(lint/local-refs-exist): handle unicode characters in IDs

### DIFF
--- a/src/core/linter-rules/local-refs-exist.js
+++ b/src/core/linter-rules/local-refs-exist.js
@@ -41,7 +41,7 @@ function linterFunction(conf, doc) {
 export const rule = new LinterRule(name, linterFunction);
 
 function isBrokenHyperlink(elem) {
-  const { href, ownerDocument: doc } = elem;
-  const { hash } = new URL(href);
+  const { ownerDocument: doc } = elem;
+  const hash = elem.getAttribute("href");
   return !doc.getElementById(hash.substring(1));
 }

--- a/src/core/linter-rules/local-refs-exist.js
+++ b/src/core/linter-rules/local-refs-exist.js
@@ -41,7 +41,6 @@ function linterFunction(conf, doc) {
 export const rule = new LinterRule(name, linterFunction);
 
 function isBrokenHyperlink(elem) {
-  const { ownerDocument: doc } = elem;
-  const hash = elem.getAttribute("href");
-  return !doc.getElementById(hash.substring(1));
+  const id = elem.getAttribute("href").substring(1);
+  return !elem.ownerDocument.getElementById(id);
 }

--- a/tests/spec/core/linter-rules/local-refs-exist-spec.js
+++ b/tests/spec/core/linter-rules/local-refs-exist-spec.js
@@ -49,4 +49,13 @@ describe("Core Linter Rule - 'local-refs-exist'", () => {
     const results = await rule.lint(config, doc);
     expect(results.length).toEqual(0);
   });
+
+  it("handles unicode characters in ID", async () => {
+    doc.body.innerHTML = `
+      <section id="přehled">PASS</section>
+      <a href="#přehled">PASS</a>
+    `;
+    const results = await rule.lint(config, doc);
+    expect(results.length).toEqual(0);
+  });
 });


### PR DESCRIPTION
Fixes #1808.
The URL was escaped earlier, breaking the `ID` to search for.
