### PR TITLE
refactor(core/webidl): split linkDefinitions()

### DIFF
--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -449,7 +449,7 @@ function linkDefinitions(parse, definitionMap, parent, idlElem) {
         case "dictionary":
         case "interface":
         case "interface mixin": {
-          idl += resolvePartial(defn);
+          idlId += resolvePartial(defn);
           linkDefinitions(defn.members, definitionMap, defn.name, idlElem);
           break;
         }
@@ -463,17 +463,6 @@ function linkDefinitions(parse, definitionMap, parent, idlElem) {
               idlElem
             );
           });
-          break;
-        // Top-level entities without linkable members.
-        case "callback":
-        case "typedef":
-        // Members of top-level entities.
-        case "attribute":
-        case "const":
-        case "field":
-        case "iterable":
-        case "maplike":
-        case "setlike":
           break;
         case "operation": {
           let overload;
@@ -493,13 +482,21 @@ function linkDefinitions(parse, definitionMap, parent, idlElem) {
             operationNames[qualifiedName] += 1;
           }
           if (!overload && defn.body && defn.body.arguments.length) {
-            idlId += "-" +
-              defn.body.arguments
-                .map(arg => arg.name.toLowerCase())
-                .join("-");
+            idlId +=
+              "-" +
+              defn.body.arguments.map(arg => arg.name.toLowerCase()).join("-");
           }
           break;
         }
+        case "callback":
+        case "typedef":
+        case "attribute":
+        case "const":
+        case "field":
+        case "iterable":
+        case "maplike":
+        case "setlike":
+          break;
         default:
           pub(
             "error",

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -488,21 +488,6 @@ function linkDefinitions(parse, definitionMap, parent, idlElem) {
           }
           break;
         }
-        case "callback":
-        case "typedef":
-        case "attribute":
-        case "const":
-        case "field":
-        case "iterable":
-        case "maplike":
-        case "setlike":
-          break;
-        default:
-          pub(
-            "error",
-            new Error(`ReSpec doesn't know about IDL type: \`${defn.type}\`.`)
-          );
-          return;
       }
       if (parent) {
         defn.linkFor = parent;

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -449,13 +449,7 @@ function linkDefinitions(parse, definitionMap, parent, idlElem) {
         case "dictionary":
         case "interface":
         case "interface mixin": {
-          if (defn.partial) {
-            if (!idlPartials[defn.name]) {
-              idlPartials[defn.name] = [];
-            }
-            idlPartials[defn.name].push(defn);
-            idlId += "-partial-" + idlPartials[defn.name].length;
-          }
+          idl += resolvePartial(defn);
           linkDefinitions(defn.members, definitionMap, defn.name, idlElem);
           break;
         }
@@ -519,6 +513,17 @@ function linkDefinitions(parse, definitionMap, parent, idlElem) {
       defn.dfn = findDfn(defn, parent, name, definitionMap, idlElem);
       defn.idlId = idlId;
     });
+}
+
+function resolvePartial(defn) {
+  if (!defn.partial) {
+    return "";
+  }
+  if (!idlPartials[defn.name]) {
+    idlPartials[defn.name] = 0;
+  }
+  idlPartials[defn.name] += 1;
+  return "-partial-" + idlPartials[defn.name];
 }
 
 function getIdlId(name, parentName) {

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -487,16 +487,16 @@ function linkDefinitions(parse, definitionMap, parent, idlElem) {
             const qualifiedName = parent + "." + name;
             const fullyQualifiedName = qualifiedName + "()";
             if (!operationNames[fullyQualifiedName]) {
-              operationNames[fullyQualifiedName] = [];
+              operationNames[fullyQualifiedName] = 0;
             }
             if (!operationNames[qualifiedName]) {
-              operationNames[qualifiedName] = [];
+              operationNames[qualifiedName] = 0;
             } else {
-              overload = operationNames[qualifiedName].length;
+              overload = operationNames[qualifiedName];
               name += "!overload-" + overload;
             }
-            operationNames[fullyQualifiedName].push(defn);
-            operationNames[qualifiedName].push(defn);
+            operationNames[fullyQualifiedName] += 1;
+            operationNames[qualifiedName] += 1;
           }
           if (!overload && defn.body && defn.body.arguments.length) {
             idlId += "-" +


### PR DESCRIPTION
Because shorter functions are easier to understand 👍 