### PR TITLE
refactor(core/webidl): remove unreachable branch

### DIFF
--- a/src/core/dfn-finder.js
+++ b/src/core/dfn-finder.js
@@ -34,6 +34,9 @@ const unlinkable = new Set(["maplike", "setlike", "stringifier"]);
  * @param {HTMLElement} idlElem
  */
 export function findDfn(defn, parent, name, definitionMap, idlElem) {
+  if (unlinkable.has(name)) {
+    return;
+  }
   const dfn = tryFindDfn(defn, parent, name, definitionMap);
   if (dfn) {
     return dfn;
@@ -151,9 +154,6 @@ function findOperationDfn(defn, parent, name, definitionMap) {
  * @param {Record<string, HTMLElement[]>} definitionMap
  */
 function findNormalDfn(defn, parent, name, definitionMap) {
-  if (unlinkable.has(name)) {
-    return;
-  }
   const parentLow = parent.toLowerCase();
   const nameLow =
     defn.type === "enum-value" && name === ""

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -114,15 +114,6 @@ function registerHelpers() {
     } else if (isDefaultJSON) {
       // If toJSON is not overridden, link directly to WebIDL spec.
       a.dataset.cite = "WEBIDL#default-tojson-operation";
-    } else {
-      // ambiguous match
-      a.dataset.noDefault = "";
-      a.dataset.linkFor = obj.linkFor ? obj.linkFor.toLowerCase() : "";
-      a.dataset.lt = obj.dfn
-        .toArray()
-        .filter(({ dataset }) => dataset && dataset.lt)
-        .map(({ dataset: { lt } }) => lt)
-        .join("|");
     }
     return a.outerHTML;
   });

--- a/tests/spec/core/webidl.html
+++ b/tests/spec/core/webidl.html
@@ -11,10 +11,10 @@
           ,   shortName:    "webidl"
           ,   editors:      [{ name: "Robin Berjon", url: "http://berjon.com/" }]
           ,   wg:           "ReSpec Hackin' Gang"
-          ,   wgURI:        "http://darobin.github.com/respec"
+          ,   wgURI:        "https://darobin.github.com/respec"
           ,   wgPublicList: "none"
-          ,   wgPatentURI:  "XXX"
-          ,   edDraftURI:   "http://darobin.github.com/respec"
+          ,   wgPatentURI:  "https://example.com/"
+          ,   edDraftURI:   "https://darobin.github.com/respec"
         };
     </script>
   </head>

--- a/tests/spec/core/webidl.html
+++ b/tests/spec/core/webidl.html
@@ -589,6 +589,7 @@
       <p id="enum-ref-without-link-for"><a>EnumBasic.one</a> may also be referenced with fully-qualified name.</p>
       <p><dfn data-dfn-for="EnumBasic">white space</dfn></p>
       <section id="enum-empty-sec" data-dfn-for="EmptyEnum">
+        <h2>Enumeration with an empty string</h2>
         <pre class="idl no-link-warnings">
         enum EmptyEnum {
           "",
@@ -713,6 +714,7 @@
       </p>
     </section>
     <section>
+      <h2>IDL block with arbitrary CSS classes</h2>
       <pre id='retain-css-classes' class='idl a b c overlarge'>
         interface NotTested {};
       </pre>


### PR DESCRIPTION
This else branch is unreachable because the function terminates early when no `obj.dfn`.

https://github.com/w3c/respec/blob/054887afb5ff8018321114fd21eee317f5956b41/src/core/webidl.js#L97-L100