### PR TITLE
Add support for Living Standard & Living Document

### DIFF
--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -108,6 +108,8 @@ const W3CDate = new Intl.DateTimeFormat(["en-AU"], {
 });
 
 const status2maturity = {
+  LS: "WD",
+  LD: "WD",
   FPWD: "WD",
   LC: "WD",
   FPLC: "WD",
@@ -137,6 +139,8 @@ const status2text = {
   "Team-SUBM": "Team Submission",
   MO: "Member-Only Document",
   ED: "Editor's Draft",
+  LS: "Living Standard",
+  LD: "Living Document",
   FPWD: "First Public Working Draft",
   WD: "Working Draft",
   "FPWD-NOTE": "Working Group Note",


### PR DESCRIPTION
This change adds support for specStatus: LS (Living Standard) and specStatus: LD (Living Document). That provides parity with the status levels of the same names available when using Bikeshed (see the related Bikeshed docs at https://tabatkins.github.io/bikeshed/#metadata-status).