### PR TITLE
test(core/webidl): links for namespaces

### DIFF
--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -224,6 +224,10 @@ describe("Core - WebIDL", () => {
     expect(interfaces[1].id).toEqual("idl-def-docisnotcasesensitive");
     expect(interfaces[2].id).toEqual("idl-def-undocinterface");
     expect(interfaces[2].querySelector(".idlID a")).toBeNull();
+    const namespace = target.querySelector(".idlNamespace");
+    expect(
+      namespace.querySelector(".idlID a").getAttribute("href")
+    ).toEqual("#dom-afterglow");
   });
 
   it("should handle constructors", () => {

--- a/tests/spec/core/webidl.html
+++ b/tests/spec/core/webidl.html
@@ -250,8 +250,12 @@
         interface DocInterface {};
         interface DocIsNotCaseSensitive {};
         interface UndocInterface {};
+        namespace Afterglow {};
       </pre>
-      <p id='if-doc-p'><dfn>DocInterface</dfn> is an interface and so is <dfn>DoCiSnOtCaSeSeNsItIvE</dfn>.</p>
+      <p id='if-doc-p'>
+        <dfn>DocInterface</dfn> is an interface and so is <dfn>DoCiSnOtCaSeSeNsItIvE</dfn>.
+        <dfn>Afterglow</dfn> is a namespace.
+      </p>
     </section>
     <section>
       <h2>Constructors</h2>


### PR DESCRIPTION
Closes #1795 

The support has been added by #1920 and this PR adds a test.