### PR TITLE
refactor: prefer import by relative path

### DIFF
--- a/src/core/base-runner.js
+++ b/src/core/base-runner.js
@@ -1,12 +1,12 @@
 // Module core/base-runner
 // The module in charge of running the whole processing pipeline.
-import "core/include-config";
-import "core/override-configuration";
-import "core/respec-ready";
-import { removeReSpec } from "core/utils";
-import { done as postProcessDone } from "core/post-process";
-import { done as preProcessDone } from "core/pre-process";
-import { pub } from "core/pubsubhub";
+import "./include-config";
+import "./override-configuration";
+import "./respec-ready";
+import { removeReSpec } from "./utils";
+import { done as postProcessDone } from "./post-process";
+import { done as preProcessDone } from "./pre-process";
+import { pub } from "./pubsubhub";
 
 export const name = "core/base-runner";
 const canMeasure = performance.mark && performance.measure;

--- a/src/core/best-practices.js
+++ b/src/core/best-practices.js
@@ -2,9 +2,9 @@
 // Handles the marking up of best practices, and can generate a summary of all of them.
 // The summary is generated if there is a section in the document with ID bp-summary.
 // Best practices are marked up with span.practicelab.
-import css from "deps/text!core/css/bp.css";
-import { pub } from "core/pubsubhub";
-import "deps/hyperhtml";
+import css from "../deps/text!core/css/bp.css";
+import { pub } from "./pubsubhub";
+import "../deps/hyperhtml";
 
 export const name = "core/best-practices";
 

--- a/src/core/biblio-db.js
+++ b/src/core/biblio-db.js
@@ -8,7 +8,7 @@
  *
  */
 /*globals IDBKeyRange, DOMException, console */
-import { pub } from "core/pubsubhub";
+import { pub } from "./pubsubhub";
 export const name = "core/biblio-db";
 
 const ALLOWED_TYPES = new Set(["alias", "reference"]);

--- a/src/core/biblio.js
+++ b/src/core/biblio.js
@@ -5,12 +5,12 @@
 
 /*jshint jquery: true*/
 /*globals console*/
-import { biblioDB } from "core/biblio-db";
-import { createResourceHint } from "core/utils";
-import { pub } from "core/pubsubhub";
+import { biblioDB } from "./biblio-db";
+import { createResourceHint } from "./utils";
+import { pub } from "./pubsubhub";
 
 // for backward compatibity
-export { wireReference, stringifyReference } from "core/render-biblio";
+export { wireReference, stringifyReference } from "./render-biblio";
 
 export const name = "core/biblio";
 

--- a/src/core/caniuse.js
+++ b/src/core/caniuse.js
@@ -3,11 +3,11 @@
  * Adds a caniuse support table for a "feature" #1238
  * Usage options: https://github.com/w3c/respec/wiki/caniuse
  */
-import { semverCompare } from "core/utils";
-import { pub, sub } from "core/pubsubhub";
-import "deps/hyperhtml";
-import { createResourceHint, fetchAndCache } from "core/utils";
-import caniuseCss from "deps/text!core/css/caniuse.css";
+import { semverCompare } from "./utils";
+import { pub, sub } from "./pubsubhub";
+import "../deps/hyperhtml";
+import { createResourceHint, fetchAndCache } from "./utils";
+import caniuseCss from "../deps/text!core/css/caniuse.css";
 
 export const name = "core/caniuse";
 

--- a/src/core/contrib.js
+++ b/src/core/contrib.js
@@ -4,9 +4,9 @@
 // #gh-commenters: people having contributed comments to issues.
 // #gh-contributors: people whose PR have been merged.
 // Spec editors get filtered out automatically.
-import { fetchIndex } from "core/github";
-import { pub } from "core/pubsubhub";
-import { joinAnd, flatten } from "core/utils";
+import { fetchIndex } from "./github";
+import { pub } from "./pubsubhub";
+import { joinAnd, flatten } from "./utils";
 export const name = "core/contrib";
 
 function prop(prop) {

--- a/src/core/data-cite.js
+++ b/src/core/data-cite.js
@@ -13,8 +13,8 @@
  * Usage:
  * https://github.com/w3c/respec/wiki/data--cite
  */
-import { resolveRef, updateFromNetwork } from "core/biblio";
-import { showInlineError, refTypeFromContext } from "core/utils";
+import { resolveRef, updateFromNetwork } from "./biblio";
+import { showInlineError, refTypeFromContext } from "./utils";
 export const name = "core/data-cite";
 
 function requestLookup(conf) {

--- a/src/core/data-include.js
+++ b/src/core/data-include.js
@@ -9,8 +9,8 @@
 //  This module only really works when you are in an HTTP context, and will most likely
 //  fail if you are editing your documents on your local drive. That is due to security
 //  restrictions in the browser.
-import { pub } from "core/pubsubhub";
-import { runTransforms } from "core/utils";
+import { pub } from "./pubsubhub";
+import { runTransforms } from "./utils";
 
 export const name = "core/data-include";
 

--- a/src/core/data-tests.js
+++ b/src/core/data-tests.js
@@ -8,8 +8,8 @@
  *
  * Docs: https://github.com/w3c/respec/wiki/data-tests
  */
-import { pub } from "core/pubsubhub";
-import { lang as defaultLang } from "core/l10n";
+import { pub } from "./pubsubhub";
+import { lang as defaultLang } from "./l10n";
 const l10n = {
   en: {
     missing_test_suite_uri:

--- a/src/core/data-transform.js
+++ b/src/core/data-transform.js
@@ -11,7 +11,7 @@
 //  know what you are doing, you should be using a dedicated module instead. This feature
 //  is not actively supported and support for it may be dropped. It is not accounted for
 //  in the test suite, and therefore could easily break.
-import { runTransforms } from "core/utils";
+import { runTransforms } from "./utils";
 
 export const name = "core/data-transform";
 

--- a/src/core/dfn.js
+++ b/src/core/dfn.js
@@ -1,7 +1,7 @@
 // Module core/dfn
 // - Finds all <dfn> elements and populates conf.definitionMap to identify them.
 
-import { getDfnTitles } from "core/utils";
+import { getDfnTitles } from "./utils";
 
 export const name = "core/dfn";
 

--- a/src/core/examples.js
+++ b/src/core/examples.js
@@ -5,10 +5,10 @@
 // When an example is found, it is reported using the "example" event. This can
 // be used by a containing shell to extract all examples.
 
-import { pub } from "core/pubsubhub";
-import "deps/hyperhtml";
-import css from "deps/text!core/css/examples.css";
-import { reindent, addId } from "core/utils";
+import { pub } from "./pubsubhub";
+import "../deps/hyperhtml";
+import css from "../deps/text!core/css/examples.css";
+import { reindent, addId } from "./utils";
 
 export const name = "core/examples";
 

--- a/src/core/exporter.js
+++ b/src/core/exporter.js
@@ -5,9 +5,9 @@
  * That is, elements that have a "removeOnSave" css class.
  */
 
-import { removeReSpec } from "core/utils";
-import { pub } from "core/pubsubhub";
-import "deps/hyperhtml";
+import { removeReSpec } from "./utils";
+import { pub } from "./pubsubhub";
+import "../deps/hyperhtml";
 
 const mimeTypes = new Map([["text/html", "html"], ["application/xml", "xml"]]);
 

--- a/src/core/figures.js
+++ b/src/core/figures.js
@@ -3,7 +3,7 @@
 // Adds width and height to images, if they are missing.
 // Generates a Table of Figures wherever there is a #tof element.
 
-import { pub } from "core/pubsubhub";
+import { pub } from "./pubsubhub";
 
 export const name = "core/figures";
 

--- a/src/core/fix-headers.js
+++ b/src/core/fix-headers.js
@@ -2,7 +2,7 @@
 // Make sure that all h1-h6 headers (that are first direct children of sections) are actually
 // numbered at the right depth level. This makes it possible to just use any of them (conventionally
 // h2) with the knowledge that the proper depth level will be used
-import { renameElement } from "core/utils";
+import { renameElement } from "./utils";
 
 export const name = "core/fix-headers";
 

--- a/src/core/github.js
+++ b/src/core/github.js
@@ -4,7 +4,7 @@
  * @see https://github.com/w3c/respec/wiki/github
  */
 
-import { pub } from "core/pubsubhub";
+import { pub } from "./pubsubhub";
 
 export const name = "core/github";
 

--- a/src/core/highlight-vars.js
+++ b/src/core/highlight-vars.js
@@ -6,8 +6,8 @@
  * All is done while keeping in mind that exported html stays clean
  * on export.
  */
-import { sub } from "core/pubsubhub";
-import hlVars from "deps/text!core/css/var.css";
+import { sub } from "./pubsubhub";
+import hlVars from "../deps/text!core/css/var.css";
 
 export const name = "core/highlight-vars";
 

--- a/src/core/highlight.js
+++ b/src/core/highlight.js
@@ -3,8 +3,8 @@
  *
  * Performs syntax highlighting to all pre and code elements.
  */
-import ghCss from "deps/text!core/css/github.css";
-import { worker } from "core/worker";
+import ghCss from "../deps/text!core/css/github.css";
+import { worker } from "./worker";
 export const name = "core/highlight";
 
 // Opportunistically insert the style into the head to reduce FOUC.

--- a/src/core/id-headers.js
+++ b/src/core/id-headers.js
@@ -3,7 +3,7 @@
 // This is currently in core though it comes from a W3C rule. It may move in the future.
 
 export const name = "core/id-headers";
-import { addId } from "core/utils";
+import { addId } from "./utils";
 
 export function run(conf) {
   document

--- a/src/core/include-config.js
+++ b/src/core/include-config.js
@@ -1,6 +1,6 @@
 // Module core/include-config
 // Inject's the document's configuration into the head as JSON.
-import { sub } from "core/pubsubhub";
+import { sub } from "./pubsubhub";
 export const name = "core/include-config";
 
 const userConfig = {};

--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -13,10 +13,10 @@
 //  - respecRFC2119: a list of the number of times each RFC2119
 //    key word was used.  NOTE: While each member is a counter, at this time
 //    the counter is not used.
-import { pub } from "core/pubsubhub";
-import "deps/hyperhtml";
-import { getTextNodes, refTypeFromContext } from "core/utils";
-import { idlStringToHtml } from "core/inline-idl-parser";
+import { pub } from "./pubsubhub";
+import "../deps/hyperhtml";
+import { getTextNodes, refTypeFromContext } from "./utils";
+import { idlStringToHtml } from "./inline-idl-parser";
 export const name = "core/inlines";
 
 export function run(conf) {

--- a/src/core/issues-notes.js
+++ b/src/core/issues-notes.js
@@ -10,10 +10,10 @@
 // numbered to avoid involuntary clashes.
 // If the configuration has issueBase set to a non-empty string, and issues are
 // manually numbered, a link to the issue is created using issueBase and the issue number
-import { pub } from "core/pubsubhub";
-import css from "deps/text!core/css/issues-notes.css";
-import "deps/hyperhtml";
-import { fetchAndCache } from "core/utils";
+import { pub } from "./pubsubhub";
+import css from "../deps/text!core/css/issues-notes.css";
+import "../deps/hyperhtml";
+import { fetchAndCache } from "./utils";
 export const name = "core/issues-notes";
 
 const MAX_GITHUB_REQUESTS = 60;

--- a/src/core/jquery-enhanced.js
+++ b/src/core/jquery-enhanced.js
@@ -4,8 +4,8 @@ import {
   getDfnTitles,
   getLinkTargets,
   renameElement,
-} from "core/utils";
-import "deps/jquery";
+} from "./utils";
+import "../deps/jquery";
 
 export const name = "core/jquery-enhanced";
 

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -1,11 +1,11 @@
 // Module core/link-to-dfn
 // Gives definitions in conf.definitionMap IDs and links <a> tags
 // to the matching definitions.
-import { linkInlineCitations } from "core/data-cite";
-import { pub } from "core/pubsubhub";
+import { linkInlineCitations } from "./data-cite";
+import { pub } from "./pubsubhub";
 import { lang as defaultLang } from "./l10n";
-import { getLinkTargets } from "core/utils";
-import { run as addExternalReferences } from "core/xref";
+import { getLinkTargets } from "./utils";
+import { run as addExternalReferences } from "./xref";
 export const name = "core/link-to-dfn";
 const l10n = {
   en: {

--- a/src/core/linter-rules/check-punctuation.js
+++ b/src/core/linter-rules/check-punctuation.js
@@ -2,8 +2,8 @@
  * Linter rule "check-punctuation". Makes sure the there are no punctuations missing at the end of a <p>
  *   in the ReSpec config.
  */
-import { lang as defaultLang } from "core/l10n";
-import LinterRule from "core/LinterRule";
+import { lang as defaultLang } from "../l10n";
+import LinterRule from "../LinterRule";
 
 const name = "check-punctuation";
 const punctuationMarks = [".", ":", "!", "?"];

--- a/src/core/linter-rules/local-refs-exist.js
+++ b/src/core/linter-rules/local-refs-exist.js
@@ -2,8 +2,8 @@
  * Linter rule "warn-local-ref".
  * Warns about href's that link to nonexistent id's in a spec
  */
-import { lang as defaultLang } from "core/l10n";
-import LinterRule from "core/LinterRule";
+import { lang as defaultLang } from "../l10n";
+import LinterRule from "../LinterRule";
 
 const name = "local-refs-exist";
 

--- a/src/core/linter-rules/no-headingless-sections.js
+++ b/src/core/linter-rules/no-headingless-sections.js
@@ -4,7 +4,7 @@
  * Checks that there are no sections in the document that don't start
  * with a heading element (h1-6).
  */
-import LinterRule from "core/LinterRule";
+import LinterRule from "../LinterRule";
 import { lang as defaultLang } from "../l10n";
 const name = "no-headingless-sections";
 const meta = {

--- a/src/core/linter-rules/no-http-props.js
+++ b/src/core/linter-rules/no-http-props.js
@@ -2,8 +2,8 @@
  * Linter rule "no-http-props". Makes sure the there are no URLs that
  * start with http:// in the ReSpec config.
  */
-import { lang as defaultLang } from "core/l10n";
-import LinterRule from "core/LinterRule";
+import { lang as defaultLang } from "../l10n";
+import LinterRule from "../LinterRule";
 
 const name = "no-http-props";
 

--- a/src/core/linter.js
+++ b/src/core/linter.js
@@ -3,7 +3,7 @@
  *
  * Core linter module. Exports a linter object.
  */
-import { pub } from "core/pubsubhub";
+import { pub } from "./pubsubhub";
 export const name = "core/linter";
 const privates = new WeakMap();
 

--- a/src/core/list-sorter.js
+++ b/src/core/list-sorter.js
@@ -1,4 +1,4 @@
-import { pub } from "core/pubsubhub";
+import { pub } from "./pubsubhub";
 export const name = "core/list-sorter";
 
 function makeSorter(direction) {

--- a/src/core/location-hash.js
+++ b/src/core/location-hash.js
@@ -1,7 +1,7 @@
 // Module core/location-hash
 // Resets window.location.hash to jump to the right point in the document
 
-import { pub } from "core/pubsubhub";
+import { pub } from "./pubsubhub";
 export const name = "core/location-hash";
 
 export function run() {

--- a/src/core/markdown.js
+++ b/src/core/markdown.js
@@ -43,7 +43,7 @@
  * The whitespace of pre elements are left alone.
  **/
 
-import { markdownToHtml } from "core/utils";
+import { markdownToHtml } from "./utils";
 export const name = "core/markdown";
 
 function processElements(selector) {

--- a/src/core/override-configuration.js
+++ b/src/core/override-configuration.js
@@ -7,7 +7,7 @@
 // Note that fields are separated by semicolons and not ampersands.
 // TODO
 //  There could probably be a UI for this to make it even simpler.
-import { sub, pub } from "core/pubsubhub";
+import { sub, pub } from "./pubsubhub";
 
 export const name = "core/override-configuration";
 

--- a/src/core/pluralize.js
+++ b/src/core/pluralize.js
@@ -3,8 +3,8 @@
 //   plurals of it are automatically added to `data-plurals`.
 // The linking is done in core/link-to-dfn
 
-import { plural as pluralOf } from "deps/pluralize";
-import { norm as normalize } from "core/utils";
+import { plural as pluralOf } from "../deps/pluralize";
+import { norm as normalize } from "./utils";
 
 export const name = "core/pluralize";
 

--- a/src/core/post-process.js
+++ b/src/core/post-process.js
@@ -8,7 +8,7 @@
  *      want to be using a new module with your own profile.
  *  - afterEnd: final thing that is called.
  */
-import { sub, pub } from "core/pubsubhub";
+import { sub, pub } from "./pubsubhub";
 
 export const name = "core/post-process";
 

--- a/src/core/pre-process.js
+++ b/src/core/pre-process.js
@@ -7,7 +7,7 @@
  *      tested. Use with care, if you know what you're doing. Chances are you really
  *      want to be using a new module with your own profile
  */
-import { sub, pub } from "core/pubsubhub";
+import { sub, pub } from "./pubsubhub";
 
 export const name = "core/pre-process";
 

--- a/src/core/render-biblio.js
+++ b/src/core/render-biblio.js
@@ -1,9 +1,9 @@
 // Module core/render-biblio
 // renders the biblio data pre-processed in core/biblio
 
-import "deps/hyperhtml";
-import { addId } from "core/utils";
-import { pub } from "core/pubsubhub";
+import "../deps/hyperhtml";
+import { addId } from "./utils";
+import { pub } from "./pubsubhub";
 
 export const name = "core/render-biblio";
 

--- a/src/core/requirements.js
+++ b/src/core/requirements.js
@@ -9,8 +9,8 @@
 // 2.  It allows referencing requirements by their ID simply using an empty <a>
 //     element with its href pointing to the requirement it should be referencing
 //     and a class of "reqRef".
-import { pub } from "core/pubsubhub";
-import "deps/hyperhtml";
+import { pub } from "./pubsubhub";
+import "../deps/hyperhtml";
 
 export const name = "core/requirements";
 

--- a/src/core/respec-ready.js
+++ b/src/core/respec-ready.js
@@ -3,7 +3,7 @@
  * The property returns a promise that settles when ReSpec finishes
  * processing the document.
  */
-import { sub } from "core/pubsubhub";
+import { sub } from "./pubsubhub";
 export const name = "core/respec-ready";
 
 const respecDonePromise = new Promise(resolve => {

--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -14,7 +14,7 @@ let appendixMode = false;
 let lastNonAppendix = 0;
 const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 export const name = "core/structure";
-import { addId } from "core/utils";
+import { addId } from "./utils";
 
 function makeTOCAtLevel($parent, doc, current, level, conf) {
   const $secs = $parent.children(

--- a/src/core/style.js
+++ b/src/core/style.js
@@ -8,7 +8,7 @@
 // CONFIGURATION
 //  - noReSpecCSS: if you're using a profile that loads this module but you don't want
 //    the style, set this to true
-import css from "deps/text!core/css/respec2.css";
+import css from "../deps/text!core/css/respec2.css";
 export const name = "core/style";
 
 // Opportunistically inserts the style, with the chance to reduce some FOUC

--- a/src/core/ui.js
+++ b/src/core/ui.js
@@ -10,10 +10,10 @@
 //  - once we have something decent, merge, ship as 3.2.0
 
 import shortcut from "shortcut";
-import { sub } from "core/pubsubhub";
-import css from "deps/text!ui/ui.css";
-import { markdownToHtml } from "core/utils";
-import "core/jquery-enhanced";
+import { sub } from "./pubsubhub";
+import css from "../deps/text!ui/ui.css";
+import { markdownToHtml } from "./utils";
+import "./jquery-enhanced";
 export const name = "core/ui";
 
 // Opportunistically inserts the style, with the chance to reduce some FOUC

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -3,8 +3,8 @@
 // Module core/utils
 // As the name implies, this contains a ragtag gang of methods that just don't fit
 // anywhere else.
-import { pub } from "core/pubsubhub";
-import marked from "deps/marked";
+import { pub } from "./pubsubhub";
+import marked from "../deps/marked";
 export const name = "core/utils";
 
 marked.setOptions({

--- a/src/core/webidl-clipboard.js
+++ b/src/core/webidl-clipboard.js
@@ -5,8 +5,8 @@
  * well-formatted IDL to the clipboard.
  *
  */
-import svgClipboard from "deps/text!core/images/clipboard.svg";
-import Clipboard from "deps/clipboard";
+import svgClipboard from "../deps/text!core/images/clipboard.svg";
+import Clipboard from "../deps/clipboard";
 export const name = "core/webidl-clipboard";
 
 // This button serves a prototype that we clone as needed.

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -4,12 +4,12 @@
 // TODO:
 //  - It could be useful to report parsed IDL items as events
 //  - don't use generated content in the CSS!
-import { pub } from "core/pubsubhub";
-import webidl2 from "deps/webidl2";
+import { pub } from "./pubsubhub";
+import webidl2 from "../deps/webidl2";
 import hb from "handlebars.runtime";
-import css from "deps/text!core/css/webidl.css";
+import css from "../deps/text!core/css/webidl.css";
 import tmpls from "templates";
-import { normalizePadding, reindent } from "core/utils";
+import { normalizePadding, reindent } from "./utils";
 
 export const name = "core/webidl";
 

--- a/src/core/worker.js
+++ b/src/core/worker.js
@@ -7,8 +7,8 @@
 export const name = "core/worker";
 
 // Opportunistically preload syntax highlighter, which is used by the worker
-import { createResourceHint } from "core/utils";
-import workerScript from "deps/text!../../worker/respec-worker.js";
+import { createResourceHint } from "./utils";
+import workerScript from "../deps/text!../../worker/respec-worker.js";
 // Opportunistically preload syntax highlighter
 const hint = {
   hint: "preload",

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -4,8 +4,8 @@
 //   so later they can be handled by core/link-to-dfn.
 // https://github.com/w3c/respec/issues/1662
 
-import { norm as normalize, showInlineError } from "core/utils";
-import * as IDB from "deps/idb";
+import { norm as normalize, showInlineError } from "./utils";
+import * as IDB from "../deps/idb";
 
 const API_URL = new URL(
   "https://wt-466c7865b463a6c4cbb820b42dde9e58-0.sandbox.auth0-extend.com/xref-proto-2"

--- a/src/w3c/abstract.js
+++ b/src/w3c/abstract.js
@@ -1,7 +1,7 @@
 // Module w3c/abstract
 // Handle the abstract section properly.
-import { pub } from "core/pubsubhub";
-import { l10n, lang } from "core/l10n";
+import { pub } from "../core/pubsubhub";
+import { l10n, lang } from "../core/l10n";
 export const name = "w3c/abstract";
 
 export async function run() {

--- a/src/w3c/conformance.js
+++ b/src/w3c/conformance.js
@@ -1,7 +1,7 @@
 // Module w3c/conformance
 // Handle the conformance section properly.
-import confoTmpl from "w3c/templates/conformance";
-import { pub } from "core/pubsubhub";
+import confoTmpl from "./templates/conformance";
+import { pub } from "../core/pubsubhub";
 
 export const name = "w3c/conformance";
 

--- a/src/w3c/defaults.js
+++ b/src/w3c/defaults.js
@@ -2,12 +2,12 @@
  * Sets the defaults for W3C specs
  */
 export const name = "w3c/defaults";
-import linter from "core/linter";
-import { rule as noHeadinglessSectionsRule } from "core/linter-rules/no-headingless-sections";
-import { rule as noHttpPropsRule } from "core/linter-rules/no-http-props";
-import { rule as privsecSectionRule } from "w3c/linter-rules/privsec-section";
-import { rule as checkPunctuation } from "core/linter-rules/check-punctuation";
-import { rule as localRefsExist } from "core/linter-rules/local-refs-exist";
+import linter from "../core/linter";
+import { rule as noHeadinglessSectionsRule } from "../core/linter-rules/no-headingless-sections";
+import { rule as noHttpPropsRule } from "../core/linter-rules/no-http-props";
+import { rule as privsecSectionRule } from "./linter-rules/privsec-section";
+import { rule as checkPunctuation } from "../core/linter-rules/check-punctuation";
+import { rule as localRefsExist } from "../core/linter-rules/local-refs-exist";
 
 linter.register(
   noHttpPropsRule,

--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -91,12 +91,12 @@
 //      - "w3c-software", a permissive and attributions license (but GPL-compatible).
 //      - "w3c-software-doc", the W3C Software and Document License
 //            https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
-import { concatDate, joinAnd, ISODate } from "core/utils";
-import { pub } from "core/pubsubhub";
-import cgbgSotdTmpl from "w3c/templates/cgbg-sotd";
-import sotdTmpl from "w3c/templates/sotd";
-import cgbgHeadersTmpl from "w3c/templates/cgbg-headers";
-import headersTmpl from "w3c/templates/headers";
+import { concatDate, joinAnd, ISODate } from "../core/utils";
+import { pub } from "../core/pubsubhub";
+import cgbgSotdTmpl from "./templates/cgbg-sotd";
+import sotdTmpl from "./templates/sotd";
+import cgbgHeadersTmpl from "./templates/cgbg-headers";
+import headersTmpl from "./templates/headers";
 
 export const name = "w3c/headers";
 

--- a/src/w3c/informative.js
+++ b/src/w3c/informative.js
@@ -1,6 +1,6 @@
 // Module w3c/informative
 // Mark specific sections as informative, based on CSS
-import "deps/hyperhtml";
+import "../deps/hyperhtml";
 export const name = "w3c/informative";
 
 export function run() {

--- a/src/w3c/l10n.js
+++ b/src/w3c/l10n.js
@@ -1,7 +1,7 @@
 // Module w3c/l10n
 // Looks at the lang attribute on the root element and uses it to manage the config.l10n object so
 // that other parts of the system can localise their text
-import { l10n } from "core/l10n";
+import { l10n } from "../core/l10n";
 export const name = "w3c/l10n";
 const additions = {
   en: {

--- a/src/w3c/linter-rules/privsec-section.js
+++ b/src/w3c/linter-rules/privsec-section.js
@@ -6,8 +6,8 @@
  * case-insensitive, multi-line check.
  *
  */
-import LinterRule from "core/LinterRule";
-import { lang as defaultLang } from "../l10n";
+import LinterRule from "../../core/LinterRule";
+import { lang as defaultLang } from "../../core/l10n";
 const name = "privsec-section";
 const meta = {
   en: {

--- a/src/w3c/linter.js
+++ b/src/w3c/linter.js
@@ -5,7 +5,7 @@
 
 export const name = "w3c/linter";
 
-import linter from "core/linter";
-import { lint as privsec } from "w3c/linter-rules/privsec-section";
+import linter from "../core/linter";
+import { lint as privsec } from "./linter-rules/privsec-section";
 
 linter.register(privsec);

--- a/src/w3c/rfc2119.js
+++ b/src/w3c/rfc2119.js
@@ -1,7 +1,7 @@
 // Module w3c/rfc2119
 // update the 2119 terms section with the terms actually used
 
-import { joinAnd } from "core/utils";
+import { joinAnd } from "../core/utils";
 
 export const name = "w3c/rfc2119";
 

--- a/src/w3c/seo.js
+++ b/src/w3c/seo.js
@@ -1,7 +1,7 @@
 // Module w3c/seo
 // Manages SEO information for documents
 // e.g. set the canonical URL for the document if configured
-import { pub } from "core/pubsubhub";
+import { pub } from "../core/pubsubhub";
 export const name = "w3c/seo";
 export function run(conf) {
   const trLatestUri = conf.shortName

--- a/src/w3c/style.js
+++ b/src/w3c/style.js
@@ -5,8 +5,8 @@
 // CONFIGURATION
 //  - specStatus: the short code for the specification's maturity level or type (required)
 
-import { toKeyValuePairs, createResourceHint, linkCSS } from "core/utils";
-import { pub, sub } from "core/pubsubhub";
+import { toKeyValuePairs, createResourceHint, linkCSS } from "../core/utils";
+import { pub, sub } from "../core/pubsubhub";
 export const name = "w3c/style";
 function attachFixupScript(doc, version) {
   const script = doc.createElement("script");

--- a/src/w3c/templates/cgbg-headers.js
+++ b/src/w3c/templates/cgbg-headers.js
@@ -1,4 +1,4 @@
-import "deps/hyperhtml";
+import "../../deps/hyperhtml";
 import showLogo from "./show-logo";
 import showPeople from "./show-people";
 import showLink from "./show-link";

--- a/src/w3c/templates/cgbg-sotd.js
+++ b/src/w3c/templates/cgbg-sotd.js
@@ -1,4 +1,4 @@
-import "deps/hyperhtml";
+import "../../deps/hyperhtml";
 
 export default conf => {
   const html = hyperHTML;

--- a/src/w3c/templates/conformance.js
+++ b/src/w3c/templates/conformance.js
@@ -1,4 +1,4 @@
-import "deps/hyperhtml";
+import "../../deps/hyperhtml";
 
 export default () => {
   const html = hyperHTML;

--- a/src/w3c/templates/headers.js
+++ b/src/w3c/templates/headers.js
@@ -1,8 +1,8 @@
-import "deps/hyperhtml";
+import "../../deps/hyperhtml";
 import showLogo from "./show-logo";
 import showPeople from "./show-people";
 import showLink from "./show-link";
-import { pub } from "core/pubsubhub";
+import { pub } from "../../core/pubsubhub";
 
 function getSpecTitleElem(conf) {
   const specTitleElem =

--- a/src/w3c/templates/show-link.js
+++ b/src/w3c/templates/show-link.js
@@ -1,5 +1,5 @@
-import "deps/hyperhtml";
-import { pub } from "core/pubsubhub";
+import "../../deps/hyperhtml";
+import { pub } from "../../core/pubsubhub";
 const html = hyperHTML;
 
 export default link => {

--- a/src/w3c/templates/show-logo.js
+++ b/src/w3c/templates/show-logo.js
@@ -1,5 +1,5 @@
-import "deps/hyperhtml";
-import { pub } from "core/pubsubhub";
+import "../../deps/hyperhtml";
+import { pub } from "../../core/pubsubhub";
 
 export default obj => {
   const a = document.createElement("a");

--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -1,4 +1,4 @@
-import "deps/hyperhtml";
+import "../../deps/hyperhtml";
 
 export default conf => {
   const html = hyperHTML;


### PR DESCRIPTION
This will:

1. enable VSCode to track types
2. ease migration to native ES module system which currently only allows relative paths.