### PR TITLE
refactor: enforce eslint sort-imports

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -18,6 +18,7 @@
     "indent": 0,
     "quotes": 0,
     "semi": ["error", "always"],
+    "sort-imports": 2,
     "no-console": 0,
     "no-unused-vars": 2,
     "no-var": 2,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,7 @@
   },
   "rules": {
     "prettier/prettier": ["error", { "endOfLine": "auto" }],
+    "no-duplicate-imports": 2,
     "dot-notation": "error",
     "indent": 0,
     "quotes": 0,

--- a/src/core/base-runner.js
+++ b/src/core/base-runner.js
@@ -3,10 +3,10 @@
 import "./include-config";
 import "./override-configuration";
 import "./respec-ready";
-import { removeReSpec } from "./utils";
 import { done as postProcessDone } from "./post-process";
 import { done as preProcessDone } from "./pre-process";
 import { pub } from "./pubsubhub";
+import { removeReSpec } from "./utils";
 
 export const name = "core/base-runner";
 const canMeasure = performance.mark && performance.measure;

--- a/src/core/best-practices.js
+++ b/src/core/best-practices.js
@@ -3,8 +3,8 @@
 // The summary is generated if there is a section in the document with ID bp-summary.
 // Best practices are marked up with span.practicelab.
 import css from "../deps/text!core/css/bp.css";
-import { pub } from "./pubsubhub";
 import hyperHTML from "../deps/hyperhtml";
+import { pub } from "./pubsubhub";
 
 export const name = "core/best-practices";
 

--- a/src/core/caniuse.js
+++ b/src/core/caniuse.js
@@ -3,11 +3,10 @@
  * Adds a caniuse support table for a "feature" #1238
  * Usage options: https://github.com/w3c/respec/wiki/caniuse
  */
-import { semverCompare } from "./utils";
+import { createResourceHint, fetchAndCache, semverCompare } from "./utils";
 import { pub, sub } from "./pubsubhub";
-import hyperHTML from "../deps/hyperhtml";
-import { createResourceHint, fetchAndCache } from "./utils";
 import caniuseCss from "../deps/text!core/css/caniuse.css";
+import hyperHTML from "../deps/hyperhtml";
 
 export const name = "core/caniuse";
 

--- a/src/core/contrib.js
+++ b/src/core/contrib.js
@@ -4,9 +4,9 @@
 // #gh-commenters: people having contributed comments to issues.
 // #gh-contributors: people whose PR have been merged.
 // Spec editors get filtered out automatically.
+import { flatten, joinAnd } from "./utils";
 import { fetchIndex } from "./github";
 import { pub } from "./pubsubhub";
-import { flatten, joinAnd } from "./utils";
 export const name = "core/contrib";
 
 function prop(prop) {

--- a/src/core/contrib.js
+++ b/src/core/contrib.js
@@ -6,7 +6,7 @@
 // Spec editors get filtered out automatically.
 import { fetchIndex } from "./github";
 import { pub } from "./pubsubhub";
-import { joinAnd, flatten } from "./utils";
+import { flatten, joinAnd } from "./utils";
 export const name = "core/contrib";
 
 function prop(prop) {

--- a/src/core/data-cite.js
+++ b/src/core/data-cite.js
@@ -14,7 +14,7 @@
  * https://github.com/w3c/respec/wiki/data--cite
  */
 import { resolveRef, updateFromNetwork } from "./biblio";
-import { showInlineError, refTypeFromContext } from "./utils";
+import { refTypeFromContext, showInlineError } from "./utils";
 export const name = "core/data-cite";
 
 function requestLookup(conf) {

--- a/src/core/data-cite.js
+++ b/src/core/data-cite.js
@@ -13,8 +13,8 @@
  * Usage:
  * https://github.com/w3c/respec/wiki/data--cite
  */
-import { resolveRef, updateFromNetwork } from "./biblio";
 import { refTypeFromContext, showInlineError } from "./utils";
+import { resolveRef, updateFromNetwork } from "./biblio";
 export const name = "core/data-cite";
 
 function requestLookup(conf) {

--- a/src/core/data-tests.js
+++ b/src/core/data-tests.js
@@ -8,9 +8,9 @@
  *
  * Docs: https://github.com/w3c/respec/wiki/data-tests
  */
-import { pub } from "./pubsubhub";
 import { lang as defaultLang } from "./l10n";
 import hyperHTML from "../deps/hyperhtml";
+import { pub } from "./pubsubhub";
 const l10n = {
   en: {
     missing_test_suite_uri:

--- a/src/core/examples.js
+++ b/src/core/examples.js
@@ -5,10 +5,10 @@
 // When an example is found, it is reported using the "example" event. This can
 // be used by a containing shell to extract all examples.
 
-import { pub } from "./pubsubhub";
-import hyperHTML from "../deps/hyperhtml";
-import css from "../deps/text!core/css/examples.css";
 import { addId, reindent } from "./utils";
+import css from "../deps/text!core/css/examples.css";
+import hyperHTML from "../deps/hyperhtml";
+import { pub } from "./pubsubhub";
 
 export const name = "core/examples";
 

--- a/src/core/examples.js
+++ b/src/core/examples.js
@@ -8,7 +8,7 @@
 import { pub } from "./pubsubhub";
 import hyperHTML from "../deps/hyperhtml";
 import css from "../deps/text!core/css/examples.css";
-import { reindent, addId } from "./utils";
+import { addId, reindent } from "./utils";
 
 export const name = "core/examples";
 

--- a/src/core/exporter.js
+++ b/src/core/exporter.js
@@ -5,9 +5,9 @@
  * That is, elements that have a "removeOnSave" css class.
  */
 
-import { removeReSpec } from "./utils";
-import { pub } from "./pubsubhub";
 import hyperHTML from "../deps/hyperhtml";
+import { pub } from "./pubsubhub";
+import { removeReSpec } from "./utils";
 
 const mimeTypes = new Map([["text/html", "html"], ["application/xml", "xml"]]);
 

--- a/src/core/highlight-vars.js
+++ b/src/core/highlight-vars.js
@@ -6,8 +6,8 @@
  * All is done while keeping in mind that exported html stays clean
  * on export.
  */
-import { sub } from "./pubsubhub";
 import hlVars from "../deps/text!core/css/var.css";
+import { sub } from "./pubsubhub";
 
 export const name = "core/highlight-vars";
 

--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -13,10 +13,10 @@
 //  - respecRFC2119: a list of the number of times each RFC2119
 //    key word was used.  NOTE: While each member is a counter, at this time
 //    the counter is not used.
-import { pub } from "./pubsubhub";
-import hyperHTML from "../deps/hyperhtml";
 import { getTextNodes, refTypeFromContext } from "./utils";
+import hyperHTML from "../deps/hyperhtml";
 import { idlStringToHtml } from "./inline-idl-parser";
+import { pub } from "./pubsubhub";
 export const name = "core/inlines";
 
 export function run(conf) {

--- a/src/core/issues-notes.js
+++ b/src/core/issues-notes.js
@@ -10,10 +10,10 @@
 // numbered to avoid involuntary clashes.
 // If the configuration has issueBase set to a non-empty string, and issues are
 // manually numbered, a link to the issue is created using issueBase and the issue number
-import { pub } from "./pubsubhub";
 import css from "../deps/text!core/css/issues-notes.css";
-import hyperHTML from "../deps/hyperhtml";
 import { fetchAndCache } from "./utils";
+import hyperHTML from "../deps/hyperhtml";
+import { pub } from "./pubsubhub";
 export const name = "core/issues-notes";
 
 const MAX_GITHUB_REQUESTS = 60;

--- a/src/core/jquery-enhanced.js
+++ b/src/core/jquery-enhanced.js
@@ -1,8 +1,8 @@
 import {
   addId,
-  getTextNodes,
   getDfnTitles,
   getLinkTargets,
+  getTextNodes,
   renameElement,
 } from "./utils";
 import "../deps/jquery";

--- a/src/core/jquery-enhanced.js
+++ b/src/core/jquery-enhanced.js
@@ -1,3 +1,4 @@
+import "../deps/jquery";
 import {
   addId,
   getDfnTitles,
@@ -5,7 +6,6 @@ import {
   getTextNodes,
   renameElement,
 } from "./utils";
-import "../deps/jquery";
 
 export const name = "core/jquery-enhanced";
 

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -1,11 +1,11 @@
 // Module core/link-to-dfn
 // Gives definitions in conf.definitionMap IDs and links <a> tags
 // to the matching definitions.
-import { linkInlineCitations } from "./data-cite";
-import { pub } from "./pubsubhub";
-import { lang as defaultLang } from "./l10n";
 import { addId, getLinkTargets, wrapInner } from "./utils";
 import { run as addExternalReferences } from "./xref";
+import { lang as defaultLang } from "./l10n";
+import { linkInlineCitations } from "./data-cite";
+import { pub } from "./pubsubhub";
 export const name = "core/link-to-dfn";
 const l10n = {
   en: {

--- a/src/core/linter-rules/check-punctuation.js
+++ b/src/core/linter-rules/check-punctuation.js
@@ -2,8 +2,8 @@
  * Linter rule "check-punctuation". Makes sure the there are no punctuations missing at the end of a <p>
  *   in the ReSpec config.
  */
-import { lang as defaultLang } from "../l10n";
 import LinterRule from "../LinterRule";
+import { lang as defaultLang } from "../l10n";
 
 const name = "check-punctuation";
 const punctuationMarks = [".", ":", "!", "?"];

--- a/src/core/linter-rules/local-refs-exist.js
+++ b/src/core/linter-rules/local-refs-exist.js
@@ -2,8 +2,8 @@
  * Linter rule "warn-local-ref".
  * Warns about href's that link to nonexistent id's in a spec
  */
-import { lang as defaultLang } from "../l10n";
 import LinterRule from "../LinterRule";
+import { lang as defaultLang } from "../l10n";
 
 const name = "local-refs-exist";
 

--- a/src/core/linter-rules/no-http-props.js
+++ b/src/core/linter-rules/no-http-props.js
@@ -2,8 +2,8 @@
  * Linter rule "no-http-props". Makes sure the there are no URLs that
  * start with http:// in the ReSpec config.
  */
-import { lang as defaultLang } from "../l10n";
 import LinterRule from "../LinterRule";
+import { lang as defaultLang } from "../l10n";
 
 const name = "no-http-props";
 

--- a/src/core/override-configuration.js
+++ b/src/core/override-configuration.js
@@ -7,7 +7,7 @@
 // Note that fields are separated by semicolons and not ampersands.
 // TODO
 //  There could probably be a UI for this to make it even simpler.
-import { sub, pub } from "./pubsubhub";
+import { pub, sub } from "./pubsubhub";
 
 export const name = "core/override-configuration";
 

--- a/src/core/pluralize.js
+++ b/src/core/pluralize.js
@@ -3,8 +3,8 @@
 //   plurals of it are automatically added to `data-plurals`.
 // The linking is done in core/link-to-dfn
 
-import { plural as pluralOf } from "../deps/pluralize";
 import { norm as normalize } from "./utils";
+import { plural as pluralOf } from "../deps/pluralize";
 
 export const name = "core/pluralize";
 

--- a/src/core/post-process.js
+++ b/src/core/post-process.js
@@ -8,7 +8,7 @@
  *      want to be using a new module with your own profile.
  *  - afterEnd: final thing that is called.
  */
-import { sub, pub } from "./pubsubhub";
+import { pub, sub } from "./pubsubhub";
 
 export const name = "core/post-process";
 

--- a/src/core/pre-process.js
+++ b/src/core/pre-process.js
@@ -7,7 +7,7 @@
  *      tested. Use with care, if you know what you're doing. Chances are you really
  *      want to be using a new module with your own profile
  */
-import { sub, pub } from "./pubsubhub";
+import { pub, sub } from "./pubsubhub";
 
 export const name = "core/pre-process";
 

--- a/src/core/render-biblio.js
+++ b/src/core/render-biblio.js
@@ -1,8 +1,8 @@
 // Module core/render-biblio
 // renders the biblio data pre-processed in core/biblio
 
-import hyperHTML from "../deps/hyperhtml";
 import { addId } from "./utils";
+import hyperHTML from "../deps/hyperhtml";
 import { pub } from "./pubsubhub";
 
 export const name = "core/render-biblio";

--- a/src/core/requirements.js
+++ b/src/core/requirements.js
@@ -9,8 +9,8 @@
 // 2.  It allows referencing requirements by their ID simply using an empty <a>
 //     element with its href pointing to the requirement it should be referencing
 //     and a class of "reqRef".
-import { pub } from "./pubsubhub";
 import hyperHTML from "../deps/hyperhtml";
+import { pub } from "./pubsubhub";
 
 export const name = "core/requirements";
 

--- a/src/core/ui.js
+++ b/src/core/ui.js
@@ -9,12 +9,12 @@
 //  - make a release candidate that people can test
 //  - once we have something decent, merge, ship as 3.2.0
 
+import "./jquery-enhanced";
+import css from "../deps/text!ui/ui.css";
+import hyperHTML from "../deps/hyperhtml";
+import { markdownToHtml } from "./utils";
 import shortcut from "shortcut";
 import { sub } from "./pubsubhub";
-import css from "../deps/text!ui/ui.css";
-import { markdownToHtml } from "./utils";
-import "./jquery-enhanced";
-import hyperHTML from "../deps/hyperhtml";
 export const name = "core/ui";
 
 // Opportunistically inserts the style, with the chance to reduce some FOUC

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -3,8 +3,8 @@
 // Module core/utils
 // As the name implies, this contains a ragtag gang of methods that just don't fit
 // anywhere else.
-import { pub } from "./pubsubhub";
 import marked from "../deps/marked";
+import { pub } from "./pubsubhub";
 export const name = "core/utils";
 
 marked.setOptions({

--- a/src/core/webidl-clipboard.js
+++ b/src/core/webidl-clipboard.js
@@ -5,8 +5,8 @@
  * well-formatted IDL to the clipboard.
  *
  */
-import svgClipboard from "../deps/text!core/images/clipboard.svg";
 import Clipboard from "../deps/clipboard";
+import svgClipboard from "../deps/text!core/images/clipboard.svg";
 export const name = "core/webidl-clipboard";
 
 // This button serves a prototype that we clone as needed.

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -4,13 +4,13 @@
 // TODO:
 //  - It could be useful to report parsed IDL items as events
 //  - don't use generated content in the CSS!
-import { pub } from "./pubsubhub";
-import webidl2 from "../deps/webidl2";
-import hb from "handlebars.runtime";
-import css from "../deps/text!core/css/webidl.css";
-import tmpls from "templates";
 import { normalizePadding, reindent } from "./utils";
+import css from "../deps/text!core/css/webidl.css";
 import { findDfn } from "./dfn-finder";
+import hb from "handlebars.runtime";
+import { pub } from "./pubsubhub";
+import tmpls from "templates";
+import webidl2 from "../deps/webidl2";
 
 export const name = "core/webidl";
 

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -4,8 +4,8 @@
 //   so later they can be handled by core/link-to-dfn.
 // https://github.com/w3c/respec/issues/1662
 
-import { norm as normalize, showInlineError } from "./utils";
 import * as IDB from "../deps/idb";
+import { norm as normalize, showInlineError } from "./utils";
 
 const API_URL = new URL(
   "https://wt-466c7865b463a6c4cbb820b42dde9e58-0.sandbox.auth0-extend.com/xref-proto-2"

--- a/src/ui/about-respec.js
+++ b/src/ui/about-respec.js
@@ -1,8 +1,8 @@
 // Module ui/about-respec
 // A simple about dialog with pointer to the help
+import { l10n, lang } from "../core/l10n";
 import hyperHTML from "../deps/hyperhtml";
 import { ui } from "../core/ui";
-import { l10n, lang } from "../core/l10n";
 
 // window.respecVersion is added at build time (see tools/builder.js)
 window.respecVersion = window.respecVersion || "Developer Edition";

--- a/src/ui/dfn-list.js
+++ b/src/ui/dfn-list.js
@@ -1,8 +1,8 @@
 /// Module ui/dfn-list
 // Displays all definitions with links to the defining element.
-import { ui } from "../core/ui";
-import hyperHTML from "../deps/hyperhtml";
 import { l10n, lang } from "../core/l10n";
+import hyperHTML from "../deps/hyperhtml";
+import { ui } from "../core/ui";
 
 const button = ui.addCommand(
   l10n[lang].definition_list,

--- a/src/ui/save-html.js
+++ b/src/ui/save-html.js
@@ -1,10 +1,10 @@
 // Module ui/save-html
 // Saves content to HTML when asked to
-import { ui } from "../core/ui";
 import { l10n, lang } from "../core/l10n";
+import hyperHTML from "../deps/hyperhtml";
 import { pub } from "../core/pubsubhub";
 import { rsDocToDataURL } from "../core/exporter";
-import hyperHTML from "../deps/hyperhtml";
+import { ui } from "../core/ui";
 
 export const name = "ui/save-html";
 

--- a/src/ui/search-specref.js
+++ b/src/ui/search-specref.js
@@ -1,9 +1,9 @@
 // Module ui/search-specref
 // Search Specref database
-import { ui } from "../core/ui";
-import { wireReference } from "../core/biblio";
 import { l10n, lang } from "../core/l10n";
 import hyperHTML from "../deps/hyperhtml";
+import { ui } from "../core/ui";
+import { wireReference } from "../core/biblio";
 
 const button = ui.addCommand(
   l10n[lang].search_specref,

--- a/src/w3c/abstract.js
+++ b/src/w3c/abstract.js
@@ -1,7 +1,7 @@
 // Module w3c/abstract
 // Handle the abstract section properly.
-import { pub } from "../core/pubsubhub";
 import { l10n, lang } from "../core/l10n";
+import { pub } from "../core/pubsubhub";
 export const name = "w3c/abstract";
 
 export async function run() {

--- a/src/w3c/defaults.js
+++ b/src/w3c/defaults.js
@@ -2,12 +2,12 @@
  * Sets the defaults for W3C specs
  */
 export const name = "w3c/defaults";
+import { rule as checkPunctuation } from "../core/linter-rules/check-punctuation";
 import linter from "../core/linter";
+import { rule as localRefsExist } from "../core/linter-rules/local-refs-exist";
 import { rule as noHeadinglessSectionsRule } from "../core/linter-rules/no-headingless-sections";
 import { rule as noHttpPropsRule } from "../core/linter-rules/no-http-props";
 import { rule as privsecSectionRule } from "./linter-rules/privsec-section";
-import { rule as checkPunctuation } from "../core/linter-rules/check-punctuation";
-import { rule as localRefsExist } from "../core/linter-rules/local-refs-exist";
 
 linter.register(
   noHttpPropsRule,

--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -92,12 +92,12 @@
 //      - "w3c-software-doc", the W3C Software and Document License
 //            https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
 import { ISODate, concatDate, joinAnd } from "../core/utils";
-import { pub } from "../core/pubsubhub";
-import cgbgSotdTmpl from "./templates/cgbg-sotd";
-import sotdTmpl from "./templates/sotd";
 import cgbgHeadersTmpl from "./templates/cgbg-headers";
+import cgbgSotdTmpl from "./templates/cgbg-sotd";
 import headersTmpl from "./templates/headers";
 import hyperHTML from "../deps/hyperhtml";
+import { pub } from "../core/pubsubhub";
+import sotdTmpl from "./templates/sotd";
 
 export const name = "w3c/headers";
 

--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -91,7 +91,7 @@
 //      - "w3c-software", a permissive and attributions license (but GPL-compatible).
 //      - "w3c-software-doc", the W3C Software and Document License
 //            https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
-import { concatDate, joinAnd, ISODate } from "../core/utils";
+import { ISODate, concatDate, joinAnd } from "../core/utils";
 import { pub } from "../core/pubsubhub";
 import cgbgSotdTmpl from "./templates/cgbg-sotd";
 import sotdTmpl from "./templates/sotd";

--- a/src/w3c/style.js
+++ b/src/w3c/style.js
@@ -5,7 +5,7 @@
 // CONFIGURATION
 //  - specStatus: the short code for the specification's maturity level or type (required)
 
-import { toKeyValuePairs, createResourceHint, linkCSS } from "../core/utils";
+import { createResourceHint, linkCSS, toKeyValuePairs } from "../core/utils";
 import { pub, sub } from "../core/pubsubhub";
 export const name = "w3c/style";
 function attachFixupScript(doc, version) {

--- a/src/w3c/templates/cgbg-headers.js
+++ b/src/w3c/templates/cgbg-headers.js
@@ -1,7 +1,7 @@
 import hyperHTML from "../../deps/hyperhtml";
+import showLink from "./show-link";
 import showLogo from "./show-logo";
 import showPeople from "./show-people";
-import showLink from "./show-link";
 
 export default conf => {
   const html = hyperHTML;

--- a/src/w3c/templates/headers.js
+++ b/src/w3c/templates/headers.js
@@ -1,8 +1,8 @@
 import hyperHTML from "../../deps/hyperhtml";
+import { pub } from "../../core/pubsubhub";
+import showLink from "./show-link";
 import showLogo from "./show-logo";
 import showPeople from "./show-people";
-import showLink from "./show-link";
-import { pub } from "../../core/pubsubhub";
 
 function getSpecTitleElem(conf) {
   const specTitleElem =


### PR DESCRIPTION
Not sure we exactly want this, I just wanted to sort `import {c, b, a}` case and found that [eslint requires more](https://eslint.org/docs/rules/sort-imports).