### PR TITLE
Remove styleless CSS classes, round 1

### DIFF
--- a/js/core/templates/webidl-contiguous/const.html
+++ b/js/core/templates/webidl-contiguous/const.html
@@ -1,4 +1,4 @@
 <span class='idlConst' id="{{obj.idlId}}" data-idl data-title='{{obj.name}}'>{{extAttr obj
 }}{{{trivia obj.trivia.base}}}const<span class='idlType'>{{idlType obj}}</span>{{nullable
 }} <span class='idlName'>{{#tryLink obj}}{{obj.name}}{{/tryLink
-}}</span> = <span class='idlConstValue'>{{stringifyIdlConst obj.value}}</span>;</span>
+}}</span> = {{stringifyIdlConst obj.value}};</span>

--- a/js/core/templates/webidl-contiguous/dict-member.html
+++ b/js/core/templates/webidl-contiguous/dict-member.html
@@ -1,4 +1,4 @@
 <span class='idlMember' id="{{obj.idlId}}" data-idl data-title='{{obj.name}}'>{{extAttr obj
 }}{{{qualifiers}}}<span class='idlType'>{{{idlType obj}}}</span> <span class='idlName'>{{#tryLink
-obj}}{{obj.name}}{{/tryLink}}</span>{{#if obj.default}} = <span class='idlMemberValue'>{{
-stringifyIdlConst obj.default}}</span>{{/if}};</span>
+obj}}{{obj.name}}{{/tryLink}}</span>{{#if obj.default}} = {{
+stringifyIdlConst obj.default}}{{/if}};</span>

--- a/js/core/templates/webidl-contiguous/extended-attribute.html
+++ b/js/core/templates/webidl-contiguous/extended-attribute.html
@@ -1,6 +1,6 @@
 {{!-- extAttrs should match the structure at https://github.com/darobin/webidl2.js#extended-attributes.
 --}}{{{trivia extAttrs.trivia.open}}}[{{#join extAttrs.items ","
-}}{{{trivia trivia.name}}}<span class='{{extAttrClassName}}'><span class="extAttrName">{{name
+}}{{{trivia trivia.name}}}<span class='extAttr'><span class="extAttrName">{{name
 }}</span>{{#if rhs}}={{#extAttrRhs rhs}}{{ this }}{{/extAttrRhs}}{{/if
 }}{{#jsIf signature}}({{#join signature.arguments ","}}{{param this}}{{/join}}){{/jsIf
 }}</span>{{/join}}]

--- a/js/core/templates/webidl-contiguous/extended-attribute.html
+++ b/js/core/templates/webidl-contiguous/extended-attribute.html
@@ -1,6 +1,6 @@
 {{!-- extAttrs should match the structure at https://github.com/darobin/webidl2.js#extended-attributes.
 --}}{{{trivia extAttrs.trivia.open}}}[{{#join extAttrs.items ","
 }}{{{trivia trivia.name}}}<span class='{{extAttrClassName}}'><span class="extAttrName">{{name
-}}</span>{{#if rhs}}=<span class="extAttrRhs">{{#extAttrRhs rhs}}{{ this }}{{/extAttrRhs}}</span>{{/if
+}}</span>{{#if rhs}}={{#extAttrRhs rhs}}{{ this }}{{/extAttrRhs}}{{/if
 }}{{#jsIf signature}}({{#join signature.arguments ","}}{{param this}}{{/join}}){{/jsIf
 }}</span>{{/join}}]

--- a/js/core/templates/webidl-contiguous/extended-attribute.html
+++ b/js/core/templates/webidl-contiguous/extended-attribute.html
@@ -1,6 +1,6 @@
 {{!-- extAttrs should match the structure at https://github.com/darobin/webidl2.js#extended-attributes.
 --}}{{{trivia extAttrs.trivia.open}}}[{{#join extAttrs.items ","
-}}{{{trivia trivia.name}}}<span class='extAttr'><span class="extAttrName">{{name
-}}</span>{{#if rhs}}={{#extAttrRhs rhs}}{{ this }}{{/extAttrRhs}}{{/if
+}}{{{trivia trivia.name}}}<span class='extAttr'><a>{{name
+}}</a>{{#if rhs}}={{#extAttrRhs rhs}}{{ this }}{{/extAttrRhs}}{{/if
 }}{{#jsIf signature}}({{#join signature.arguments ","}}{{param this}}{{/join}}){{/jsIf
 }}</span>{{/join}}]

--- a/js/core/templates/webidl-contiguous/param.html
+++ b/js/core/templates/webidl-contiguous/param.html
@@ -1,5 +1,5 @@
 {{!-- obj is an instance of https://github.com/darobin/webidl2.js#arguments
---}}<span class='idlParam'>{{extAttr obj
+--}}{{extAttr obj
 }}{{{optional}}}<span class='idlType'>{{idlType obj}}{{variadic
 }}</span> <span class='idlParamName'>{{obj.escapedName}}</span>{{#if obj.default
-}} = <span class='idlDefaultValue'>{{stringifyIdlConst obj.default}}</span>{{/if}}</span>
+}} = <span class='idlDefaultValue'>{{stringifyIdlConst obj.default}}</span>{{/if}}

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -200,13 +200,10 @@ function extAttr(extAttrs) {
   const safeString = new hb.SafeString(idlExtAttributeTmpl(opt));
   const tmpParser = document.createElement("div");
   tmpParser.innerHTML = safeString;
-  Array.from(tmpParser.querySelectorAll(".extAttrName"))
+  Array.from(tmpParser.getElementsByTagName("a"))
     .filter(elem => extendedAttributesLinks.has(elem.textContent))
-    .forEach(elem => {
-      const a = elem.ownerDocument.createElement("a");
-      a.dataset.cite = extendedAttributesLinks.get(elem.textContent);
-      a.textContent = elem.textContent;
-      elem.replaceChild(a, elem.firstChild);
+    .forEach(a => {
+      a.dataset.cite = extendedAttributesLinks.get(a.textContent);
     });
   return new hb.SafeString(tmpParser.innerHTML);
 }

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -34,12 +34,6 @@ function registerHelpers() {
   hb.registerHelper("extAttr", obj => {
     return extAttr(obj.extAttrs);
   });
-  hb.registerHelper("extAttrClassName", function() {
-    const { name } = this;
-    return ["Constructor", "NamedConstructor"].includes(name)
-      ? "idlCtor"
-      : "extAttr";
-  });
   hb.registerHelper("extAttrRhs", (rhs, options) => {
     if (rhs.type === "identifier") {
       return options.fn(rhs.value);

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -185,10 +185,10 @@ describe("Core - WebIDL", () => {
 
     target = doc.getElementById("if-identifier-list");
     text = "[Global=Window, Exposed=(Window,Worker)] interface SuperStar {};";
-    const rhs = target.querySelectorAll(".extAttrRhs");
+    const rhs = target.querySelectorAll(".extAttr");
     expect(target.textContent).toEqual(text);
-    expect(rhs[0].textContent).toEqual("Window");
-    expect(rhs[1].textContent).toEqual("(Window,Worker)");
+    expect(rhs[0].textContent).toEqual("Global=Window");
+    expect(rhs[1].textContent).toEqual("Exposed=(Window,Worker)");
 
     target = doc.getElementById("if-inheritance");
     text = "interface SuperStar : HyperStar {};";
@@ -269,7 +269,7 @@ describe("Core - WebIDL", () => {
     const ctors = target.getElementsByClassName("idlCtor");
     expect(ctors.length).toEqual(2);
     const ctor = ctors[1];
-    expect(ctor.querySelector(".extAttrRhs").textContent).toEqual("Sun");
+    expect(ctor.textContent).toEqual("NamedConstructor=Sun(boolean bar, Date foo)");
     const params = [...ctor.getElementsByClassName("idlParam")];
     expect(params.length).toEqual(2);
     expect(params.filter(p => p.textContent.includes("Date")).length).toEqual(

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -178,10 +178,9 @@ describe("Core - WebIDL", () => {
     target = doc.getElementById("if-extended-attribute");
     text = "[Something, Constructor()] " + text;
     expect(target.textContent).toEqual(text);
-    expect(target.querySelector(".extAttr").textContent).toEqual("Something");
-    expect(target.querySelector(".idlCtor").textContent).toEqual(
-      "Constructor()"
-    );
+    const extAttrs = target.querySelectorAll(".extAttr");
+    expect(extAttrs[0].textContent).toEqual("Something");
+    expect(extAttrs[1].textContent).toEqual("Constructor()");
 
     target = doc.getElementById("if-identifier-list");
     text = "[Global=Window, Exposed=(Window,Worker)] interface SuperStar {};";
@@ -235,9 +234,9 @@ describe("Core - WebIDL", () => {
       " Constructor(boolean bar, sequence<double> foo, Promise<double> blah)]\n" +
       "interface SuperStar {};";
     expect(target.textContent).toEqual(text);
-    const ctors = target.getElementsByClassName("idlCtor");
-    expect(ctors.length).toEqual(2);
-    const ctor = ctors[1];
+    const ctors = target.getElementsByClassName("extAttr");
+    expect(ctors.length).toEqual(3);
+    const ctor = ctors[2];
     expect(ctor.querySelector(".extAttrName").textContent).toEqual(
       "Constructor"
     );
@@ -266,9 +265,9 @@ describe("Core - WebIDL", () => {
       " NamedConstructor=Sun(boolean bar, Date foo)]\n" +
       "interface SuperStar {};";
     expect(target.textContent).toEqual(text);
-    const ctors = target.getElementsByClassName("idlCtor");
-    expect(ctors.length).toEqual(2);
-    const ctor = ctors[1];
+    const ctors = target.getElementsByClassName("extAttr");
+    expect(ctors.length).toEqual(3);
+    const ctor = ctors[2];
     expect(ctor.textContent).toEqual("NamedConstructor=Sun(boolean bar, Date foo)");
     const params = [...ctor.getElementsByClassName("idlParam")];
     expect(params.length).toEqual(2);

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -238,7 +238,7 @@ describe("Core - WebIDL", () => {
     expect(ctors.length).toEqual(3);
     const ctor = ctors[2];
     expect(ctor.querySelector("a").textContent).toEqual("Constructor");
-    const params = [...ctor.getElementsByClassName("idlParam")];
+    const params = [...ctor.getElementsByClassName("idlType")];
     expect(params.length).toEqual(3);
     expect(
       params.filter(p => p.textContent.includes("sequence")).length
@@ -246,9 +246,7 @@ describe("Core - WebIDL", () => {
     expect(
       params.filter(p => p.textContent.includes("Promise")).length
     ).toEqual(1);
-    expect(ctor.querySelector(".idlParam .idlType").textContent).toEqual(
-      "boolean"
-    );
+    expect(params[0].textContent).toEqual("boolean");
 
     target = doc.getElementById("ctor-noea");
     text = "[Constructor] interface SuperStar {};";
@@ -269,14 +267,12 @@ describe("Core - WebIDL", () => {
     expect(ctor.textContent).toEqual(
       "NamedConstructor=Sun(boolean bar, Date foo)"
     );
-    const params = [...ctor.getElementsByClassName("idlParam")];
+    const params = [...ctor.getElementsByClassName("idlType")];
     expect(params.length).toEqual(2);
     expect(params.filter(p => p.textContent.includes("Date")).length).toEqual(
       1
     );
-    expect(ctor.querySelector(".idlParam .idlType").textContent).toEqual(
-      "boolean"
-    );
+    expect(params[0].textContent).toEqual("boolean");
   });
 
   it("should handle constants", () => {
@@ -802,10 +798,10 @@ callback CallBack = Z? (X x, optional Y y, /*trivia*/ optional Z z);
     expect(target.querySelector(".idlType").textContent).toEqual(
       " unsigned long long?"
     );
-    let prm = target.querySelectorAll(".idlCallback .idlParam");
+    let prm = target.querySelectorAll(".idlParamName");
     expect(prm.length).toEqual(1);
-    expect(prm[0].querySelector(".idlType").textContent).toEqual(" any");
-    expect(prm[0].querySelector(".idlParamName").textContent).toEqual("value");
+    expect(target.querySelectorAll(".idlType")[1].textContent).toEqual(" any");
+    expect(prm[0].textContent).toEqual("value");
 
     // Links and IDs.
     expect(
@@ -818,12 +814,13 @@ callback CallBack = Z? (X x, optional Y y, /*trivia*/ optional Z z);
     target = doc.getElementById("cb-mult-args");
     text = "callback SortCallback = void (any a, any b);";
     expect(target.textContent).toEqual(text);
-    prm = target.querySelectorAll(".idlCallback .idlParam");
+    prm = target.querySelectorAll(".idlParamName");
     expect(prm.length).toEqual(2);
-    expect(prm[0].querySelector(".idlType").textContent).toEqual("any");
-    expect(prm[0].querySelector(".idlParamName").textContent).toEqual("a");
-    expect(prm[1].querySelector(".idlType").textContent).toEqual(" any");
-    expect(prm[1].querySelector(".idlParamName").textContent).toEqual("b");
+    const idlTypes = target.getElementsByClassName("idlType");
+    expect(idlTypes[1].textContent).toEqual("any");
+    expect(prm[0].textContent).toEqual("a");
+    expect(idlTypes[2].textContent).toEqual(" any");
+    expect(prm[1].textContent).toEqual("b");
   });
 
   it("should handle typedefs", () => {

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -325,7 +325,6 @@ describe("Core - WebIDL", () => {
     const const1 = target.querySelector(".idlConst");
     expect(const1.querySelector(".idlType").textContent).toEqual(" boolean");
     expect(const1.querySelector(".idlName").textContent).toEqual("test");
-    expect(const1.querySelector(".idlConstValue").textContent).toEqual("true");
     expect(
       consts[consts.length - 1].querySelectorAll(".extAttr").length
     ).toEqual(1);
@@ -642,9 +641,6 @@ interface ReadOnlySetLike {
       "\n  // 1\n  DOMString"
     );
     expect(member.querySelector(".idlName").textContent).toEqual("value");
-    expect(
-      members[members.length - 1].querySelector(".idlMemberValue").textContent
-    ).toEqual('"blah blah"');
 
     target = doc.getElementById("dict-required-fields");
     text =

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -237,9 +237,7 @@ describe("Core - WebIDL", () => {
     const ctors = target.getElementsByClassName("extAttr");
     expect(ctors.length).toEqual(3);
     const ctor = ctors[2];
-    expect(ctor.querySelector(".extAttrName").textContent).toEqual(
-      "Constructor"
-    );
+    expect(ctor.querySelector("a").textContent).toEqual("Constructor");
     const params = [...ctor.getElementsByClassName("idlParam")];
     expect(params.length).toEqual(3);
     expect(
@@ -268,7 +266,9 @@ describe("Core - WebIDL", () => {
     const ctors = target.getElementsByClassName("extAttr");
     expect(ctors.length).toEqual(3);
     const ctor = ctors[2];
-    expect(ctor.textContent).toEqual("NamedConstructor=Sun(boolean bar, Date foo)");
+    expect(ctor.textContent).toEqual(
+      "NamedConstructor=Sun(boolean bar, Date foo)"
+    );
     const params = [...ctor.getElementsByClassName("idlParam")];
     expect(params.length).toEqual(2);
     expect(params.filter(p => p.textContent.includes("Date")).length).toEqual(


### PR DESCRIPTION
Those are solely for testing purpose, which just tests their existence. We don't need them as we already checks the whole `<pre>` text content.

Related to #1917.