### PR TITLE
refactor: Remove unused CSS selectors

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,9 +13,9 @@
     "ecmaVersion": 2018
   },
   "rules": {
+    "prettier/prettier": ["error", { "endOfLine": "auto" }],
     "dot-notation": "error",
     "indent": 0,
-    "linebreak-style": 0,
     "quotes": 0,
     "semi": ["error", "always"],
     "no-console": 0,

--- a/js/core/css/webidl.css
+++ b/js/core/css/webidl.css
@@ -23,19 +23,6 @@ pre.idl::before {
   line-height: 28px;  
 }
 
-.idlType {
-  color: #ff4500;
-  font-weight: bold;
-  text-decoration: none;
-}
-
-
-/*.idlModule*/
-
-
-/*.idlModuleID*/
-
-
 /*.idlInterface*/
 
 .idlInterfaceID,
@@ -135,22 +122,6 @@ a.idlEnumItem {
 }
 
 
-/*.idlIterable*/
-
-.idlIterableKeyType,
-.idlIterableValueType {
-  color: #005a9c;
-}
-
-
-/*.idlMaplike*/
-
-.idlMaplikeKeyType,
-.idlMaplikeValueType {
-  color: #005a9c;
-}
-
-
 /*.idlConst*/
 
 .idlConstType {
@@ -167,188 +138,13 @@ a.idlEnumItem {
   text-decoration: none;
 }
 
-
-/*.idlException*/
-
-.idlExceptionID {
-  font-weight: bold;
-  color: #c00;
-}
-
 .idlTypedefID,
 .idlTypedefType {
   color: #005a9c;
 }
 
-.idlRaises,
-.idlRaises a.idlType,
-.idlRaises a.idlType code,
-.excName a,
-.excName a code {
-  color: #c00;
-  font-weight: normal;
-}
-
-.excName a {
-  font-family: monospace;
-}
-
-.idlRaises a.idlType,
-.excName a.idlType {
-  border-bottom: 1px dotted #c00;
-}
-
-.excGetSetTrue,
-.excGetSetFalse,
-.prmNullTrue,
-.prmNullFalse,
-.prmOptTrue,
-.prmOptFalse {
-  width: 45px;
-  text-align: center;
-}
-
-.excGetSetTrue,
-.prmNullTrue,
-.prmOptTrue {
-  color: #0c0;
-}
-
-.excGetSetFalse,
-.prmNullFalse,
-.prmOptFalse {
-  color: #c00;
-}
-
-.idlImplements a, .idlIncludes a {
+.idlIncludes a {
   font-weight: bold;
-}
-
-dl.attributes,
-dl.methods,
-dl.constants,
-dl.constructors,
-dl.fields,
-dl.dictionary-members {
-  margin-left: 2em;
-}
-
-.attributes dt,
-.methods dt,
-.constants dt,
-.constructors dt,
-.fields dt,
-.dictionary-members dt {
-  font-weight: normal;
-}
-
-.attributes dt code,
-.methods dt code,
-.constants dt code,
-.constructors dt code,
-.fields dt code,
-.dictionary-members dt code {
-  font-weight: bold;
-  color: #000;
-  font-family: monospace;
-}
-
-.attributes dt code,
-.fields dt code,
-.dictionary-members dt code {
-  background: #ffffd2;
-}
-
-.attributes dt .idlAttrType code,
-.fields dt .idlFieldType code,
-.dictionary-members dt .idlMemberType code {
-  color: #005a9c;
-  background: transparent;
-  font-family: inherit;
-  font-weight: normal;
-  font-style: italic;
-}
-
-.methods dt code {
-  background: #d9e6f8;
-}
-
-.constants dt code {
-  background: #ddffd2;
-}
-
-.constructors dt code {
-  background: #cfc;
-}
-
-.attributes dd,
-.methods dd,
-.constants dd,
-.constructors dd,
-.fields dd,
-.dictionary-members dd {
-  margin-bottom: 1em;
-}
-
-table.parameters,
-table.exceptions {
-  border-spacing: 0;
-  border-collapse: collapse;
-  margin: 0.5em 0;
-  width: 100%;
-}
-
-table.parameters {
-  border-bottom: 1px solid #90b8de;
-}
-
-table.exceptions {
-  border-bottom: 1px solid #deb890;
-}
-
-.parameters th,
-.exceptions th {
-  color: inherit;
-  padding: 3px 5px;
-  text-align: left;
-  font-weight: normal;
-}
-
-.parameters th {
-  color: #fff;
-  background: #005a9c;
-}
-
-.exceptions th {
-  background: #deb890;
-}
-
-.parameters td,
-.exceptions td {
-  padding: 3px 10px;
-  border-top: 1px solid #ddd;
-  vertical-align: top;
-}
-
-.parameters tr:first-child td,
-.exceptions tr:first-child td {
-  border-top: none;
-}
-
-.parameters td.prmName,
-.exceptions td.excName,
-.exceptions td.excCodeName {
-  width: 100px;
-}
-
-.parameters td.prmType {
-  width: 120px;
-}
-
-table.exceptions table {
-  border-spacing: 0;
-  border-collapse: collapse;
-  width: 100%;
 }
 
 .respec-button-copy-paste:focus {

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -135,9 +135,7 @@ export async function run(conf, doc, cb) {
     });
     if (!foundDfn && linkTargets.length !== 0) {
       // ignore WebIDL
-      if (
-        !$ant.parents("pre.idl, span.idlMemberType, span.idlTypedefType").length
-      ) {
+      if (!ant.closest("pre.idl, span.idlMemberType, span.idlTypedefType")) {
         if (ant.dataset.cite === "") {
           badLinks.push(ant);
         } else {

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -136,9 +136,7 @@ export async function run(conf, doc, cb) {
     if (!foundDfn && linkTargets.length !== 0) {
       // ignore WebIDL
       if (
-        !$ant.parents(
-          "pre.idl, span.idlMemberType, span.idlTypedefType"
-        ).length
+        !$ant.parents("pre.idl, span.idlMemberType, span.idlTypedefType").length
       ) {
         if (ant.dataset.cite === "") {
           badLinks.push(ant);

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -137,7 +137,7 @@ export async function run(conf, doc, cb) {
       // ignore WebIDL
       if (
         !$ant.parents(
-          ".idl:not(.extAttr), dl.methods, dl.attributes, dl.constants, dl.constructors, dl.fields, dl.dictionary-members, span.idlMemberType, span.idlTypedefType, div.idlImplementsDesc"
+          "pre.idl, span.idlMemberType, span.idlTypedefType"
         ).length
       ) {
         if (ant.dataset.cite === "") {


### PR DESCRIPTION
Those are mostly for ancient non-contiguous IDL.