### PR TITLE
feat(core/data-type): auto assign IDL types to dfns

### DIFF
--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -512,6 +512,8 @@ function linkDefinitions(parse, definitionMap, parent, idlElem) {
         case "enum":
           name = defn.name;
           for (const v of defn.values) {
+            // TODO: fix when this lands https://github.com/w3c/webidl2.js/pull/232
+            // when 232 lands, the type will be correct, so this check is not needed.
             if (v.type === "string") {
               v.dfn = findDfn(
                 defn,
@@ -753,6 +755,8 @@ function findDfn(defn, parent, name, definitionMap, type, idlElem) {
       name.replace(/[()]/g, "").replace(/\s/g, "-");
     dfn.id = id;
   }
+  // TODO: fix when https://github.com/w3c/webidl2.js/pull/232
+  // Fix will just be: dfn.dataset.idl = defn.type;
   dfn.dataset.idl = type === "enum-value" ? type : defn.type;
   dfn.dataset.title = dfn.textContent;
   dfn.dataset.dfnFor = parent;

--- a/tests/spec/core/data-type-spec.js
+++ b/tests/spec/core/data-type-spec.js
@@ -1,0 +1,134 @@
+describe("Core — data-type attribute", () => {
+  afterAll(flushIframes);
+  it("assigns the return type as the type for a method", async () => {
+    const body = `
+      <section>
+        <h2><dfn>PaymentRequest</dfn></h2>
+        <pre class="idl">
+          interface PaymentRequest {
+            Promise&lt;void&gt; returnsPromise();
+            void returnsVoid(DOMString someArg);
+          };
+        </pre>
+        <div data-dfn-for="PaymentRequest">
+          <dfn>returnsPromise()</dfn> method
+          <dfn>returnsVoid()</dfn> method
+        </div>
+      </section>
+    `;
+    const ops = makeStandardOps(null, body);
+    const doc = await makeRSDoc(ops);
+
+    // Promise&lt;void&gt; returnsPromise();
+    const returnsPromise = doc.getElementById(
+      "dom-paymentrequest-returnspromise"
+    );
+    expect(returnsPromise.dataset.type).toBe("Promise");
+
+    // void returnsVoid(DOMString someArg);
+    const returnsVoid = doc.getElementById("dom-paymentrequest-returnsvoid");
+    expect(returnsVoid.dataset.type).toBe("void");
+  });
+
+  it("adds data-type to an interface's attribute definitions", async () => {
+    const body = `
+      <section>
+        <h2><dfn>PaymentRequest</dfn></h2>
+        <pre class="idl">
+          interface PaymentRequest {
+            readonly attribute unsigned short entryType;
+            readonly attribute ( unsigned short or unsigned long long or DOMString ) entryType2;
+            readonly attribute (DOMString or ArrayBuffer)? result;
+            readonly attribute DOMString id;
+            readonly attribute PaymentAddress? shippingAddress;
+            readonly attribute FrozenArray&lt;DOMString> addressLine;
+            attribute EventHandler onmerchantvalidation;
+          };
+        </pre>
+        <div data-dfn-for="PaymentRequest">
+          <dfn>entryType</dfn> attribute
+          <dfn>entryType2</dfn> attribute
+          <dfn>result</dfn> attribute
+          <dfn>id</dfn> attribute
+          <dfn>shippingAddress</dfn> attribute
+          <dfn>addressLine</dfn> attribute
+          <dfn>onmerchantvalidation</dfn> attribute
+        </div>
+      </section>
+    `;
+    const ops = makeStandardOps(null, body);
+    const doc = await makeRSDoc(ops);
+
+    // readonly attribute (DOMString or ArrayBuffer)? result;
+    const entryType2 = doc.getElementById("dom-paymentrequest-entrytype2");
+    expect(entryType2.dataset.type).toBe(
+      "unsigned short|unsigned long long|DOMString"
+    );
+
+    // readonly attribute (DOMString or ArrayBuffer)? result;
+    const entryType = doc.getElementById("dom-paymentrequest-entrytype");
+    expect(entryType.dataset.type).toBe("unsigned short");
+
+    // readonly attribute (DOMString or ArrayBuffer)? result;
+    const result = doc.getElementById("dom-paymentrequest-result");
+    expect(result.dataset.type).toBe("DOMString|ArrayBuffer");
+
+    // readonly attribute DOMString id;
+    const id = doc.getElementById("dom-paymentrequest-id");
+    expect(id.dataset.type).toBe("DOMString");
+
+    // readonly attribute PaymentAddress? shippingAddress;
+    const shippingAddress = doc.getElementById(
+      "dom-paymentrequest-shippingaddress"
+    );
+    expect(shippingAddress.dataset.type).toBe("PaymentAddress");
+
+    // readonly attribute FrozenArray<DOMString> addressLine;
+    const addressLine = doc.getElementById("dom-paymentrequest-addressline");
+    expect(addressLine.dataset.type).toBe("FrozenArray");
+
+    // attribute EventHandler onmerchantvalidation;
+    const onmerchantvalidation = doc.getElementById(
+      "dom-paymentrequest-onmerchantvalidation"
+    );
+    expect(onmerchantvalidation.dataset.type).toBe("EventHandler");
+  });
+
+  it("adds data-type to an dictionary's member definitions", async () => {
+    const body = `
+      <section>
+        <h2><dfn>PaymentMethodData</dfn> dictionary</h2>
+        <pre class="idl">
+          dictionary PaymentMethodData {
+            required DOMString supportedMethods;
+            object? data = null;
+            sequence&lt;PaymentItem&gt; displayItems;
+          };
+        </pre>
+        <div data-dfn-for="PaymentMethodData">
+          <dfn>supportedMethods</dfn> member
+          <dfn>data </dfn> member
+          <dfn>displayItems</dfn> member
+        </div>
+      </section>
+    `;
+    const ops = makeStandardOps(null, body);
+    const doc = await makeRSDoc(ops);
+
+    // required DOMString supportedMethods;
+    const supportedMethods = doc.getElementById(
+      "dom-paymentmethoddata-supportedmethods"
+    );
+    expect(supportedMethods.dataset.type).toBe("DOMString");
+
+    // object data;
+    const dataMember = doc.getElementById("dom-paymentmethoddata-data");
+    expect(dataMember.dataset.type).toBe("object");
+
+    // sequence<PaymentItem> displayItems;
+    const displayItems = doc.getElementById(
+      "dom-paymentmethoddata-displayitems"
+    );
+    expect(displayItems.dataset.type).toBe("sequence");
+  });
+});

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -147,7 +147,7 @@ describe("Core - WebIDL", () => {
         expect(elem.id).toEqual(`dom-parenthesistest-${id}`);
         expect(elem.dataset.dfnType).toEqual("dfn");
         expect(elem.dataset.dfnFor).toEqual("parenthesistest");
-        expect(elem.dataset.idl).toEqual("");
+        expect(elem.dataset.idl).toEqual("operation");
         // corresponding link
         const aElem = section.querySelector(
           `pre a[href="#dom-parenthesistest-${id}"]`
@@ -990,5 +990,40 @@ callback CallBack = Z? (X x, optional Y y, /*trivia*/ optional Z z);
       "#coded-things a[href='#dom-codedthings-barbar']"
     );
     expect(linkToBarBarAttr.length).toBe(2);
+  });
+  it("sets the IDL type for each type of IDL token", () => {
+    const section = doc.getElementById("idl-dfn-types");
+
+    //interface InterfaceType
+    const interfaceType = section.querySelector("#dom-interfacetype");
+    expect(interfaceType.dataset.idl).toBe("interface");
+
+    // attribute attributeType;
+    const attributeType = section.querySelector(
+      "#dom-interfacetype-attributetype"
+    );
+    expect(attributeType.dataset.idl).toBe("attribute");
+
+    // operationType();
+    const operationType = section.querySelector(
+      "#dom-interfacetype-operationtype"
+    );
+    expect(operationType.dataset.idl).toBe("operation");
+
+    // DictionaryType
+    const dictionaryType = section.querySelector("#dom-dictionarytype");
+    expect(dictionaryType.dataset.idl).toBe("dictionary");
+
+    // fieldType member (field)
+    const fieldType = section.querySelector("#dom-dictionarytype-fieldtype");
+    expect(fieldType.dataset.idl).toBe("field");
+
+    // enum EnumType
+    const enumType = section.querySelector("#dom-enumtype");
+    expect(enumType.dataset.idl).toBe("enum");
+
+    // "enumValueType"
+    const enumValueType = section.querySelector("#dom-enumtype-enumvaluetype");
+    expect(enumValueType.dataset.idl).toBe("enum-value");
   });
 });

--- a/tests/spec/core/webidl.html
+++ b/tests/spec/core/webidl.html
@@ -788,5 +788,29 @@
           <li><a>doTheFoo</a>
         </ol>
       </section>
+      <section id="idl-dfn-types">
+        <h2>It gives definitions the right idl type</h2>
+        <pre class="idl">
+          interface InterfaceType {
+            readonly attribute DOMString attributeType;
+            void operationType();
+          };
+          dictionary DictionaryType {
+            DOMString fieldType;
+          };
+          enum EnumType {
+            "enumValueType"
+          };
+        </pre>
+        <p>
+          <dfn>InterfaceType</dfn>
+          <dfn data-dfn-for="InterfaceType">attributeType</dfn>
+          <dfn data-dfn-for="InterfaceType">operationType</dfn>
+          <dfn>DictionaryType</dfn>
+          <dfn data-dfn-for="DictionaryType">fieldType</dfn>
+          <dfn>EnumType</dfn>
+          <dfn data-dfn-for="EnumType">enumValueType</dfn>
+        </p>
+      </section>
   </body>
 </html>

--- a/tests/testFiles.json
+++ b/tests/testFiles.json
@@ -6,6 +6,7 @@
   "spec/core/data-cite-spec.js",
   "spec/core/data-include-spec.js",
   "spec/core/data-tests-spec.js",
+  "spec/core/data-type-spec.js",
   "spec/core/dfn-spec.js",
   "spec/core/examples-spec.js",
   "spec/core/figures-spec.js",


### PR DESCRIPTION
Given:

```HTML
<pre class=idl>
interface Foo {
   attribute Bar bar;
   DOMString toString();
};
</pre>

<dfn>Foo</dfn>
<dfn data-dfn-for="Foo">bar</dfn>
<dfn data-dfn-for="Foo">toString()</dfn>
```

The `<dfn data-dfn-for="Foo">bar</dfn>` gains:

 * `data-type`: `Bar` 
 * `data-idl`: `attribute` 

The `<dfn data-dfn-for="Foo">bar</dfn>` gains:

 * `data-type`: `DOMString`, which is the return type.
 * `data-idl`: `operation` 

Having these bits of information allow us to do interesting things - like type checking, chained linking, cute pop-ups showing the type, etc.   