### PR TITLE
Add showInlineError/Warning helper functions

### DIFF
--- a/src/core/data-cite.js
+++ b/src/core/data-cite.js
@@ -13,7 +13,7 @@
  * Usage:
  * https://github.com/w3c/respec/wiki/data--cite
  */
-import { refTypeFromContext, showInlineError, wrapInner } from "./utils";
+import { refTypeFromContext, showInlineWarning, wrapInner } from "./utils";
 import { resolveRef, updateFromNetwork } from "./biblio";
 import hyperHTML from "../deps/hyperhtml";
 export const name = "core/data-cite";
@@ -32,7 +32,7 @@ function requestLookup(conf) {
       const entry = await resolveRef(key);
       cleanElement(elem);
       if (!entry) {
-        showInlineError(elem, `Couldn't find a match for "${originalKey}".`);
+        showInlineWarning(elem, `Couldn't find a match for "${originalKey}".`);
         return;
       }
       href = entry.href;

--- a/src/core/data-cite.js
+++ b/src/core/data-cite.js
@@ -32,7 +32,7 @@ function requestLookup(conf) {
       const entry = await resolveRef(key);
       cleanElement(elem);
       if (!entry) {
-        showInlineWarning(elem, `Couldn't find a match for "${originalKey}".`);
+        showInlineWarning(elem, `Couldn't find a match for "${originalKey}"`);
         return;
       }
       href = entry.href;

--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -13,7 +13,7 @@
 //  - respecRFC2119: a list of the number of times each RFC2119
 //    key word was used.  NOTE: While each member is a counter, at this time
 //    the counter is not used.
-import { getTextNodes, refTypeFromContext } from "./utils";
+import { getTextNodes, refTypeFromContext, showInlineWarning } from "./utils";
 import hyperHTML from "../deps/hyperhtml";
 import { idlStringToHtml } from "./inline-idl-parser";
 import { pub } from "./pubsubhub";
@@ -99,16 +99,11 @@ export function run(conf) {
             df.appendChild(document.createTextNode("]"));
 
             if (illegal && !conf.normativeReferences.has(ref)) {
-              cite.classList.add("respec-offending-element");
-              const msg =
+              showInlineWarning(
+                cite,
                 "Normative references in informative sections are not allowed. " +
-                `Remove '!' from the start of the reference \`[[!${ref}]]\`. `;
-              pub(
-                "warn",
-                msg + "See developer console to find offending element."
+                  `Remove '!' from the start of the reference \`[[!${ref}]]\``
               );
-              cite.title = msg;
-              console.warn(msg, cite);
             }
 
             if (type === "informative" && !illegal) {

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -38,7 +38,11 @@ export async function run(conf) {
         // up as <span>s instead of <dfn>.
         const oldIsDfn = titles[title][dfnFor].localName === "dfn";
         const newIsDfn = dfn.localName === "dfn";
-        if (oldIsDfn && newIsDfn) {
+        if (oldIsDfn) {
+          if (!newIsDfn) {
+            // Don't overwrite <dfn> definitions.
+            return;
+          }
           listOfDuplicateDfns.push(dfn);
         }
       }

--- a/src/core/linter.js
+++ b/src/core/linter.js
@@ -53,11 +53,11 @@ async function toLinterWarning(promiseToLint) {
       occurrences,
       offendingElements,
     } = output;
-    const message = `Linter (${name}): ${description} ${howToFix} ${help} (x ${occurrences})`;
+    const message = `Linter (${name}): ${description} ${howToFix} ${help}`;
     if (offendingElements.length) {
-      showInlineWarning(offendingElements, message);
+      showInlineWarning(offendingElements, `${message} Occured`);
     } else {
-      pub("warn", message);
+      pub("warn", `${message} (Count: ${occurrences})`);
     }
   });
 }

--- a/src/core/linter.js
+++ b/src/core/linter.js
@@ -4,6 +4,7 @@
  * Core linter module. Exports a linter object.
  */
 import { pub } from "./pubsubhub";
+import { showInlineWarning } from "./utils";
 export const name = "core/linter";
 const privates = new WeakMap();
 
@@ -41,28 +42,24 @@ const baseResult = {
 
 async function toLinterWarning(promiseToLint) {
   const results = await promiseToLint;
-  results
-    .map(async resultPromise => {
-      const result = await resultPromise;
-      const output = { ...baseResult, ...result };
-      const {
-        description,
-        help,
-        howToFix,
-        name,
-        occurrences,
-        offendingElements,
-      } = output;
-      const msg = `${description} ${howToFix} ${help} ("${name}" x ${occurrences})`;
-      offendingElements.forEach(elem => {
-        elem.classList.add("respec-offending-element");
-      });
-      console.warn(`Linter (${name}):`, description, ...offendingElements);
-      return msg;
-    })
-    .forEach(async msgPromise => {
-      pub("warn", await msgPromise);
-    });
+  results.forEach(async resultPromise => {
+    const result = await resultPromise;
+    const output = { ...baseResult, ...result };
+    const {
+      description,
+      help,
+      howToFix,
+      name,
+      occurrences,
+      offendingElements,
+    } = output;
+    const message = `Linter (${name}): ${description} ${howToFix} ${help} (x ${occurrences})`;
+    if (offendingElements.length) {
+      showInlineWarning(offendingElements, message);
+    } else {
+      pub("warn", message);
+    }
+  });
 }
 
 export function run(conf) {

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -345,7 +345,6 @@ export function showInlineError(elems, msg, title) {
   console.error(msg, elems);
 }
 
-let offenders = 0;
 /**
  * Adds error class to each element while emitting a warning
  * @param {Element} elem
@@ -356,9 +355,8 @@ function markAsOffending(elem, msg, title) {
   elem.classList.add("respec-offending-element");
   elem.setAttribute("title", title || msg);
   if (!elem.id) {
-    elem.id = `respecOffender${offenders}`;
+    addId(elem, "respecOffender");
   }
-  offenders += 1;
 }
 
 /**

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -357,7 +357,9 @@ export function showInlineError(elems, msg, title) {
  */
 function markAsOffending(elem, msg, title) {
   elem.classList.add("respec-offending-element");
-  elem.setAttribute("title", title || msg);
+  if (!elem.hasAttribute("title")) {
+    elem.setAttribute("title", title || msg);
+  }
   if (!elem.id) {
     addId(elem, "respec-offender");
   }

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -315,20 +315,40 @@ export function removeReSpec(doc) {
 
 /**
  * Adds error class to each element while emitting a warning
- * @param {Element|Array:Elements} elems
+ * @param {Element|Element[]} elems
+ * @param {String} msg message to show in warning
+ * @param {String} title error message to add on each element
+ */
+export function showInlineWarning(elems, msg, title) {
+  markAsOffending(elems, msg, title);
+  pub("warn", msg + " See developer console for details.");
+  console.warn(msg, elems);
+}
+
+/**
+ * Adds error class to each element while emitting a warning
+ * @param {Element|Element[]} elems
  * @param {String} msg message to show in warning
  * @param {String} title error message to add on each element
  */
 export function showInlineError(elems, msg, title) {
+  markAsOffending(elems, msg, title);
+  pub("error", msg + " See developer console for details.");
+  console.error(msg, elems);
+}
+
+/**
+ * Adds error class to each element while emitting a warning
+ * @param {Element|Element[]} elems
+ * @param {String} msg message to show in warning
+ * @param {String} title error message to add on each element
+ */
+function markAsOffending(elems, msg, title) {
   if (!Array.isArray(elems)) elems = [elems];
-  if (!elems.length) return;
-  if (!title) title = msg;
   elems.forEach(elem => {
     elem.classList.add("respec-offending-element");
-    elem.setAttribute("title", title);
+    elem.setAttribute("title", title || msg);
   });
-  pub("warn", msg + " See developer console for details.");
-  console.warn(msg, elems);
 }
 
 // STRING HELPERS

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -321,11 +321,13 @@ export function removeReSpec(doc) {
  */
 export function showInlineWarning(elems, msg, title) {
   if (!Array.isArray(elems)) elems = [elems];
-  const links = elems.map((element, i) => {
-    markAsOffending(element, msg, title);
-    return generateMarkdownLink(element, i);
-  }).join(", ");
-  pub("warn", msg + `at: ${links}.`);
+  const links = elems
+    .map((element, i) => {
+      markAsOffending(element, msg, title);
+      return generateMarkdownLink(element, i);
+    })
+    .join(", ");
+  pub("warn", msg + ` at: ${links}.`);
   console.warn(msg, elems);
 }
 
@@ -337,11 +339,13 @@ export function showInlineWarning(elems, msg, title) {
  */
 export function showInlineError(elems, msg, title) {
   if (!Array.isArray(elems)) elems = [elems];
-  const links = elems.map((element, i) => {
-    markAsOffending(element, msg, title);
-    return generateMarkdownLink(element, i);
-  }).join(", ");
-  pub("error", msg + `at: ${links}.`);
+  const links = elems
+    .map((element, i) => {
+      markAsOffending(element, msg, title);
+      return generateMarkdownLink(element, i);
+    })
+    .join(", ");
+  pub("error", msg + ` at: ${links}.`);
   console.error(msg, elems);
 }
 
@@ -355,7 +359,7 @@ function markAsOffending(elem, msg, title) {
   elem.classList.add("respec-offending-element");
   elem.setAttribute("title", title || msg);
   if (!elem.id) {
-    addId(elem, "respecOffender");
+    addId(elem, "respec-offender");
   }
 }
 

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -5,7 +5,7 @@
 // https://github.com/w3c/respec/issues/1662
 
 import * as IDB from "../deps/idb";
-import { norm as normalize, showInlineError } from "./utils";
+import { norm as normalize, showInlineWarning } from "./utils";
 
 const API_URL = new URL(
   "https://wt-466c7865b463a6c4cbb820b42dde9e58-0.sandbox.auth0-extend.com/xref-proto-2"
@@ -237,7 +237,7 @@ function addDataCiteToTerms(results, xrefMap, conf) {
             `Adding an informative reference to "${term}" from "${cite}" ` +
             "in a normative section";
           const title = "Error: Informative reference in normative section";
-          showInlineError(entry.elem, msg, title);
+          showInlineWarning(entry.elem, msg, title);
         }
       }
     });
@@ -270,7 +270,7 @@ function disambiguate(fetchedData, context, term) {
       `Couldn't match "**${term}**" to anything in the document or to any other spec. ` +
       "Please provide a [`data-cite`](https://github.com/w3c/respec/wiki/data--cite) attribute for it.";
     const title = "Error: No matching dfn found.";
-    if (!elem.dataset.cite) showInlineError(elem, msg, title);
+    if (!elem.dataset.cite) showInlineWarning(elem, msg, title);
     return null;
   }
 
@@ -287,6 +287,6 @@ function disambiguate(fetchedData, context, term) {
       .map(s => `**${s}**`)
       .join(", ")}.`;
   const title = "Error: Linking an ambiguous dfn.";
-  showInlineError(elem, msg, title);
+  showInlineWarning(elem, msg, title);
   return null;
 }

--- a/src/w3c/templates/show-logo.js
+++ b/src/w3c/templates/show-logo.js
@@ -1,13 +1,13 @@
 import hyperHTML from "../../deps/hyperhtml";
-import { pub } from "../../core/pubsubhub";
+import { showInlineWarning } from "../../core/utils";
 
 export default obj => {
   const a = document.createElement("a");
   if (!obj.alt) {
-    const msg = "Found spec logo without an `alt` attribute. See dev console.";
-    a.classList.add("respec-offending-element");
-    pub("warn", msg);
-    console.warn("warn", msg, a);
+    showInlineWarning(
+      a,
+      "Found spec logo without an `alt` attribute"
+    );
   }
   a.href = obj.url || "";
   a.classList.add("logo");

--- a/src/w3c/templates/show-logo.js
+++ b/src/w3c/templates/show-logo.js
@@ -4,10 +4,7 @@ import { showInlineWarning } from "../../core/utils";
 export default obj => {
   const a = document.createElement("a");
   if (!obj.alt) {
-    showInlineWarning(
-      a,
-      "Found spec logo without an `alt` attribute"
-    );
+    showInlineWarning(a, "Found spec logo without an `alt` attribute");
   }
   a.href = obj.url || "";
   a.classList.add("logo");

--- a/tests/spec/core/xref-spec.js
+++ b/tests/spec/core/xref-spec.js
@@ -218,7 +218,7 @@ describe("Core — xref", () => {
     const five = doc.getElementById("five");
     expect(five.href).toEqual("");
     expect(five.classList.contains("respec-offending-element")).toBeTruthy();
-    expect(five.title).toEqual(`Couldn't find a match for "NOT-FOUND".`);
+    expect(five.title).toEqual(`Couldn't find a match for "NOT-FOUND"`);
   });
 
   it("treats terms as local if empty data-cite on parent", async () => {


### PR DESCRIPTION
Didn't know we already had `showInlineError()`! The function showed "warning" instead of "error" despite of its name, so this PR renames it as `showInlineWarning` and adds proper `showInlineError`.