### PR TITLE
Allow use of additionalCopyrightHolders for CG/BG documents

### DIFF
--- a/src/w3c/templates/cgbg-headers.js
+++ b/src/w3c/templates/cgbg-headers.js
@@ -133,7 +133,14 @@ export default conf => {
   }
   <p class='copyright'>
     <a href='https://www.w3.org/Consortium/Legal/ipr-notice#Copyright'>Copyright</a> &copy;
-    ${conf.copyrightStart ? `${conf.copyrightStart}-` : ""}${conf.publishYear}
+    ${conf.copyrightStart ? `${conf.copyrightStart}-` : ""}${
+        conf.publishYear
+      }
+    ${
+      conf.additionalCopyrightHolders
+        ? html` ${[conf.additionalCopyrightHolders]} &amp;`
+        : ""
+    }
     the Contributors to the ${conf.title} Specification, published by the
     <a href='${conf.wgURI}'>${conf.wg}</a> under the
     ${

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -641,6 +641,46 @@ describe("W3C — Headers", () => {
       const doc = await makeRSDoc(ops);
       expect($(".head .copyright", doc).text()).toMatch(/XXX\s+&\s+W3C/);
     });
+    it("takes additionalCopyrightHolders into account for CG drafts", async () => {
+      const ops = makeStandardOps();
+      const newProps = {
+        specStatus: "CG-DRAFT",
+        additionalCopyrightHolders: "XXX",
+      };
+      Object.assign(ops.config, newProps);
+      const doc = await makeRSDoc(ops);
+      expect($(".head .copyright", doc).text()).toMatch(/XXX\s+&\s+the\s+Contributors\s+to\s+the/);
+    });
+    it("takes additionalCopyrightHolders into account for CG final reports", async () => {
+      const ops = makeStandardOps();
+      const newProps = {
+        specStatus: "CG-FINAL",
+        additionalCopyrightHolders: "XXX",
+      };
+      Object.assign(ops.config, newProps);
+      const doc = await makeRSDoc(ops);
+      expect($(".head .copyright", doc).text()).toMatch(/XXX\s+&\s+the\s+Contributors\s+to\s+the/);
+    });
+    it("takes additionalCopyrightHolders into account for BG drafts", async () => {
+      const ops = makeStandardOps();
+      const newProps = {
+        specStatus: "BG-DRAFT",
+        additionalCopyrightHolders: "XXX",
+      };
+      Object.assign(ops.config, newProps);
+      const doc = await makeRSDoc(ops);
+      expect($(".head .copyright", doc).text()).toMatch(/XXX\s+&\s+the\s+Contributors\s+to\s+the/);
+    });
+    it("takes additionalCopyrightHolders into account for BG final reports", async () => {
+      const ops = makeStandardOps();
+      const newProps = {
+        specStatus: "BG-FINAL",
+        additionalCopyrightHolders: "XXX",
+      };
+      Object.assign(ops.config, newProps);
+      const doc = await makeRSDoc(ops);
+      expect($(".head .copyright", doc).text()).toMatch(/XXX\s+&\s+the\s+Contributors\s+to\s+the/);
+    });
     it("takes additionalCopyrightHolders into account when spec is unofficial", async () => {
       const ops = makeStandardOps();
       const newProps = {


### PR DESCRIPTION
The option was ignored for CG/BG documents. However, it may be useful in some cases where a CG is a joint work with another organization (The Web Media API CG is an example of a joint group with CTA).