### PR TITLE
refactor(core/dfn-finder): lt for empty enum value

### DIFF
--- a/src/core/dfn-finder.js
+++ b/src/core/dfn-finder.js
@@ -155,23 +155,20 @@ function findOperationDfn(defn, parent, name, definitionMap) {
  */
 function findNormalDfn(defn, parent, name, definitionMap) {
   const parentLow = parent.toLowerCase();
-  const nameLow =
-    defn.type === "enum-value" && name === ""
-      ? "the-empty-string"
-      : name.toLowerCase();
+  let resolvedName =
+    defn.type === "enum-value" && name === "" ? "the-empty-string" : name;
+  const nameLow = resolvedName.toLowerCase();
   let dfnForArray = definitionMap[nameLow];
   let dfns = getDfns(dfnForArray, parentLow, name, defn.type);
   // If we haven't found any definitions with explicit [for]
   // and [title], look for a dotted definition, "parent.name".
   if (dfns.length === 0 && parentLow !== "") {
-    const dottedName = parentLow + "." + nameLow;
-    dfnForArray = definitionMap[dottedName];
+    resolvedName = parentLow + "." + nameLow;
+    dfnForArray = definitionMap[resolvedName];
     if (dfnForArray !== undefined && dfnForArray.length === 1) {
       dfns = dfnForArray;
-      // Found it: update the definition to specify its [for] and data-lt.
-      delete definitionMap[dottedName];
-      dfns[0].dataset.dfnFor = parentLow;
-      dfns[0].dataset.lt = nameLow;
+      // Found it: register with its local name
+      delete definitionMap[resolvedName];
       if (definitionMap[nameLow] === undefined) {
         definitionMap[nameLow] = [];
       }
@@ -185,6 +182,9 @@ function findNormalDfn(defn, parent, name, definitionMap) {
     pub("error", msg);
   }
   if (dfns.length) {
+    if (name !== resolvedName) {
+      dfns[0].dataset.lt = resolvedName;
+    }
     return decorateDfn(dfns[0], defn, parentLow, nameLow);
   }
 }

--- a/src/core/jquery-enhanced.js
+++ b/src/core/jquery-enhanced.js
@@ -58,8 +58,9 @@ window.$.fn.linkTargets = function() {
 
 // Applied to an element, sets an ID for it (and returns it), using a specific prefix
 // if provided, and a specific text if given.
-window.$.fn.makeID = function(pfx = "", txt = "") {
-  return addId(this[0], pfx, txt);
+window.$.fn.makeID = function(pfx = "", txt = "", noLC = false) {
+  const elem = this[0];
+  return addId(elem, pfx, txt, noLC);
 };
 
 // Returns all the descendant text nodes of an element. Note that those nodes aren't

--- a/src/core/jquery-enhanced.js
+++ b/src/core/jquery-enhanced.js
@@ -58,9 +58,8 @@ window.$.fn.linkTargets = function() {
 
 // Applied to an element, sets an ID for it (and returns it), using a specific prefix
 // if provided, and a specific text if given.
-window.$.fn.makeID = function(pfx = "", txt = "", noLC = false) {
-  const elem = this[0];
-  return addId(elem, pfx, txt, noLC);
+window.$.fn.makeID = function(pfx = "", txt = "") {
+  return addId(this[0], pfx, txt);
 };
 
 // Returns all the descendant text nodes of an element. Note that those nodes aren't

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -588,18 +588,18 @@ export function flatten(collector, item) {
  * @param {Element} elem element
  * @param {String} pfx prefix
  * @param {String} txt text
- * @param {Boolean} noLC
+ * @param {Boolean} noLC do not convert to lowercase
  * @returns {String} generated (or existing) id for element
  */
-export function addId(elem, pfx = "", txt = "", noLC = false) {
+export function addId(elem, pfx = "", txt = "") {
   if (elem.id) {
     return elem.id;
   }
   if (!txt) {
     txt = (elem.title ? elem.title : elem.textContent).trim();
   }
-  let id = noLC ? txt : txt.toLowerCase();
-  id = id
+  let id = txt
+    .toLowerCase()
     .trim()
     .normalize("NFD")
     .replace(/[\u0300-\u036f]/g, "")
@@ -658,7 +658,7 @@ export function getTextNodes(el, exclusions = []) {
  *   the algorithm used for determining the actual title of a
  *   <dfn> element (but can apply to other as well).
  * if args.isDefinition is true, then the element is a definition, not a
- *   reference to a definition. Any @title or @lt will be replaced with
+ *   reference to a definition. Any @title will be replaced with
  *   @data-lt to be consistent with Bikeshed / Shepherd.
  * This method now *prefers* the data-lt attribute for the list of
  *   titles. That attribute is added by this method to dfn elements, so
@@ -713,7 +713,7 @@ export function getDfnTitles(elem, args) {
 /**
  * For an element (usually <a>), returns an array of targets that
  * element might refer to, of the form
- * @typedef {for: 'interfacename', title: 'membername'} LinkTarget
+ * @typedef {{for: string, title: string}} LinkTarget
  *
  * For an element like:
  *  <p link-for="Int1"><a for="Int2">Int3.member</a></p>

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -591,15 +591,15 @@ export function flatten(collector, item) {
  * @param {Boolean} noLC do not convert to lowercase
  * @returns {String} generated (or existing) id for element
  */
-export function addId(elem, pfx = "", txt = "") {
+export function addId(elem, pfx = "", txt = "", noLC = false) {
   if (elem.id) {
     return elem.id;
   }
   if (!txt) {
     txt = (elem.title ? elem.title : elem.textContent).trim();
   }
-  let id = txt
-    .toLowerCase()
+  let id = noLC ? txt : txt.toLowerCase();
+  id = id
     .trim()
     .normalize("NFD")
     .replace(/[\u0300-\u036f]/g, "")

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -104,7 +104,6 @@ function registerHelpers() {
     const { dfn } = obj;
     // unambiguous match
     if (dfn) {
-      a.dataset.noDefault = "";
       a.dataset.linkFor = obj.linkFor ? obj.linkFor.toLowerCase() : "";
       a.dataset.lt = dfn.dataset.lt ? dfn.dataset.lt : "";
       // handle the empty string for enum values

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -105,11 +105,7 @@ function registerHelpers() {
     // unambiguous match
     if (dfn) {
       a.dataset.linkFor = obj.linkFor ? obj.linkFor.toLowerCase() : "";
-      a.dataset.lt = dfn.dataset.lt ? dfn.dataset.lt : "";
-      // handle the empty string for enum values
-      if (obj.idlType === "enum-value" && content === "") {
-        a.href = "#" + dfn.id;
-      }
+      a.dataset.lt = dfn.dataset.lt || "";
     } else if (isDefaultJSON) {
       // If toJSON is not overridden, link directly to WebIDL spec.
       a.dataset.cite = "WEBIDL#default-tojson-operation";


### PR DESCRIPTION
1. Remove `data-no-default` as nothing uses it
2. Remove the fourth argument from `addId` as nothing uses it.
3. Assign `data-lt` for empty enum value to handle it automatically

Currently we have three places to treat empty enum value in a special way (`util.getDfnTitles()`, `findNormalDfn()`, and `tryLink()`, respectively), and this PR removes one of them.