### PR TITLE
refactor: split findDfn() as dfn-finder module

### DIFF
--- a/src/core/dfn-finder.js
+++ b/src/core/dfn-finder.js
@@ -1,0 +1,110 @@
+import { pub } from "./pubsubhub";
+import { wrapInner } from "./utils";
+
+const topLevelEntities = new Set([
+  "callback interface",
+  "callback",
+  "dictionary",
+  "enum",
+  "interface mixin",
+  "interface",
+  "typedef",
+]);
+
+export function findDfn_(
+  defn,
+  { parent, name, originalParent, originalName, definitionMap, type, idlElem }
+) {
+  let dfnForArray = definitionMap[name];
+  let dfns = [];
+  if (dfnForArray) {
+    // Definitions that have a title and [data-dfn-for] that exactly match the
+    // IDL entity:
+    dfns = dfnForArray.filter(dfn => dfn.closest(`[data-dfn-for="${parent}"]`));
+    // If this is a top-level entity, and we didn't find anything with
+    // an explicitly empty [for], try <dfn> that inherited a [for].
+    if (dfns.length === 0 && parent === "" && dfnForArray.length === 1) {
+      dfns = dfnForArray;
+    } else if (topLevelEntities.has(type) && dfnForArray.length) {
+      const dfn = dfnForArray.find(
+        dfn => dfn.textContent.trim() === originalName
+      );
+      if (dfn) dfns = [dfn];
+    }
+  }
+  // If we haven't found any definitions with explicit [for]
+  // and [title], look for a dotted definition, "parent.name".
+  if (dfns.length === 0 && parent !== "") {
+    const dottedName = parent + "." + name;
+    dfnForArray = definitionMap[dottedName];
+    if (dfnForArray !== undefined && dfnForArray.length === 1) {
+      dfns = dfnForArray;
+      // Found it: update the definition to specify its [for] and data-lt.
+      delete definitionMap[dottedName];
+      dfns[0].dataset.dfnFor = parent;
+      dfns[0].dataset.lt = name;
+      if (definitionMap[name] === undefined) {
+        definitionMap[name] = [];
+      }
+      definitionMap[name].push(dfns[0]);
+    }
+  }
+  if (dfns.length > 1) {
+    const msg = `Multiple \`<dfn>\`s for \`${originalName}\` ${
+      originalParent ? `in \`${originalParent}\`` : ""
+    }`;
+    pub("error", msg);
+  }
+  if (dfns.length === 0) {
+    const showWarnings =
+      type &&
+      idlElem &&
+      name &&
+      idlElem.classList.contains("no-link-warnings") === false;
+    if (showWarnings) {
+      const name = type === "operation" ? `${originalName}()` : originalName;
+      const parentName = originalParent ? ` \`${originalParent}\`'s` : "";
+      let msg = `Missing \`<dfn>\` for${parentName} \`${name}\` ${type}`;
+      msg +=
+        ". [More info](https://github.com/w3c/respec/wiki/WebIDL-thing-is-not-defined).";
+      pub("warn", msg);
+    }
+    return;
+  }
+  const [dfn] = dfns;
+  if (!dfn.id) {
+    const id =
+      "dom-" +
+      (parent ? parent + "-" : "") +
+      name.replace(/[()]/g, "").replace(/\s/g, "-");
+    dfn.id = id;
+  }
+  dfn.dataset.idl = type || defn.type;
+  dfn.dataset.title = dfn.textContent;
+  dfn.dataset.dfnFor = parent;
+  // Derive the data-type for dictionary members, interface attributes,
+  // and methods
+  switch (defn.type) {
+    case "operation":
+    case "attribute":
+    case "field":
+      dfn.dataset.type = getDataType(defn);
+      break;
+  }
+
+  // Mark the definition as code.
+  if (!dfn.querySelector("code") && !dfn.closest("code") && dfn.children) {
+    wrapInner(dfn, dfn.ownerDocument.createElement("code"));
+  }
+  return dfn;
+}
+
+function getDataType(idlStruct) {
+  const { idlType, baseName, generic, type, body, union } = idlStruct;
+  if (typeof idlType === "string") return idlType;
+  if (generic) return generic.value;
+  if (type === "operation") return getDataType(body.idlType);
+  // join on "|" handles for "unsigned short" etc.
+  if (union) return idlType.map(getDataType).join("|");
+  return baseName ? baseName : getDataType(idlType);
+}

--- a/src/core/dfn-finder.js
+++ b/src/core/dfn-finder.js
@@ -29,7 +29,7 @@ export function findDfn(defn, parent, name, definitionMap, idlElem) {
   return (
     findAttributeDfn(defn, parent, name, definitionMap, idlElem) ||
     findOperationDfn(defn, parent, name, definitionMap, idlElem) ||
-    findGeneralDfn(defn, parent, name, definitionMap, idlElem)
+    findNormalDfn(defn, parent, name, definitionMap, idlElem)
   );
 }
 
@@ -42,7 +42,7 @@ function findAttributeDfn(defn, parent, name, definitionMap, idlElem) {
   const asQualifiedName = parent + "." + asLocalName;
   let dfn;
   if (definitionMap[asQualifiedName] || definitionMap[asLocalName]) {
-    dfn = findGeneralDfn(defn, parent, asLocalName, definitionMap, idlElem);
+    dfn = findNormalDfn(defn, parent, asLocalName, definitionMap, idlElem);
   }
   if (!dfn) {
     return; // try finding dfn using name, using normal search path...
@@ -75,7 +75,7 @@ function findOperationDfn(defn, parent, name, definitionMap, idlElem) {
     const lookupName = definitionMap[asMethodName]
       ? asMethodName
       : asFullyQualifiedName;
-    const dfn = findGeneralDfn(
+    const dfn = findNormalDfn(
       defn,
       parent,
       lookupName,
@@ -95,7 +95,7 @@ function findOperationDfn(defn, parent, name, definitionMap, idlElem) {
     return dfn;
   }
   // no method alias, so let's find the dfn and add it
-  const dfn = findGeneralDfn(defn, parent, name, definitionMap, idlElem);
+  const dfn = findNormalDfn(defn, parent, name, definitionMap, idlElem);
   if (!dfn) {
     return;
   }
@@ -106,7 +106,7 @@ function findOperationDfn(defn, parent, name, definitionMap, idlElem) {
   return dfn;
 }
 
-function findGeneralDfn(defn, parent, name, definitionMap, idlElem) {
+function findNormalDfn(defn, parent, name, definitionMap, idlElem) {
   if (unlinkable.has(name)) {
     return;
   }

--- a/src/core/dfn-finder.js
+++ b/src/core/dfn-finder.js
@@ -16,22 +16,7 @@ export function findDfn_(
   { parent, name, originalParent, originalName, definitionMap, type, idlElem }
 ) {
   let dfnForArray = definitionMap[name];
-  let dfns = [];
-  if (dfnForArray) {
-    // Definitions that have a title and [data-dfn-for] that exactly match the
-    // IDL entity:
-    dfns = dfnForArray.filter(dfn => dfn.closest(`[data-dfn-for="${parent}"]`));
-    // If this is a top-level entity, and we didn't find anything with
-    // an explicitly empty [for], try <dfn> that inherited a [for].
-    if (dfns.length === 0 && parent === "" && dfnForArray.length === 1) {
-      dfns = dfnForArray;
-    } else if (topLevelEntities.has(type) && dfnForArray.length) {
-      const dfn = dfnForArray.find(
-        dfn => dfn.textContent.trim() === originalName
-      );
-      if (dfn) dfns = [dfn];
-    }
-  }
+  let dfns = getDfns(dfnForArray, parent, originalName, type);
   // If we haven't found any definitions with explicit [for]
   // and [title], look for a dotted definition, "parent.name".
   if (dfns.length === 0 && parent !== "") {
@@ -97,6 +82,28 @@ export function findDfn_(
     wrapInner(dfn, dfn.ownerDocument.createElement("code"));
   }
   return dfn;
+}
+
+function getDfns(dfnForArray, parent, originalName, type) {
+  if (!dfnForArray) {
+    return [];
+  }
+  // Definitions that have a title and [data-dfn-for] that exactly match the
+  // IDL entity:
+  const dfns = dfnForArray.filter(dfn =>
+    dfn.closest(`[data-dfn-for="${parent}"]`)
+  );
+  // If this is a top-level entity, and we didn't find anything with
+  // an explicitly empty [for], try <dfn> that inherited a [for].
+  if (dfns.length === 0 && parent === "" && dfnForArray.length === 1) {
+    return dfnForArray;
+  } else if (topLevelEntities.has(type) && dfnForArray.length) {
+    const dfn = dfnForArray.find(
+      dfn => dfn.textContent.trim() === originalName
+    );
+    if (dfn) return [dfn];
+  }
+  return dfns;
 }
 
 function getDataType(idlStruct) {

--- a/src/core/dfn-finder.js
+++ b/src/core/dfn-finder.js
@@ -16,7 +16,7 @@ const topLevelEntities = new Set([
 // https://github.com/w3c/respec/issues/982
 const unlinkable = new Set(["maplike", "setlike", "stringifier"]);
 
-export function findDfn_(defn, { parent, name, definitionMap, type, idlElem }) {
+export function findDfn_(defn, { parent, name, definitionMap, idlElem }) {
   if (unlinkable.has(name)) {
     return;
   }
@@ -28,7 +28,7 @@ export function findDfn_(defn, { parent, name, definitionMap, type, idlElem }) {
       ? "the-empty-string"
       : name.toLowerCase();
   let dfnForArray = definitionMap[name];
-  let dfns = getDfns(dfnForArray, parent, originalName, type);
+  let dfns = getDfns(dfnForArray, parent, originalName, defn.type);
   // If we haven't found any definitions with explicit [for]
   // and [title], look for a dotted definition, "parent.name".
   if (dfns.length === 0 && parent !== "") {
@@ -54,21 +54,20 @@ export function findDfn_(defn, { parent, name, definitionMap, type, idlElem }) {
   }
   if (dfns.length === 0) {
     const showWarnings =
-      type &&
       idlElem &&
       name &&
       idlElem.classList.contains("no-link-warnings") === false;
     if (showWarnings) {
-      const name = type === "operation" ? `${originalName}()` : originalName;
+      const name = defn.type === "operation" ? `${originalName}()` : originalName;
       const parentName = originalParent ? ` \`${originalParent}\`'s` : "";
-      let msg = `Missing \`<dfn>\` for${parentName} \`${name}\` ${type}`;
+      let msg = `Missing \`<dfn>\` for${parentName} \`${name}\` ${defn.type}`;
       msg +=
         ". [More info](https://github.com/w3c/respec/wiki/WebIDL-thing-is-not-defined).";
       pub("warn", msg);
     }
     return;
   }
-  return decorateDfn(dfns[0], defn, parent, name, type);
+  return decorateDfn(dfns[0], defn, parent, name, defn.type);
 }
 
 function decorateDfn(dfn, defn, parent, name, type) {

--- a/src/core/dfn-finder.js
+++ b/src/core/dfn-finder.js
@@ -56,7 +56,10 @@ export function findDfn_(
     }
     return;
   }
-  const [dfn] = dfns;
+  return decorateDfn(dfns[0], defn, parent, name, type);
+}
+
+function decorateDfn(dfn, defn, parent, name, type) {
   if (!dfn.id) {
     const id =
       "dom-" +

--- a/src/core/dfn-finder.js
+++ b/src/core/dfn-finder.js
@@ -58,7 +58,8 @@ export function findDfn_(defn, { parent, name, definitionMap, idlElem }) {
       name &&
       idlElem.classList.contains("no-link-warnings") === false;
     if (showWarnings) {
-      const name = defn.type === "operation" ? `${originalName}()` : originalName;
+      const name =
+        defn.type === "operation" ? `${originalName}()` : originalName;
       const parentName = originalParent ? ` \`${originalParent}\`'s` : "";
       let msg = `Missing \`<dfn>\` for${parentName} \`${name}\` ${defn.type}`;
       msg +=

--- a/src/core/dfn-finder.js
+++ b/src/core/dfn-finder.js
@@ -11,10 +11,22 @@ const topLevelEntities = new Set([
   "typedef",
 ]);
 
-export function findDfn_(
-  defn,
-  { parent, name, originalParent, originalName, definitionMap, type, idlElem }
-) {
+// TODO: make these linkable somehow.
+// https://github.com/w3c/respec/issues/999
+// https://github.com/w3c/respec/issues/982
+const unlinkable = new Set(["maplike", "setlike", "stringifier"]);
+
+export function findDfn_(defn, { parent, name, definitionMap, type, idlElem }) {
+  if (unlinkable.has(name)) {
+    return;
+  }
+  const originalParent = parent;
+  const originalName = name;
+  parent = parent.toLowerCase();
+  name =
+    defn.type === "enum-value" && name === ""
+      ? "the-empty-string"
+      : name.toLowerCase();
   let dfnForArray = definitionMap[name];
   let dfns = getDfns(dfnForArray, parent, originalName, type);
   // If we haven't found any definitions with explicit [for]

--- a/src/core/dfn-finder.js
+++ b/src/core/dfn-finder.js
@@ -26,7 +26,7 @@ const unlinkable = new Set(["maplike", "setlike", "stringifier"]);
 // marked as an IDL definition, and returned. If no <dfn> is found,
 // the function returns 'undefined'.
 /**
- * @param {WebIDL2.IDLTypeDescription} defn
+ * @param {*} defn
  * @param {string} parent
  * @param {string} name
  * @param {Record<string, HTMLElement[]>} definitionMap
@@ -44,7 +44,7 @@ export function findDfn(defn, parent, name, definitionMap, idlElem) {
 }
 
 /**
- * @param {WebIDL2.IDLTypeDescription} defn
+ * @param {*} defn
  * @param {string} parent
  * @param {string} name
  * @param {Record<string, HTMLElement[]>} definitionMap
@@ -69,7 +69,7 @@ function findAttributeDfn(defn, parent, name, definitionMap, idlElem) {
 }
 
 /**
- * @param {WebIDL2.IDLTypeDescription} defn
+ * @param {*} defn
  * @param {string} parent
  * @param {string} name
  * @param {Record<string, HTMLElement[]>} definitionMap
@@ -121,7 +121,7 @@ function findOperationDfn(defn, parent, name, definitionMap, idlElem) {
 }
 
 /**
- * @param {WebIDL2.IDLTypeDescription} defn
+ * @param {*} defn
  * @param {string} parent
  * @param {string} name
  * @param {Record<string, HTMLElement[]>} definitionMap
@@ -180,10 +180,10 @@ function findNormalDfn(defn, parent, name, definitionMap, idlElem) {
 }
 
 /**
- * @param {HTMLElement} dfn 
- * @param {WebIDL2.IDLTypeDescription} defn 
- * @param {string} parent 
- * @param {string} name 
+ * @param {HTMLElement} dfn
+ * @param {*} defn
+ * @param {string} parent
+ * @param {string} name
  */
 function decorateDfn(dfn, defn, parent, name) {
   if (!dfn.id) {
@@ -214,9 +214,9 @@ function decorateDfn(dfn, defn, parent, name) {
 }
 
 /**
- * @param {HTMLElement[]} dfnForArray 
- * @param {string} parent 
- * @param {string} originalName 
+ * @param {HTMLElement[]} dfnForArray
+ * @param {string} parent
+ * @param {string} originalName
  * @param {string} type
  */
 function getDfns(dfnForArray, parent, originalName, type) {
@@ -241,7 +241,7 @@ function getDfns(dfnForArray, parent, originalName, type) {
   return dfns;
 }
 
-/** 
+/**
  * @return {string}
  */
 function getDataType(idlStruct) {

--- a/src/core/dfn-finder.js
+++ b/src/core/dfn-finder.js
@@ -16,16 +16,16 @@ const topLevelEntities = new Set([
 // https://github.com/w3c/respec/issues/982
 const unlinkable = new Set(["maplike", "setlike", "stringifier"]);
 
-// This function looks for a <dfn> element whose title is 'name' and
-// that is "for" 'parent', which is the empty string when 'name'
-// refers to a top-level entity. For top-level entities, <dfn>
-// elements that inherit a non-empty [dfn-for] attribute are also
-// counted as matching.
-//
-// When a matching <dfn> is found, it's given <code> formatting,
-// marked as an IDL definition, and returned. If no <dfn> is found,
-// the function returns 'undefined'.
 /**
+ * This function looks for a <dfn> element whose title is 'name' and
+ * that is "for" 'parent', which is the empty string when 'name'
+ * refers to a top-level entity. For top-level entities, <dfn>
+ * elements that inherit a non-empty [dfn-for] attribute are also
+ * counted as matching.
+ *
+ * When a matching <dfn> is found, it's given <code> formatting,
+ * marked as an IDL definition, and returned. If no <dfn> is found,
+ * the function returns 'undefined'.
  * @param {*} defn
  * @param {string} parent
  * @param {string} name

--- a/src/core/dfn-finder.js
+++ b/src/core/dfn-finder.js
@@ -55,7 +55,7 @@ function findAttributeDfn(defn, parent, name, definitionMap, idlElem) {
 
 function findOperationDfn(defn, parent, name, definitionMap, idlElem) {
   // Overloads all have unique names
-  if (name.search("!overload") !== -1) {
+  if (name.includes("!overload")) {
     return findNormalDfn(defn, parent, name, definitionMap, idlElem);
   }
   const parentLow = parent.toLowerCase();

--- a/src/core/dfn-finder.js
+++ b/src/core/dfn-finder.js
@@ -75,13 +75,7 @@ function findOperationDfn(defn, parent, name, definitionMap, idlElem) {
     const lookupName = definitionMap[asMethodName]
       ? asMethodName
       : asFullyQualifiedName;
-    const dfn = findNormalDfn(
-      defn,
-      parent,
-      lookupName,
-      definitionMap,
-      idlElem
-    );
+    const dfn = findNormalDfn(defn, parent, lookupName, definitionMap, idlElem);
     if (!dfn) {
       return; // try finding dfn using name, using normal search path...
     }

--- a/src/core/dfn-finder.js
+++ b/src/core/dfn-finder.js
@@ -25,6 +25,13 @@ const unlinkable = new Set(["maplike", "setlike", "stringifier"]);
 // When a matching <dfn> is found, it's given <code> formatting,
 // marked as an IDL definition, and returned. If no <dfn> is found,
 // the function returns 'undefined'.
+/**
+ * @param {WebIDL2.IDLTypeDescription} defn
+ * @param {string} parent
+ * @param {string} name
+ * @param {Record<string, HTMLElement[]>} definitionMap
+ * @param {HTMLElement} idlElem
+ */
 export function findDfn(defn, parent, name, definitionMap, idlElem) {
   switch (defn.type) {
     case "attribute":
@@ -36,6 +43,13 @@ export function findDfn(defn, parent, name, definitionMap, idlElem) {
   }
 }
 
+/**
+ * @param {WebIDL2.IDLTypeDescription} defn
+ * @param {string} parent
+ * @param {string} name
+ * @param {Record<string, HTMLElement[]>} definitionMap
+ * @param {HTMLElement} idlElem
+ */
 function findAttributeDfn(defn, parent, name, definitionMap, idlElem) {
   const parentLow = parent.toLowerCase();
   const asLocalName = name.toLowerCase();
@@ -45,6 +59,7 @@ function findAttributeDfn(defn, parent, name, definitionMap, idlElem) {
     dfn = findNormalDfn(defn, parent, asLocalName, definitionMap, idlElem);
   }
   if (!dfn) {
+    // try finding dfn using name, using normal search path...
     return findNormalDfn(defn, parent, name, definitionMap, idlElem);
   }
   const lt = dfn.dataset.lt ? dfn.dataset.lt.split("|") : [];
@@ -53,6 +68,13 @@ function findAttributeDfn(defn, parent, name, definitionMap, idlElem) {
   return dfn;
 }
 
+/**
+ * @param {WebIDL2.IDLTypeDescription} defn
+ * @param {string} parent
+ * @param {string} name
+ * @param {Record<string, HTMLElement[]>} definitionMap
+ * @param {HTMLElement} idlElem
+ */
 function findOperationDfn(defn, parent, name, definitionMap, idlElem) {
   // Overloads all have unique names
   if (name.includes("!overload")) {
@@ -98,6 +120,13 @@ function findOperationDfn(defn, parent, name, definitionMap, idlElem) {
   return dfn;
 }
 
+/**
+ * @param {WebIDL2.IDLTypeDescription} defn
+ * @param {string} parent
+ * @param {string} name
+ * @param {Record<string, HTMLElement[]>} definitionMap
+ * @param {HTMLElement} idlElem
+ */
 function findNormalDfn(defn, parent, name, definitionMap, idlElem) {
   if (unlinkable.has(name)) {
     return;
@@ -147,10 +176,16 @@ function findNormalDfn(defn, parent, name, definitionMap, idlElem) {
     }
     return;
   }
-  return decorateDfn(dfns[0], defn, parentLow, nameLow, defn.type);
+  return decorateDfn(dfns[0], defn, parentLow, nameLow);
 }
 
-function decorateDfn(dfn, defn, parent, name, type) {
+/**
+ * @param {HTMLElement} dfn 
+ * @param {WebIDL2.IDLTypeDescription} defn 
+ * @param {string} parent 
+ * @param {string} name 
+ */
+function decorateDfn(dfn, defn, parent, name) {
   if (!dfn.id) {
     const id =
       "dom-" +
@@ -158,7 +193,7 @@ function decorateDfn(dfn, defn, parent, name, type) {
       name.replace(/[()]/g, "").replace(/\s/g, "-");
     dfn.id = id;
   }
-  dfn.dataset.idl = type || defn.type;
+  dfn.dataset.idl = defn.type;
   dfn.dataset.title = dfn.textContent;
   dfn.dataset.dfnFor = parent;
   // Derive the data-type for dictionary members, interface attributes,
@@ -178,6 +213,12 @@ function decorateDfn(dfn, defn, parent, name, type) {
   return dfn;
 }
 
+/**
+ * @param {HTMLElement[]} dfnForArray 
+ * @param {string} parent 
+ * @param {string} originalName 
+ * @param {string} type
+ */
 function getDfns(dfnForArray, parent, originalName, type) {
   if (!dfnForArray) {
     return [];
@@ -200,6 +241,9 @@ function getDfns(dfnForArray, parent, originalName, type) {
   return dfns;
 }
 
+/** 
+ * @return {string}
+ */
 function getDataType(idlStruct) {
   const { idlType, baseName, generic, type, body, union } = idlStruct;
   if (typeof idlType === "string") return idlType;

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -506,7 +506,6 @@ function linkDefinitions(parse, definitionMap, parent, idlElem) {
                 name,
                 enumValue.value,
                 definitionMap,
-                "enum-value",
                 idlElem
               );
             });
@@ -582,7 +581,7 @@ function linkDefinitions(parse, definitionMap, parent, idlElem) {
       if (parent) {
         defn.linkFor = parent;
       }
-      defn.dfn = findDfn(defn, parent, name, definitionMap, defn.type, idlElem);
+      defn.dfn = findDfn(defn, parent, name, definitionMap, idlElem);
     });
 }
 
@@ -595,11 +594,11 @@ function linkDefinitions(parse, definitionMap, parent, idlElem) {
 // When a matching <dfn> is found, it's given <code> formatting,
 // marked as an IDL definition, and returned. If no <dfn> is found,
 // the function returns 'undefined'.
-function findDfn(defn, parent, name, definitionMap, type, idlElem) {
+function findDfn(defn, parent, name, definitionMap, idlElem) {
   return (
     findAttributeDfn(defn, parent, name, definitionMap, idlElem) ||
     findOperationDfn(defn, parent, name, definitionMap, idlElem) ||
-    findDfn_(defn, { parent, name, definitionMap, type, idlElem })
+    findDfn_(defn, { parent, name, definitionMap, idlElem })
   );
 }
 

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -499,16 +499,15 @@ function linkDefinitions(parse, definitionMap, parent, idlElem) {
         }
         case "enum":
           name = defn.name;
-          defn.values
-            .forEach(enumValue => {
-              enumValue.dfn = findDfn(
-                enumValue,
-                name,
-                enumValue.value,
-                definitionMap,
-                idlElem
-              );
-            });
+          defn.values.forEach(enumValue => {
+            enumValue.dfn = findDfn(
+              enumValue,
+              name,
+              enumValue.value,
+              definitionMap,
+              idlElem
+            );
+          });
           defn.idlId = "idl-def-" + name.toLowerCase();
           break;
         // Top-level entities without linkable members.

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -9,7 +9,7 @@ import webidl2 from "../deps/webidl2";
 import hb from "handlebars.runtime";
 import css from "../deps/text!core/css/webidl.css";
 import tmpls from "templates";
-import { normalizePadding, reindent } from "./utils";
+import { normalizePadding, reindent, wrapInner } from "./utils";
 
 export const name = "core/webidl";
 
@@ -766,11 +766,7 @@ function findDfn(defn, parent, name, definitionMap, type, idlElem) {
 
   // Mark the definition as code.
   if (!dfn.querySelector("code") && !dfn.closest("code") && dfn.children) {
-    const code = dfn.ownerDocument.createElement("code");
-    while (dfn.hasChildNodes()) {
-      code.appendChild(dfn.firstChild);
-    }
-    dfn.appendChild(code);
+    wrapInner(dfn, dfn.ownerDocument.createElement("code"));
   }
   return dfn;
 }

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -9,7 +9,8 @@ import webidl2 from "../deps/webidl2";
 import hb from "handlebars.runtime";
 import css from "../deps/text!core/css/webidl.css";
 import tmpls from "templates";
-import { normalizePadding, reindent, wrapInner } from "./utils";
+import { normalizePadding, reindent } from "./utils";
+import { findDfn_ } from "./dfn-finder";
 
 export const name = "core/webidl";
 
@@ -33,15 +34,6 @@ const idlTypedefTmpl = tmpls["typedef.html"];
 // https://github.com/w3c/respec/issues/999
 // https://github.com/w3c/respec/issues/982
 const unlinkable = new Set(["maplike", "setlike", "stringifier"]);
-const topLevelEntities = new Set([
-  "callback interface",
-  "callback",
-  "dictionary",
-  "enum",
-  "interface mixin",
-  "interface",
-  "typedef",
-]);
 
 function registerHelpers() {
   hb.registerHelper("extAttr", obj => {
@@ -684,101 +676,17 @@ function findDfn(defn, parent, name, definitionMap, type, idlElem) {
     default:
       name = name.toLowerCase();
   }
-  if (unlinkable.has(name)) {
-    return;
+  if (!unlinkable.has(name)) {
+    return findDfn_(defn, {
+      parent,
+      name,
+      originalParent,
+      originalName,
+      definitionMap,
+      type,
+      idlElem,
+    });
   }
-  let dfnForArray = definitionMap[name];
-  let dfns = [];
-  if (dfnForArray) {
-    // Definitions that have a title and [data-dfn-for] that exactly match the
-    // IDL entity:
-    dfns = dfnForArray.filter(dfn => dfn.closest(`[data-dfn-for="${parent}"]`));
-    // If this is a top-level entity, and we didn't find anything with
-    // an explicitly empty [for], try <dfn> that inherited a [for].
-    if (dfns.length === 0 && parent === "" && dfnForArray.length === 1) {
-      dfns = dfnForArray;
-    } else if (topLevelEntities.has(type) && dfnForArray.length) {
-      const dfn = dfnForArray.find(
-        dfn => dfn.textContent.trim() === originalName
-      );
-      if (dfn) dfns = [dfn];
-    }
-  }
-  // If we haven't found any definitions with explicit [for]
-  // and [title], look for a dotted definition, "parent.name".
-  if (dfns.length === 0 && parent !== "") {
-    const dottedName = parent + "." + name;
-    dfnForArray = definitionMap[dottedName];
-    if (dfnForArray !== undefined && dfnForArray.length === 1) {
-      dfns = dfnForArray;
-      // Found it: update the definition to specify its [for] and data-lt.
-      delete definitionMap[dottedName];
-      dfns[0].dataset.dfnFor = parent;
-      dfns[0].dataset.lt = name;
-      if (definitionMap[name] === undefined) {
-        definitionMap[name] = [];
-      }
-      definitionMap[name].push(dfns[0]);
-    }
-  }
-  if (dfns.length > 1) {
-    const msg = `Multiple \`<dfn>\`s for \`${originalName}\` ${
-      originalParent ? `in \`${originalParent}\`` : ""
-    }`;
-    pub("error", msg);
-  }
-  if (dfns.length === 0) {
-    const showWarnings =
-      type &&
-      idlElem &&
-      name &&
-      idlElem.classList.contains("no-link-warnings") === false;
-    if (showWarnings) {
-      const name = type === "operation" ? `${originalName}()` : originalName;
-      const parentName = originalParent ? ` \`${originalParent}\`'s` : "";
-      let msg = `Missing \`<dfn>\` for${parentName} \`${name}\` ${type}`;
-      msg +=
-        ". [More info](https://github.com/w3c/respec/wiki/WebIDL-thing-is-not-defined).";
-      pub("warn", msg);
-    }
-    return;
-  }
-  const [dfn] = dfns;
-  if (!dfn.id) {
-    const id =
-      "dom-" +
-      (parent ? parent + "-" : "") +
-      name.replace(/[()]/g, "").replace(/\s/g, "-");
-    dfn.id = id;
-  }
-  dfn.dataset.idl = type || defn.type;
-  dfn.dataset.title = dfn.textContent;
-  dfn.dataset.dfnFor = parent;
-  // Derive the data-type for dictionary members, interface attributes,
-  // and methods
-  switch (defn.type) {
-    case "operation":
-    case "attribute":
-    case "field":
-      dfn.dataset.type = getDataType(defn);
-      break;
-  }
-
-  // Mark the definition as code.
-  if (!dfn.querySelector("code") && !dfn.closest("code") && dfn.children) {
-    wrapInner(dfn, dfn.ownerDocument.createElement("code"));
-  }
-  return dfn;
-}
-
-function getDataType(idlStruct) {
-  const { idlType, baseName, generic, type, body, union } = idlStruct;
-  if (typeof idlType === "string") return idlType;
-  if (generic) return generic.value;
-  if (type === "operation") return getDataType(body.idlType);
-  // join on "|" handles for "unsigned short" etc.
-  if (union) return idlType.map(getDataType).join("|");
-  return baseName ? baseName : getDataType(idlType);
 }
 
 export function run(conf) {

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -10,7 +10,7 @@ import hb from "handlebars.runtime";
 import css from "../deps/text!core/css/webidl.css";
 import tmpls from "templates";
 import { normalizePadding, reindent } from "./utils";
-import { findDfn_ } from "./dfn-finder";
+import { findDfn } from "./dfn-finder";
 
 export const name = "core/webidl";
 
@@ -582,95 +582,6 @@ function linkDefinitions(parse, definitionMap, parent, idlElem) {
       }
       defn.dfn = findDfn(defn, parent, name, definitionMap, idlElem);
     });
-}
-
-// This function looks for a <dfn> element whose title is 'name' and
-// that is "for" 'parent', which is the empty string when 'name'
-// refers to a top-level entity. For top-level entities, <dfn>
-// elements that inherit a non-empty [dfn-for] attribute are also
-// counted as matching.
-//
-// When a matching <dfn> is found, it's given <code> formatting,
-// marked as an IDL definition, and returned. If no <dfn> is found,
-// the function returns 'undefined'.
-function findDfn(defn, parent, name, definitionMap, idlElem) {
-  return (
-    findAttributeDfn(defn, parent, name, definitionMap, idlElem) ||
-    findOperationDfn(defn, parent, name, definitionMap, idlElem) ||
-    findDfn_(defn, { parent, name, definitionMap, idlElem })
-  );
-}
-
-function findAttributeDfn(defn, parent, name, definitionMap, idlElem) {
-  if (defn.type !== "attribute") {
-    return;
-  }
-  parent = parent.toLowerCase();
-  const asLocalName = name.toLowerCase();
-  const asQualifiedName = parent + "." + asLocalName;
-  let dfn;
-  if (definitionMap[asQualifiedName] || definitionMap[asLocalName]) {
-    dfn = findDfn_(defn, { parent, name: asLocalName, definitionMap, idlElem });
-  }
-  if (!dfn) {
-    return; // try finding dfn using name, using normal search path...
-  }
-  const lt = dfn.dataset.lt ? dfn.dataset.lt.split("|") : [];
-  lt.push(asQualifiedName, asLocalName);
-  dfn.dataset.lt = [...new Set(lt)].join("|");
-  return dfn;
-}
-
-function findOperationDfn(defn, parent, name, definitionMap, idlElem) {
-  if (defn.type !== "operation") {
-    return;
-  }
-  // Overloads all have unique names
-  if (name.search("!overload") !== -1) {
-    return;
-  }
-  parent = parent.toLowerCase();
-  // Allow linking to both "method()" and "method" name.
-  const asLocalName = name.toLowerCase();
-  const asMethodName = asLocalName + "()";
-  const asQualifiedName = parent + "." + asLocalName;
-  const asFullyQualifiedName = asQualifiedName + "()";
-
-  if (
-    definitionMap[asMethodName] ||
-    definitionMap[asFullyQualifiedName.toLowerCase()]
-  ) {
-    const lookupName = definitionMap[asMethodName]
-      ? asMethodName
-      : asFullyQualifiedName;
-    const dfn = findDfn_(defn, {
-      parent,
-      name: lookupName,
-      definitionMap,
-      idlElem,
-    });
-    if (!dfn) {
-      return; // try finding dfn using name, using normal search path...
-    }
-    const lt = dfn.dataset.lt ? dfn.dataset.lt.split("|") : [];
-    lt.push(asFullyQualifiedName, asQualifiedName, lookupName, asLocalName);
-    dfn.dataset.lt = lt.join("|");
-    if (!definitionMap[asLocalName]) {
-      definitionMap[asLocalName] = [];
-    }
-    definitionMap[asLocalName].push(dfn);
-    return dfn;
-  }
-  // no method alias, so let's find the dfn and add it
-  const dfn = findDfn_(defn, { parent, name, definitionMap, idlElem });
-  if (!dfn) {
-    return;
-  }
-  const lt = dfn.dataset.lt ? dfn.dataset.lt.split("|") : [];
-  lt.push(asMethodName, name);
-  dfn.dataset.lt = lt.reverse().join("|");
-  definitionMap[asMethodName] = [dfn];
-  return dfn;
 }
 
 export function run(conf) {


### PR DESCRIPTION
findDfn() is an unreadable aircraft-carrier-sized function so this PR breaks it into pieces.

Some functions are still too long but should be more readable than before.