### PR TITLE
fix(tools/builder): source map from terser

### DIFF
--- a/tools/builder.js
+++ b/tools/builder.js
@@ -78,10 +78,13 @@ See original source for licenses: https://github.com/w3c/respec */
 window.respecVersion = "${version}";
 ${optimizedJs}
 require(['profile-${name}']);`;
+    const respecJsMap = sourceMap.replace(`"mappings": "`, `"mappings": ";;;;;;`);
     const result = terser.minify(respecJs, {
       toplevel: true,
       sourceMap: {
         filename: `respec-${name}.js`,
+        content: respecJsMap,
+        root: "../js/",
         url: `respec-${name}.build.js.map`,
       },
     });
@@ -90,7 +93,7 @@ require(['profile-${name}']);`;
     }
     const mapPath = path.dirname(outPath) + `/respec-${name}.build.js.map`;
     const promiseToWriteJs = fsp.writeFile(outPath, result.code, "utf-8");
-    const promiseToWriteMap = fsp.writeFile(mapPath, sourceMap, "utf-8");
+    const promiseToWriteMap = fsp.writeFile(mapPath, result.map, "utf-8");
     await Promise.all([promiseToWriteJs, promiseToWriteMap]);
   };
 }

--- a/tools/builder.js
+++ b/tools/builder.js
@@ -78,7 +78,10 @@ See original source for licenses: https://github.com/w3c/respec */
 window.respecVersion = "${version}";
 ${optimizedJs}
 require(['profile-${name}']);`;
-    const respecJsMap = sourceMap.replace(`"mappings": "`, `"mappings": ";;;;;;`);
+    const respecJsMap = sourceMap.replace(
+      `"mappings": "`,
+      `"mappings": ";;;;;;`
+    );
     const result = terser.minify(respecJs, {
       toplevel: true,
       sourceMap: {

--- a/tools/builder.js
+++ b/tools/builder.js
@@ -71,17 +71,10 @@ const usageSections = [
 function appendBoilerplate(outPath, version, name) {
   return async (optimizedJs, sourceMap) => {
     const respecJs = `"use strict";
-/* ReSpec ${version}
-Created by Robin Berjon, http://berjon.com/ (@robinberjon)
-Documentation: http://w3.org/respec/.
-See original source for licenses: https://github.com/w3c/respec */
 window.respecVersion = "${version}";
 ${optimizedJs}
 require(['profile-${name}']);`;
-    const respecJsMap = sourceMap.replace(
-      `"mappings": "`,
-      `"mappings": ";;;;;;`
-    );
+    const respecJsMap = sourceMap.replace(`"mappings": "`, `"mappings": ";;`);
     const result = terser.minify(respecJs, {
       toplevel: true,
       sourceMap: {


### PR DESCRIPTION
Currently we chooses source map from requirejs and ignores terser, causing broken source map. This fixes the issue.