### PR TITLE
feat(core/inlines): make variables context aware (Part 1)

### DIFF
--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -78,7 +78,7 @@ export function run(conf) {
               document.createTextNode(`{{{${ref.replace(/^\\/, "")}}}}`)
             );
           } else {
-            df.appendChild(idlStringToHtml(ref));
+            df.appendChild(idlStringToHtml(ref, txt));
           }
         } else if (matched.startsWith("[[")) {
           // BIBREF


### PR DESCRIPTION
Adds contextual awareness and data typing to variables. 

A variable in an algorithm can now have an explicit type: 

```HTM
<li><var data-type="Foo">kitty</var> is a {{{ Cat }}}.</li>
```

So:

```HTML
  <li><var data-type="Word">something</var></li>
  <li>Call the {{{ kitty.say( something ) }}}</var> method.</li>
```

So:
  1.  `say()` is now linked.  
  1. `something` is automatically data-typed! 

This means that we have the infrastructure in place to do type checking. 

Related: https://www.youtube.com/watch?v=HujoDX_JZmY