### PR TITLE
fix(core/biblio): avoid dup refs when case differs

### DIFF
--- a/src/core/biblio.js
+++ b/src/core/biblio.js
@@ -19,8 +19,11 @@ const bibrefsURL = new URL("https://specref.herokuapp.com/bibrefs?refs=");
 // Normative references take precedence over informative ones,
 // so any duplicates ones are removed from the informative set.
 function normalizeReferences(conf) {
+  const normalizedNormativeRefs = new Set(
+    [...conf.normativeReferences].map(key => key.toLowerCase())
+  );
   Array.from(conf.informativeReferences)
-    .filter(key => conf.normativeReferences.has(key))
+    .filter(key => normalizedNormativeRefs.has(key.toLowerCase()))
     .forEach(redundantKey => conf.informativeReferences.delete(redundantKey));
 }
 

--- a/tests/spec/core/biblio-spec.js
+++ b/tests/spec/core/biblio-spec.js
@@ -33,6 +33,7 @@ describe("W3C — Bibliographic References", () => {
   };
   const body = `
     <section id='sotd'>
+      <p>[[!DOM]] [[dom]] [[fetch]] [[!FeTcH]] [[FETCh]] [[fetCH]]
       <p>foo [[!TestRef1]] [[TestRef2]] [[!TestRef3]]</p>
     </section>
     <section id='sample'>
@@ -145,6 +146,17 @@ describe("W3C — Bibliographic References", () => {
     );
     expect(first).toMatch("[a]");
     expect(last).toMatch("[Zzz]");
+  });
+
+  it("makes sure that normative references win irrespective of case", () => {
+    expect(doc.querySelectorAll("#bib-dom").length).toBe(1);
+    const domRef = doc.querySelector("#bib-dom");
+    expect(domRef.closest("section").id).toBe("normative-references");
+
+    expect(doc.querySelectorAll("#bib-fetch").length).toBe(1);
+    const fetchRef = doc.querySelector("#bib-fetch");
+    expect(fetchRef.closest("section").id).toBe("normative-references");
+    expect(fetchRef.textContent.trim()).toBe("[FeTcH]");
   });
 
   it("shows error if reference doesn't exist", async () => {


### PR DESCRIPTION
This fixes a bug whereby if a non-normative reference had a different case from a normative one, ReSpec ended up adding the reference to both the normative and informative sections. This was making document invalid, because we were ending up with double definitions and two unique ids in the document.    