### PR TITLE
refactor(core/webidl): remove remnants of implements/ws

### DIFF
--- a/js/core/templates/webidl-contiguous/extended-attribute.html
+++ b/js/core/templates/webidl-contiguous/extended-attribute.html
@@ -2,5 +2,5 @@
 --}}{{{trivia extAttrs.trivia.open}}}[{{#join extAttrs.items ","
 }}{{{trivia trivia.name}}}<span class='{{extAttrClassName}}'><span class="extAttrName">{{name
 }}</span>{{#if rhs}}=<span class="extAttrRhs">{{#extAttrRhs rhs}}{{ this }}{{/extAttrRhs}}</span>{{/if
-}}{{#jsIf signature}}({{#joinNonWhitespace signature.arguments ","}}{{param this}}{{/joinNonWhitespace}}){{/jsIf
+}}{{#jsIf signature}}({{#join signature.arguments ","}}{{param this}}{{/join}}){{/jsIf
 }}</span>{{/join}}]

--- a/js/core/templates/webidl-contiguous/implements.html
+++ b/js/core/templates/webidl-contiguous/implements.html
@@ -1,2 +1,0 @@
-<span class='idlImplements'>{{extAttr obj}}{{{trivia
-obj.trivia.target}}}<a>{{obj.target}}</a> implements <a>{{obj.implements}}</a>;</span>

--- a/src/core/dfn-finder.js
+++ b/src/core/dfn-finder.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { pub } from "./pubsubhub";
 import { wrapInner } from "./utils";
 

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -239,7 +239,6 @@ const standardTypes = new Map([
   ["Buffer", "WEBIDL#idl-Buffer"],
   ["byte", "WEBIDL#idl-byte"],
   ["ByteString", "WEBIDL#idl-ByteString"],
-  ["Callback", "WEBIDL#idl-Callback"],
   ["DataView", "WEBIDL#idl-DataView"],
   ["DOMException", "WEBIDL#idl-DOMException"],
   ["DOMString", "WEBIDL#idl-DOMString"],

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -521,7 +521,7 @@ function linkDefinitions(parse, definitionMap, parent, idlElem) {
               operationNames[qualifiedName] = [];
             } else {
               overload = operationNames[qualifiedName].length;
-              name += "!overload-" + defn.overload;
+              name += "!overload-" + overload;
             }
             operationNames[fullyQualifiedName].push(defn);
             operationNames[qualifiedName].push(defn);

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -400,15 +400,14 @@ function writeAttribute(attr) {
 }
 
 function writeMethod(meth) {
-  const paramObjs = ((meth.body && meth.body.arguments) || [])
-    .map(it => {
-      const trivia = it.optional ? it.optional.trivia : "";
-      return idlParamTmpl({
-        obj: it,
-        optional: it.optional ? `${writeTrivia(trivia)}optional` : "",
-        variadic: it.variadic ? "..." : "",
-      });
+  const paramObjs = ((meth.body && meth.body.arguments) || []).map(it => {
+    const trivia = it.optional ? it.optional.trivia : "";
+    return idlParamTmpl({
+      obj: it,
+      optional: it.optional ? `${writeTrivia(trivia)}optional` : "",
+      variadic: it.variadic ? "..." : "",
     });
+  });
   const params = paramObjs.join(",");
   const modifiers = ["getter", "setter", "deleter", "stringifier", "static"];
   let special = "";

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -617,7 +617,7 @@ export function run(conf) {
         }
         conf.definitionMap[title].push(elem);
       });
-    idlElement.parentElement.replaceChild(newElement, idlElement);
+    idlElement.replaceWith(newElement);
     newElement.classList.add(...idlElement.classList);
   });
   document.normalize();

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -23,7 +23,6 @@ const idlEnumItemTmpl = tmpls["enum-item.html"];
 const idlEnumTmpl = tmpls["enum.html"];
 const idlExtAttributeTmpl = tmpls["extended-attribute.html"];
 const idlIncludesTmpl = tmpls["includes.html"];
-const idlImplementsTmpl = tmpls["implements.html"];
 const idlInterfaceTmpl = tmpls["interface.html"];
 const idlIterableLikeTmpl = tmpls["iterable-like.html"];
 const idlLineCommentTmpl = tmpls["line-comment.html"];
@@ -292,8 +291,6 @@ function writeDefinition(obj) {
       return idlTypedefTmpl(opt);
     case "includes":
       return idlIncludesTmpl(opt);
-    case "implements":
-      return idlImplementsTmpl(opt);
     case "interface":
       return writeInterfaceDefinition(opt);
     case "interface mixin":
@@ -459,7 +456,7 @@ function writeMember(memb) {
 function linkDefinitions(parse, definitionMap, parent, idlElem) {
   parse
     // Don't bother with any of these
-    .filter(({ type }) => !["includes", "implements", "eof"].includes(type))
+    .filter(({ type }) => !["includes", "eof"].includes(type))
     .forEach(defn => {
       let name;
       switch (defn.type) {


### PR DESCRIPTION
`implements` is gone, `ws` is also gone. Farewell!