### PR TITLE
refactor: array-only flatten(), etc.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7985,7 +7985,7 @@
       "dependencies": {
         "ansi-escapes": {
           "version": "3.1.0",
-          "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
           "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
         },
         "chardet": {

--- a/src/core/dfn-finder.js
+++ b/src/core/dfn-finder.js
@@ -28,12 +28,16 @@ const unlinkable = new Set(["maplike", "setlike", "stringifier"]);
  * marked as an IDL definition, and returned. If no <dfn> is found,
  * the function returns 'undefined'.
  * @param {*} defn
- * @param {string} parent
  * @param {string} name
  * @param {Record<string, HTMLElement[]>} definitionMap
- * @param {HTMLElement} idlElem
+ * @param {{ parent?: string; suppressWarnings?: boolean }} options
  */
-export function findDfn(defn, parent, name, definitionMap, idlElem) {
+export function findDfn(
+  defn,
+  name,
+  definitionMap,
+  { parent = "", suppressWarnings = false } = {}
+) {
   if (unlinkable.has(name)) {
     return;
   }
@@ -41,8 +45,7 @@ export function findDfn(defn, parent, name, definitionMap, idlElem) {
   if (dfn) {
     return dfn;
   }
-  const showWarnings =
-    idlElem && name && !idlElem.classList.contains("no-link-warnings");
+  const showWarnings = name && !suppressWarnings;
   if (showWarnings) {
     const styledName = defn.type === "operation" ? `${name}()` : name;
     const ofParent = parent ? ` \`${parent}\`'s` : "";

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -131,7 +131,7 @@ export async function run(conf) {
     });
     if (!foundDfn && linkTargets.length !== 0) {
       // ignore WebIDL
-      if (!ant.closest("pre.idl, span.idlMemberType, span.idlTypedefType")) {
+      if (!ant.closest("pre.idl")) {
         if (ant.dataset.cite === "") {
           badLinks.push(ant);
         } else {

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -564,20 +564,16 @@ export async function fetchAndCache(request, maxAge = 86400000) {
 /**
  * Spreads one iterable into another.
  *
- * @param {Iterable} collector
- * @param {any|Iterable} item
+ * @param {Array} collector
+ * @param {any|Array} item
  * @returns {Array}
  */
 export function flatten(collector, item) {
-  const isObject = typeof item === "object";
-  const isIterable =
-    Object(item)[Symbol.iterator] && typeof item.values === "function";
-  const items = !isObject
+  const items = !Array.isArray(item)
     ? [item]
-    : isIterable
-    ? [...item.values()].reduce(flatten, [])
-    : Object.values(item);
-  return [...collector, ...items];
+    : [...item.values()].reduce(flatten, []);
+  collector.push(...items);
+  return collector;
 }
 
 // --- DOM HELPERS -------------------------------

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -533,20 +533,18 @@ export function run(conf) {
     linkDefinitions(parse, conf.definitionMap, "", idlElement);
     const newElement = makeMarkup(parse);
     if (idlElement.id) newElement.id = idlElement.id;
-    newElement
-      .querySelectorAll("[data-idl]")
-      .forEach(elem => {
-        const title = elem.dataset.title.toLowerCase();
-        // Select the nearest ancestor element that can contain members.
-        const parent = elem.parentElement.closest("[data-idl][data-title]");
-        if (parent) {
-          elem.dataset.dfnFor = parent.dataset.title.toLowerCase();
-        }
-        if (!conf.definitionMap[title]) {
-          conf.definitionMap[title] = [];
-        }
-        conf.definitionMap[title].push(elem);
-      });
+    newElement.querySelectorAll("[data-idl]").forEach(elem => {
+      const title = elem.dataset.title.toLowerCase();
+      // Select the nearest ancestor element that can contain members.
+      const parent = elem.parentElement.closest("[data-idl][data-title]");
+      if (parent) {
+        elem.dataset.dfnFor = parent.dataset.title.toLowerCase();
+      }
+      if (!conf.definitionMap[title]) {
+        conf.definitionMap[title] = [];
+      }
+      conf.definitionMap[title].push(elem);
+    });
     idlElement.replaceWith(newElement);
     newElement.classList.add(...idlElement.classList);
   });

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -534,15 +534,11 @@ export function run(conf) {
     const newElement = makeMarkup(parse);
     if (idlElement.id) newElement.id = idlElement.id;
     newElement
-      .querySelectorAll(
-        ".idlAttribute,.idlCallback,.idlConst,.idlDictionary,.idlEnum,.idlField,.idlInterface,.idlMember,.idlMethod,.idlMaplike,.idlIterable,.idlTypedef"
-      )
+      .querySelectorAll("[data-idl]")
       .forEach(elem => {
         const title = elem.dataset.title.toLowerCase();
         // Select the nearest ancestor element that can contain members.
-        const parent = elem.parentElement.closest(
-          ".idlDictionary,.idlEnum,.idlInterface"
-        );
+        const parent = elem.parentElement.closest("[data-idl][data-title]");
         if (parent) {
           elem.dataset.dfnFor = parent.dataset.title.toLowerCase();
         }

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -448,7 +448,10 @@ function linkDefinitions(parse, definitionMap, parent, idlElem) {
       if (parent) {
         defn.linkFor = parent;
       }
-      defn.dfn = findDfn(defn, parent, name, definitionMap, idlElem);
+      defn.dfn = findDfn(defn, name, definitionMap, {
+        parent,
+        suppressWarnings: idlElem.classList.contains("no-link-warnings"),
+      });
       defn.idlId = idlId;
     });
 }

--- a/tests/spec/core/utils-spec.js
+++ b/tests/spec/core/utils-spec.js
@@ -486,18 +486,17 @@ describe("Core - Utils", () => {
   });
 
   describe("flatten()", () => {
-    it("flattens iterables", () => {
+    it("flattens arrays", () => {
       expect(utils.flatten(["pass"], [123, 456])).toEqual(["pass", 123, 456]);
       const map = new Map([["key-fail", "pass"], ["anotherKey", 123]]);
-      expect(utils.flatten([], map)).toEqual(["pass", 123]);
-      expect(utils.flatten([], new Set(["pass", 123]))).toEqual(["pass", 123]);
-      expect(utils.flatten([], { "key-fail": "pass", other: 123 })).toEqual([
-        "pass",
-        123,
-      ]);
+      expect(utils.flatten([], map)).toEqual([map]);
+      const set = new Set(["pass", 123]);
+      expect(utils.flatten([], set)).toEqual([set]);
+      const object = { "key-fail": "pass", other: 123 };
+      expect(utils.flatten([], object)).toEqual([object]);
     });
 
-    it("flattens nested iterables as a reducer", () => {
+    it("flattens nested arrays as a reducer", () => {
       const input = [
         new Map([["fail", "123"]]),
         new Set([456]),
@@ -505,7 +504,7 @@ describe("Core - Utils", () => {
         { key: "11" },
       ];
       const output = input.reduce(utils.flatten, ["first", 0]);
-      expect(output).toEqual(["first", 0, "123", 456, 7, 8, 9, 10, "11"]);
+      expect(output).toEqual(["first", 0, input[0], input[1], 7, 8, input[2][1][1][0], input[3]]);
     });
 
     it("flattens sparse and arrays", () => {


### PR DESCRIPTION
I tried flattening arrays filled with `HTMLElement`s and then found the current `flatten()` also flattens `HTMLAnchorElement` (which is iterable)! This PR makes the function more align with the suggested [`Array.prototype.flat`](https://tc39.github.io/proposal-flatMap/).