### PR TITLE
fix(package): puppeteer 1.10.0 causes hightlighter to pause

### DIFF
--- a/examples/basic.built.html
+++ b/examples/basic.built.html
@@ -26,17 +26,25 @@
         This is required.
       </p>
     </section>
-    <section data-dfn-for="Foo" data-link-for="Foo">
+    <section data-dfn-for="Foo">
       <h2><dfn>Foo</dfn> interface</h2>
       <pre class="idl">
+      [Constructor]
       interface Foo {
         attribute Bar bar;
         void doTheFoo();
       };
       </pre>
-     <p>The <a>Foo</a> interface is nice. Lets you do stuff.</p>
-     <p>The <dfn>bar</dfn> attribute, returns 🍺.</p>
-     <p>The <dfn>doTheFoo()</dfn> method, returns nothing.</p>
+      <p>The <a>Foo</a> interface is nice. Lets you do stuff.</p>
+      <p>The <dfn>bar</dfn> attribute, returns 🍺.</p>
+      <p>The <dfn>doTheFoo()</dfn> method, returns nothing.</p>
+      <pre class="js example" title="Usage example">
+        const foo = new Foo();
+        if (foo.bar === "my bar") {
+          foo.doTheBar();
+        }
+      </pre>
     </section>
   </body>
 </html>
+

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset='utf-8'>
     <title>Replace me with a real title</title>
-    <script src='../js/deps/require.js' data-main='../js/profile-w3c-common' 
+    <script src='../js/deps/require.js' data-main='../js/profile-w3c-common'
       async class='remove'></script>
     <script class='remove'>
       var respecConfig = {
@@ -30,6 +30,7 @@
     <section data-dfn-for="Foo">
       <h2><dfn>Foo</dfn> interface</h2>
       <pre class="idl">
+      [Constructor]
       interface Foo {
         attribute Bar bar;
         void doTheFoo();
@@ -38,6 +39,12 @@
       <p>The <a>Foo</a> interface is nice. Lets you do stuff.</p>
       <p>The <dfn>bar</dfn> attribute, returns 🍺.</p>
       <p>The <dfn>doTheFoo()</dfn> method, returns nothing.</p>
+      <pre class="js example" title="Usage example">
+        const foo = new Foo();
+        if (foo.bar === "my bar") {
+          foo.doTheBar();
+        }
+      </pre>
     </section>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -269,7 +269,7 @@
     },
     "array-equal": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM="
     },
     "array-slice": {
@@ -937,7 +937,7 @@
     },
     "boom": {
       "version": "0.4.2",
-      "resolved": "http://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
       "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
       "requires": {
         "hoek": "0.9.x"
@@ -1205,7 +1205,7 @@
       "dependencies": {
         "commander": {
           "version": "2.2.0",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.2.0.tgz",
           "integrity": "sha1-F1rUuTF/P/YV8gHB5XIk9Vo+kd8=",
           "optional": true
         }
@@ -1408,7 +1408,7 @@
     },
     "combined-stream": {
       "version": "0.0.7",
-      "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
       "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
       "optional": true,
       "requires": {
@@ -1522,7 +1522,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -1638,7 +1638,7 @@
     },
     "cryptiles": {
       "version": "0.2.2",
-      "resolved": "http://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
       "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
       "optional": true,
       "requires": {
@@ -1673,7 +1673,7 @@
     },
     "ctype": {
       "version": "0.5.3",
-      "resolved": "http://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
       "integrity": "sha1-gsGMJGH3QRTvFsE1IkrQuRRMoS8=",
       "optional": true
     },
@@ -1911,7 +1911,7 @@
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
-          "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
           "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
         },
         "entities": {
@@ -2086,7 +2086,7 @@
     },
     "entities": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
       "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY="
     },
     "epipebomb": {
@@ -2809,7 +2809,7 @@
     },
     "form-data": {
       "version": "0.1.4",
-      "resolved": "http://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
       "integrity": "sha1-kavXiKupcCsaq/qLwBAxoqyeOxI=",
       "optional": true,
       "requires": {
@@ -2820,7 +2820,7 @@
       "dependencies": {
         "async": {
           "version": "0.9.2",
-          "resolved": "http://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
           "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
           "optional": true
         },
@@ -3464,7 +3464,7 @@
       "dependencies": {
         "async": {
           "version": "0.8.0",
-          "resolved": "http://registry.npmjs.org/async/-/async-0.8.0.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.8.0.tgz",
           "integrity": "sha1-7mXsdymML/FFa8RBigUtDwZDURI="
         },
         "minimist": {
@@ -3494,7 +3494,7 @@
       "dependencies": {
         "async": {
           "version": "0.8.0",
-          "resolved": "http://registry.npmjs.org/async/-/async-0.8.0.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.8.0.tgz",
           "integrity": "sha1-7mXsdymML/FFa8RBigUtDwZDURI="
         },
         "glob": {
@@ -3517,7 +3517,7 @@
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "resolved": "http://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
               "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
               "optional": true
             },
@@ -3578,7 +3578,7 @@
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "resolved": "http://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
               "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
             },
             "source-map": {
@@ -3936,7 +3936,7 @@
     },
     "hawk": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
       "integrity": "sha1-h81JH5tG5OKurKM1QWdmiF0tHtk=",
       "optional": true,
       "requires": {
@@ -3967,7 +3967,7 @@
     },
     "hoek": {
       "version": "0.9.1",
-      "resolved": "http://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
       "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU="
     },
     "home-or-tmp": {
@@ -3995,7 +3995,7 @@
     },
     "htmlparser2": {
       "version": "3.8.3",
-      "resolved": "http://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
       "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
       "requires": {
         "domelementtype": "1",
@@ -5411,7 +5411,7 @@
       "dependencies": {
         "debug": {
           "version": "0.7.4",
-          "resolved": "http://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
           "integrity": "sha1-BuHqgILCyxTjmAbiLi9vdX+Srzk="
         }
       }
@@ -5431,7 +5431,7 @@
     },
     "less": {
       "version": "1.7.5",
-      "resolved": "http://registry.npmjs.org/less/-/less-1.7.5.tgz",
+      "resolved": "https://registry.npmjs.org/less/-/less-1.7.5.tgz",
       "integrity": "sha1-TyIM9yiKJ+rKc5325ICKLUwNV1Y=",
       "requires": {
         "clean-css": "2.2.x",
@@ -5444,7 +5444,7 @@
       "dependencies": {
         "graceful-fs": {
           "version": "3.0.11",
-          "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
           "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
           "optional": true,
           "requires": {
@@ -6490,7 +6490,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
     },
     "pinkie": {
@@ -6652,9 +6652,9 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "puppeteer": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.10.0.tgz",
-      "integrity": "sha512-3i28X/ucX8t3eL4TZA60FLMOQNKqudFSOGDHr0cT7T4dE027CrcS885aAqjdxNybhMPliM5yImNsKJ6SQrPzhw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-1.9.0.tgz",
+      "integrity": "sha512-GH4PmhJf9wBRAPvtJkEJLAvdNNOofZortmBZSj8cGWYni98GUFqsf66blOEfJbo5B8l0KG5HR2d/W2MejnUrzg==",
       "requires": {
         "debug": "^3.1.0",
         "extract-zip": "^1.6.6",
@@ -6950,7 +6950,7 @@
       "dependencies": {
         "mime-types": {
           "version": "1.0.2",
-          "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
           "integrity": "sha1-mVrhOSq4r/y/yyZB3QVOlDwNXc4=",
           "optional": true
         },
@@ -7396,7 +7396,7 @@
     },
     "sntp": {
       "version": "0.2.4",
-      "resolved": "http://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
       "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
       "optional": true,
       "requires": {
@@ -8169,7 +8169,7 @@
       "dependencies": {
         "readable-stream": {
           "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
             "core-util-is": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "loading-indicator": "^2.0.0",
     "marked": "^0.5.1",
     "prompt": "^1.0.0",
-    "puppeteer": "^1.10.0",
+    "puppeteer": "1.9.0",
     "snyk": "^1.108.2"
   },
   "prettier": {

--- a/tests/headless.js
+++ b/tests/headless.js
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 /*eslint-env node*/
 "use strict";
+const port = 5000;
 const testURLs = [
-  `file:///${__dirname}/../examples/basic.built.html`,
-  `file:///${__dirname}/../examples/basic.html`,
+  `http://localhost:${port}/examples/basic.built.html`,
+  `http://localhost:${port}/examples/basic.html`,
 ];
 const colors = require("colors");
 const { exec } = require("child_process");
@@ -19,6 +20,9 @@ colors.setTheme({
   verbose: "cyan",
   warn: "yellow",
 });
+
+const handler = require("serve-handler");
+const http = require("http");
 
 function toExecutable(cmd) {
   return {
@@ -41,6 +45,11 @@ function toExecutable(cmd) {
 }
 
 async function runRespec2html() {
+  const server = http.createServer((request, response) => {
+    return handler(request, response);
+  });
+  server.listen(port, () => {});
+
   const errors = new Set();
   // Incrementally spawn processes and add them to process counter.
   const executables = testURLs.map(url => {


### PR DESCRIPTION
Something in puppeteer 1.10.0 has caused a regression whereby the highlight worker doesn't respond. 

https://github.com/w3c/spec-generator/pull/135 

Although reproducible, it's unfortunately a heisenbug: If I enable puppeteers/chrome's devtools, the problem doesn't occur.  

Best solution appears to be to just roll back to 1.9.0. 