### PR TITLE
refactor: import hyperHTML as a module, etc.

### DIFF
--- a/src/core/best-practices.js
+++ b/src/core/best-practices.js
@@ -4,7 +4,7 @@
 // Best practices are marked up with span.practicelab.
 import css from "../deps/text!core/css/bp.css";
 import { pub } from "./pubsubhub";
-import "../deps/hyperhtml";
+import hyperHTML from "../deps/hyperhtml";
 
 export const name = "core/best-practices";
 

--- a/src/core/caniuse.js
+++ b/src/core/caniuse.js
@@ -5,7 +5,7 @@
  */
 import { semverCompare } from "./utils";
 import { pub, sub } from "./pubsubhub";
-import "../deps/hyperhtml";
+import hyperHTML from "../deps/hyperhtml";
 import { createResourceHint, fetchAndCache } from "./utils";
 import caniuseCss from "../deps/text!core/css/caniuse.css";
 

--- a/src/core/data-tests.js
+++ b/src/core/data-tests.js
@@ -106,6 +106,6 @@ export function run(conf) {
     })
     .forEach(({ elem, details }) => {
       delete elem.dataset.tests;
-      elem.insertAdjacentElement("beforeend", details);
+      elem.append(details);
     });
 }

--- a/src/core/data-tests.js
+++ b/src/core/data-tests.js
@@ -10,6 +10,7 @@
  */
 import { pub } from "./pubsubhub";
 import { lang as defaultLang } from "./l10n";
+import hyperHTML from "../deps/hyperhtml";
 const l10n = {
   en: {
     missing_test_suite_uri:

--- a/src/core/examples.js
+++ b/src/core/examples.js
@@ -6,7 +6,7 @@
 // be used by a containing shell to extract all examples.
 
 import { pub } from "./pubsubhub";
-import "../deps/hyperhtml";
+import hyperHTML from "../deps/hyperhtml";
 import css from "../deps/text!core/css/examples.css";
 import { reindent, addId } from "./utils";
 

--- a/src/core/exporter.js
+++ b/src/core/exporter.js
@@ -7,7 +7,7 @@
 
 import { removeReSpec } from "./utils";
 import { pub } from "./pubsubhub";
-import "../deps/hyperhtml";
+import hyperHTML from "../deps/hyperhtml";
 
 const mimeTypes = new Map([["text/html", "html"], ["application/xml", "xml"]]);
 

--- a/src/core/id-headers.js
+++ b/src/core/id-headers.js
@@ -4,6 +4,7 @@
 
 export const name = "core/id-headers";
 import { addId } from "./utils";
+import hyperHTML from "../deps/hyperhtml";
 
 export function run(conf) {
   document

--- a/src/core/inline-idl-parser.js
+++ b/src/core/inline-idl-parser.js
@@ -13,6 +13,8 @@
  *  { base: "Dictionary", member: "member" }
  */
 
+import hyperHTML from "../deps/hyperhtml";
+
 const methodRegex = /\((.*)\)$/;
 const idlSplitRegex = /\b\.\b|\.(?=\[\[)/;
 const dictionaryRegex = /(\w+)\["(\w+)"\]/;

--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -14,7 +14,7 @@
 //    key word was used.  NOTE: While each member is a counter, at this time
 //    the counter is not used.
 import { pub } from "./pubsubhub";
-import "../deps/hyperhtml";
+import hyperHTML from "../deps/hyperhtml";
 import { getTextNodes, refTypeFromContext } from "./utils";
 import { idlStringToHtml } from "./inline-idl-parser";
 export const name = "core/inlines";

--- a/src/core/issues-notes.js
+++ b/src/core/issues-notes.js
@@ -12,7 +12,7 @@
 // manually numbered, a link to the issue is created using issueBase and the issue number
 import { pub } from "./pubsubhub";
 import css from "../deps/text!core/css/issues-notes.css";
-import "../deps/hyperhtml";
+import hyperHTML from "../deps/hyperhtml";
 import { fetchAndCache } from "./utils";
 export const name = "core/issues-notes";
 

--- a/src/core/markdown.js
+++ b/src/core/markdown.js
@@ -221,6 +221,6 @@ export function run(conf) {
   const fragment = structure(newBody, document);
   // Frankenstein the whole thing back together
   newBody.appendChild(fragment);
-  newBody.insertAdjacentElement("afterbegin", rsUI);
+  newBody.prepend(rsUI);
   document.body.parentNode.replaceChild(newBody, document.body);
 }

--- a/src/core/render-biblio.js
+++ b/src/core/render-biblio.js
@@ -1,7 +1,7 @@
 // Module core/render-biblio
 // renders the biblio data pre-processed in core/biblio
 
-import "../deps/hyperhtml";
+import hyperHTML from "../deps/hyperhtml";
 import { addId } from "./utils";
 import { pub } from "./pubsubhub";
 

--- a/src/core/requirements.js
+++ b/src/core/requirements.js
@@ -10,7 +10,7 @@
 //     element with its href pointing to the requirement it should be referencing
 //     and a class of "reqRef".
 import { pub } from "./pubsubhub";
-import "../deps/hyperhtml";
+import hyperHTML from "../deps/hyperhtml";
 
 export const name = "core/requirements";
 

--- a/src/core/ui.js
+++ b/src/core/ui.js
@@ -14,6 +14,7 @@ import { sub } from "./pubsubhub";
 import css from "../deps/text!ui/ui.css";
 import { markdownToHtml } from "./utils";
 import "./jquery-enhanced";
+import "../deps/hyperhtml";
 export const name = "core/ui";
 
 // Opportunistically inserts the style, with the chance to reduce some FOUC
@@ -34,7 +35,7 @@ function ariaDecorate(elem, ariaMap) {
   }, elem);
 }
 
-const $respecUI = $("<div id='respec-ui' class='removeOnSave' hidden></div>");
+const respecUI = hyperHTML`<div id='respec-ui' class='removeOnSave' hidden></div>`;
 const $menu = $(
   "<ul id=respec-menu role=menu aria-labelledby='respec-pill' hidden></ul>"
 );
@@ -44,24 +45,23 @@ const errors = [];
 const warnings = [];
 const buttons = {};
 
-sub("start-all", () => document.body.prepend($respecUI[0]), { once: true });
-sub("end-all", () => document.body.prepend($respecUI[0]), { once: true });
+sub("start-all", () => document.body.prepend(respecUI), { once: true });
+sub("end-all", () => document.body.prepend(respecUI), { once: true });
 
 const $respecPill = $("<button id='respec-pill' disabled>ReSpec</button>");
-$respecPill
-  .click(function(e) {
-    e.stopPropagation();
-    if ($menu[0].hidden) {
-      $menu[0].classList.remove("respec-hidden");
-      $menu[0].classList.add("respec-visible");
-    } else {
-      $menu[0].classList.add("respec-hidden");
-      $menu[0].classList.remove("respec-visible");
-    }
-    this.setAttribute("aria-expanded", String($menu[0].hidden));
-    $menu[0].hidden = !$menu[0].hidden;
-  })
-  .appendTo($respecUI);
+respecUI.appendChild($respecPill[0]);
+$respecPill.click(function(e) {
+  e.stopPropagation();
+  if ($menu[0].hidden) {
+    $menu[0].classList.remove("respec-hidden");
+    $menu[0].classList.add("respec-visible");
+  } else {
+    $menu[0].classList.add("respec-hidden");
+    $menu[0].classList.remove("respec-visible");
+  }
+  this.setAttribute("aria-expanded", String($menu[0].hidden));
+  $menu[0].hidden = !$menu[0].hidden;
+});
 document.documentElement.addEventListener("click", () => {
   if (!$menu[0].hidden) {
     $menu[0].classList.remove("respec-visible");
@@ -69,7 +69,7 @@ document.documentElement.addEventListener("click", () => {
     $menu[0].hidden = true;
   }
 });
-$menu.appendTo($respecUI);
+respecUI.appendChild($menu[0]);
 
 const ariaMap = new Map([
   ["controls", "respec-menu"],
@@ -92,7 +92,7 @@ function errWarn(msg, arr, butName, title) {
       arr.length +
       "</button>"
   )
-    .appendTo($respecUI)
+    .appendTo(respecUI)
     .click(function() {
       this.setAttribute("aria-expanded", "true");
       const $ul = $("<ol class='respec-" + butName + "-list'></ol>");
@@ -165,13 +165,13 @@ function errWarn(msg, arr, butName, title) {
 export const ui = {
   show: function() {
     try {
-      $respecUI[0].hidden = false;
+      respecUI.hidden = false;
     } catch (err) {
       console.error(err);
     }
   },
   hide: function() {
-    $respecUI[0].hidden = true;
+    respecUI.hidden = true;
   },
   enable: function() {
     $respecPill[0].removeAttribute("disabled");

--- a/src/core/ui.js
+++ b/src/core/ui.js
@@ -44,20 +44,8 @@ const errors = [];
 const warnings = [];
 const buttons = {};
 
-sub(
-  "start-all",
-  () => {
-    document.body.insertAdjacentElement("afterbegin", $respecUI[0]);
-  },
-  { once: true }
-);
-sub(
-  "end-all",
-  () => {
-    document.body.insertAdjacentElement("afterbegin", $respecUI[0]);
-  },
-  { once: true }
-);
+sub("start-all", () => document.body.prepend($respecUI[0]), { once: true });
+sub("end-all", () => document.body.prepend($respecUI[0]), { once: true });
 
 const $respecPill = $("<button id='respec-pill' disabled>ReSpec</button>");
 $respecPill

--- a/src/core/ui.js
+++ b/src/core/ui.js
@@ -14,7 +14,7 @@ import { sub } from "./pubsubhub";
 import css from "../deps/text!ui/ui.css";
 import { markdownToHtml } from "./utils";
 import "./jquery-enhanced";
-import "../deps/hyperhtml";
+import hyperHTML from "../deps/hyperhtml";
 export const name = "core/ui";
 
 // Opportunistically inserts the style, with the chance to reduce some FOUC

--- a/src/core/webidl-index.js
+++ b/src/core/webidl-index.js
@@ -27,7 +27,7 @@ export function run() {
     } else {
       header.innerHTML = "IDL Index";
     }
-    idlIndexSec.insertAdjacentElement("afterbegin", header);
+    idlIndexSec.prepend(header);
   }
   if (!document.querySelector("pre.idl")) {
     const text = "This specification doesn't declare any Web IDL.";

--- a/src/ui/about-respec.js
+++ b/src/ui/about-respec.js
@@ -1,6 +1,6 @@
 // Module ui/about-respec
 // A simple about dialog with pointer to the help
-import "../deps/hyperhtml";
+import hyperHTML from "../deps/hyperhtml";
 import { ui } from "../core/ui";
 import { l10n, lang } from "../core/l10n";
 

--- a/src/ui/about-respec.js
+++ b/src/ui/about-respec.js
@@ -1,8 +1,8 @@
 // Module ui/about-respec
 // A simple about dialog with pointer to the help
-import "deps/hyperhtml";
-import { ui } from "core/ui";
-import { l10n, lang } from "core/l10n";
+import "../deps/hyperhtml";
+import { ui } from "../core/ui";
+import { l10n, lang } from "../core/l10n";
 
 // window.respecVersion is added at build time (see tools/builder.js)
 window.respecVersion = window.respecVersion || "Developer Edition";

--- a/src/ui/dfn-list.js
+++ b/src/ui/dfn-list.js
@@ -1,7 +1,7 @@
 /// Module ui/dfn-list
 // Displays all definitions with links to the defining element.
 import { ui } from "../core/ui";
-import "../deps/hyperhtml";
+import hyperHTML from "../deps/hyperhtml";
 import { l10n, lang } from "../core/l10n";
 
 const button = ui.addCommand(
@@ -13,7 +13,7 @@ const button = ui.addCommand(
 
 const ul = document.createElement("ul");
 ul.classList.add("respec-dfn-list");
-const render = window.hyperHTML.bind(ul);
+const render = hyperHTML.bind(ul);
 
 ul.addEventListener("click", ev => {
   ui.closeModal();
@@ -24,7 +24,7 @@ function show() {
   const definitionLinks = Object.entries(respecConfig.definitionMap)
     .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
     .map(([, dfn]) => {
-      return window.hyperHTML.wire(dfn, ":li>a")`
+      return hyperHTML.wire(dfn, ":li>a")`
         <li>
           <a href="${"#" + dfn.id}">
             ${dfn.textContent}

--- a/src/ui/dfn-list.js
+++ b/src/ui/dfn-list.js
@@ -1,8 +1,8 @@
 /// Module ui/dfn-list
 // Displays all definitions with links to the defining element.
-import { ui } from "core/ui";
-import "deps/hyperhtml";
-import { l10n, lang } from "core/l10n";
+import { ui } from "../core/ui";
+import "../deps/hyperhtml";
+import { l10n, lang } from "../core/l10n";
 
 const button = ui.addCommand(
   l10n[lang].definition_list,

--- a/src/ui/save-html.js
+++ b/src/ui/save-html.js
@@ -1,10 +1,10 @@
 // Module ui/save-html
 // Saves content to HTML when asked to
-import { ui } from "core/ui";
-import { l10n, lang } from "core/l10n";
-import { pub } from "core/pubsubhub";
-import { rsDocToDataURL } from "core/exporter";
-import "deps/hyperhtml";
+import { ui } from "../core/ui";
+import { l10n, lang } from "../core/l10n";
+import { pub } from "../core/pubsubhub";
+import { rsDocToDataURL } from "../core/exporter";
+import "../deps/hyperhtml";
 
 export const name = "ui/save-html";
 

--- a/src/ui/save-html.js
+++ b/src/ui/save-html.js
@@ -4,7 +4,7 @@ import { ui } from "../core/ui";
 import { l10n, lang } from "../core/l10n";
 import { pub } from "../core/pubsubhub";
 import { rsDocToDataURL } from "../core/exporter";
-import "../deps/hyperhtml";
+import hyperHTML from "../deps/hyperhtml";
 
 export const name = "ui/save-html";
 

--- a/src/ui/search-specref.js
+++ b/src/ui/search-specref.js
@@ -1,8 +1,8 @@
 // Module ui/search-specref
 // Search Specref database
-import { ui } from "core/ui";
-import { wireReference } from "core/biblio";
-import { l10n, lang } from "core/l10n";
+import { ui } from "../core/ui";
+import { wireReference } from "../core/biblio";
+import { l10n, lang } from "../core/l10n";
 
 const button = ui.addCommand(
   l10n[lang].search_specref,

--- a/src/ui/search-specref.js
+++ b/src/ui/search-specref.js
@@ -3,6 +3,7 @@
 import { ui } from "../core/ui";
 import { wireReference } from "../core/biblio";
 import { l10n, lang } from "../core/l10n";
+import hyperHTML from "../deps/hyperhtml";
 
 const button = ui.addCommand(
   l10n[lang].search_specref,
@@ -14,7 +15,7 @@ const specrefURL = "https://specref.herokuapp.com/";
 const refSearchURL = `${specrefURL}search-refs`;
 const reveseLookupURL = `${specrefURL}reverse-lookup`;
 const form = document.createElement("form");
-const renderer = window.hyperHTML.bind(form);
+const renderer = hyperHTML.bind(form);
 const resultList = hyperHTML.bind(document.createElement("div"));
 
 form.id = "specref-ui";

--- a/src/w3c/abstract.js
+++ b/src/w3c/abstract.js
@@ -17,5 +17,5 @@ export async function run() {
   }
   abstractHeading = document.createElement("h2");
   abstractHeading.innerText = l10n[lang].abstract;
-  abs.insertAdjacentElement("afterbegin", abstractHeading);
+  abs.prepend(abstractHeading);
 }

--- a/src/w3c/conformance.js
+++ b/src/w3c/conformance.js
@@ -6,8 +6,8 @@ import { pub } from "../core/pubsubhub";
 export const name = "w3c/conformance";
 
 export function run(conf) {
-  const $confo = $("#conformance");
-  if ($confo.length) $confo.prepend(confoTmpl(conf).childNodes);
+  const confo = document.getElementById("conformance");
+  if (confo) confo.prepend(...confoTmpl(conf).childNodes);
   // Added message for legacy compat with Aria specs
   // See https://github.com/w3c/respec/issues/793
   pub("end", "w3c/conformance");

--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -97,6 +97,7 @@ import cgbgSotdTmpl from "./templates/cgbg-sotd";
 import sotdTmpl from "./templates/sotd";
 import cgbgHeadersTmpl from "./templates/cgbg-headers";
 import headersTmpl from "./templates/headers";
+import hyperHTML from "../deps/hyperhtml";
 
 export const name = "w3c/headers";
 

--- a/src/w3c/informative.js
+++ b/src/w3c/informative.js
@@ -1,6 +1,6 @@
 // Module w3c/informative
 // Mark specific sections as informative, based on CSS
-import "../deps/hyperhtml";
+import hyperHTML from "../deps/hyperhtml";
 export const name = "w3c/informative";
 
 export function run() {

--- a/src/w3c/templates/cgbg-headers.js
+++ b/src/w3c/templates/cgbg-headers.js
@@ -1,4 +1,4 @@
-import "../../deps/hyperhtml";
+import hyperHTML from "../../deps/hyperhtml";
 import showLogo from "./show-logo";
 import showPeople from "./show-people";
 import showLink from "./show-link";

--- a/src/w3c/templates/cgbg-sotd.js
+++ b/src/w3c/templates/cgbg-sotd.js
@@ -1,4 +1,4 @@
-import "../../deps/hyperhtml";
+import hyperHTML from "../../deps/hyperhtml";
 
 export default conf => {
   const html = hyperHTML;

--- a/src/w3c/templates/conformance.js
+++ b/src/w3c/templates/conformance.js
@@ -1,4 +1,4 @@
-import "../../deps/hyperhtml";
+import hyperHTML from "../../deps/hyperhtml";
 
 export default () => {
   const html = hyperHTML;

--- a/src/w3c/templates/headers.js
+++ b/src/w3c/templates/headers.js
@@ -1,4 +1,4 @@
-import "../../deps/hyperhtml";
+import hyperHTML from "../../deps/hyperhtml";
 import showLogo from "./show-logo";
 import showPeople from "./show-people";
 import showLink from "./show-link";

--- a/src/w3c/templates/show-link.js
+++ b/src/w3c/templates/show-link.js
@@ -1,4 +1,4 @@
-import "../../deps/hyperhtml";
+import hyperHTML from "../../deps/hyperhtml";
 import { pub } from "../../core/pubsubhub";
 const html = hyperHTML;
 

--- a/src/w3c/templates/show-logo.js
+++ b/src/w3c/templates/show-logo.js
@@ -1,4 +1,4 @@
-import "../../deps/hyperhtml";
+import hyperHTML from "../../deps/hyperhtml";
 import { pub } from "../../core/pubsubhub";
 
 export default obj => {

--- a/src/w3c/templates/show-people.js
+++ b/src/w3c/templates/show-people.js
@@ -1,3 +1,5 @@
+import hyperHTML from "../../deps/hyperhtml";
+
 export default (conf, name, items = []) => {
   const html = hyperHTML;
   const results = [];

--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -1,4 +1,4 @@
-import "../../deps/hyperhtml";
+import hyperHTML from "../../deps/hyperhtml";
 
 export default conf => {
   const html = hyperHTML;

--- a/tests/spec/core/exporter-spec.js
+++ b/tests/spec/core/exporter-spec.js
@@ -37,8 +37,9 @@ describe("Core - exporter", () => {
       comments.push(walker.currentNode);
     }
 
-    const hyperComments = comments.filter(comment =>
-      comment.textContent.startsWith("-") && comment.textContent.endsWith("%")
+    const hyperComments = comments.filter(
+      comment =>
+        comment.textContent.startsWith("-") && comment.textContent.endsWith("%")
     );
     expect(hyperComments.length).toBe(0);
 

--- a/tests/spec/core/utils-spec.js
+++ b/tests/spec/core/utils-spec.js
@@ -504,7 +504,16 @@ describe("Core - Utils", () => {
         { key: "11" },
       ];
       const output = input.reduce(utils.flatten, ["first", 0]);
-      expect(output).toEqual(["first", 0, input[0], input[1], 7, 8, input[2][1][1][0], input[3]]);
+      expect(output).toEqual([
+        "first",
+        0,
+        input[0],
+        input[1],
+        7,
+        8,
+        input[2][1][1][0],
+        input[3],
+      ]);
     });
 
     it("flattens sparse and arrays", () => {

--- a/tools/copydeps.js
+++ b/tools/copydeps.js
@@ -11,7 +11,7 @@ const srcDesMap = [
     "./js/deps/handlebars.js",
   ],
   ["./node_modules/highlight.js/src/styles/github.css", "./js/core/css/"],
-  ["./node_modules/hyperhtml/index.js", "./js/deps/hyperhtml.js"],
+  ["./node_modules/hyperhtml/umd.js", "./js/deps/hyperhtml.js"],
   ["./node_modules/jquery/dist/jquery.slim.js", "./js/deps/jquery.js"],
   ["./node_modules/marked/lib/marked.js", "./js/deps/"],
   ["./node_modules/requirejs/require.js", "./js/deps/"],


### PR DESCRIPTION
This PR: 

1. removes jQuery from `core/conformance`
2. converts legacy `insertAdjacentElement()` to modern `append()` / `prepend()`
3. converts `import "../deps/hyperhtml"` to `import hyperHTML from "../deps/hyperhtml"` so that it won't pollute global namespace.