### PR TITLE
refactor: use dot notation when possible

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,9 @@
     "ecmaVersion": 2018
   },
   "rules": {
+    "dot-notation": "error",
     "indent": 0,
+    "linebreak-style": 0,
     "quotes": 0,
     "semi": ["error", "always"],
     "no-console": 0,

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "copydeps": "node ./tools/copydeps.js",
     "handlebars": "handlebars",
     "karma": "karma start --single-run",
-    "lint": "npx eslint src/**/*.js tests/**/*.js",
+    "lint": "npx eslint src/**/*.js tests/**/*.js tools/*.js",
     "release": "node ./tools/release.js",
     "server": "npm start",
     "snyk": "snyk",

--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -433,10 +433,10 @@ export function run(conf) {
       );
     });
   if (conf.bugTracker) {
-    if (conf.bugTracker["new"] && conf.bugTracker.open) {
+    if (conf.bugTracker.new && conf.bugTracker.open) {
       conf.bugTrackerHTML =
         "<a href='" +
-        conf.bugTracker["new"] +
+        conf.bugTracker.new +
         "'>" +
         conf.l10n.file_a_bug +
         "</a> " +
@@ -450,9 +450,9 @@ export function run(conf) {
     } else if (conf.bugTracker.open) {
       conf.bugTrackerHTML =
         "<a href='" + conf.bugTracker.open + "'>open bugs</a>";
-    } else if (conf.bugTracker["new"]) {
+    } else if (conf.bugTracker.new) {
       conf.bugTrackerHTML =
-        "<a href='" + conf.bugTracker["new"] + "'>file a bug</a>";
+        "<a href='" + conf.bugTracker.new + "'>file a bug</a>";
     }
   }
   if (conf.copyrightStart && conf.copyrightStart == conf.publishYear)

--- a/tools/release.js
+++ b/tools/release.js
@@ -163,7 +163,7 @@ const Prompts = {
             ? commitHints.exec(line)[0].toLowerCase()
             : "";
           let result = line;
-          let icon = match && iconMap.has(match) ? iconMap.get(match) : "❓";
+          const icon = match && iconMap.has(match) ? iconMap.get(match) : "❓";
           // colorize
           if (match) {
             result = result.replace(match.toLowerCase(), colors[match](match));
@@ -280,7 +280,7 @@ function toExecPromise(cmd, { timeout, showOutput }) {
       reject(new Error(`Command took too long: ${cmd}`));
       proc.kill("SIGTERM");
     }, timeout);
-    const proc = exec(cmd, function(err, stdout, stderr) {
+    const proc = exec(cmd, (err, stdout) => {
       clearTimeout(id);
       if (err) {
         return reject(err);
@@ -371,8 +371,9 @@ const run = async () => {
       case "up-to-date":
         break;
       case "needs to push":
-        var err = `Found unpushed commits on "${MAIN_BRANCH}" branch! Can't proceed.`;
-        throw new Error(err);
+        throw new Error(
+          `Found unpushed commits on "${MAIN_BRANCH}" branch! Can't proceed.`
+        );
       default:
         throw new Error(`Your branch is not up-to-date. It ${branchState}.`);
     }
@@ -391,9 +392,7 @@ const run = async () => {
     indicators.get("build-merge-tag").show();
     await npm("run build:components");
     await Builder.build({ name: "w3c-common" });
-    console.log(
-      colors.info(" Making sure the generated version is ok... 🕵🏻")
-    );
+    console.log(colors.info(" Making sure the generated version is ok... 🕵🏻"));
     await node(
       `./tools/respec2html.js -e --timeout 30 --src file:///${__dirname}/../examples/basic.built.html --out /dev/null`,
       { showOutput: true }


### PR DESCRIPTION
Resolves https://github.com/w3c/respec/pull/1887#discussion_r232881824

`"linebreak-style": 0` is because we are using git which automatically cares line endings. I turned it off in #1777 but it has been revived by prettier and exploded Windows environments 🤣