### PR TITLE
feat(core/issues-notes): allow token only github Authorization

### DIFF
--- a/src/core/issues-notes.js
+++ b/src/core/issues-notes.js
@@ -208,6 +208,9 @@ async function fetchAndStoreGithubIssues(conf) {
         const credentials = btoa(`${githubUser}:${githubToken}`);
         const Authorization = `Basic ${credentials}`;
         Object.assign(headers, { Authorization });
+      } else if (githubToken) {
+        const Authorization = `token ${githubToken}`;
+        Object.assign(headers, { Authorization });
       }
       const request = new Request(issueURL, {
         mode: "cors",


### PR DESCRIPTION
Sending the username is redundant, if one can just send the token: 
https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/