### PR TITLE
refactor(core/link-to-dfn): split functions

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "target": "es2018"
+  }
+}

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,5 +1,0 @@
-{
-  "compilerOptions": {
-    "target": "es2018"
-  }
-}

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -236,7 +236,7 @@ function shouldWrapByCode(dfn, term) {
 function findExplicitExternalLinks() {
   const links = document.querySelectorAll(
     "a[data-cite]:not([data-cite='']):not([data-cite*='#']), " +
-    "dfn[data-cite]:not([data-cite='']):not([data-cite*='#'])"
+      "dfn[data-cite]:not([data-cite='']):not([data-cite*='#'])"
   );
   return [...links]
     .filter(el => {

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -234,10 +234,11 @@ function shouldWrapByCode(dfn, term) {
  * Examples: a[data-cite="spec"], dfn[data-cite="spec"], dfn.externalDFN
  */
 function findExplicitExternalLinks() {
-  const selector =
+  const links = document.querySelectorAll(
     "a[data-cite]:not([data-cite='']):not([data-cite*='#']), " +
-    "dfn[data-cite]:not([data-cite='']):not([data-cite*='#'])";
-  return [...document.querySelectorAll(selector)]
+    "dfn[data-cite]:not([data-cite='']):not([data-cite*='#'])"
+  );
+  return [...links]
     .filter(el => {
       const closest = /** @type {HTMLElement} */ (el.closest("[data-cite]"));
       return !closest || closest.dataset.cite !== "";

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -84,6 +84,7 @@ function mapTitleToDfns(definitionMap) {
   Object.keys(definitionMap).forEach(title => {
     const { result, duplicates } = collectDfns(definitionMap, title);
     titleToDfns[title] = result;
+    assignDfnIds(result, title);
     if (duplicates.length > 0) {
       showInlineError(
         duplicates,
@@ -124,22 +125,22 @@ function collectDfns(definitionMap, title) {
       }
     }
     result[dfnFor] = dfn;
-    assignDfnId(dfn, title);
   });
   return { result, duplicates };
 }
 
 /**
- * @param {HTMLElement} dfn
+ * @param {Record<string, HTMLElement>} dfns
  * @param {string} title
  */
-function assignDfnId(dfn, title) {
-  if (!dfn.id) {
-    const { dfnFor } = dfn.dataset;
-    if (dfn.dataset.idl) {
-      addId(dfn, "dom", (dfnFor ? dfnFor + "-" : "") + title);
-    } else {
-      addId(dfn, "dfn", title);
+function assignDfnIds(dfns, title) {
+  for (const [dfnFor, dfn] of Object.entries(dfns)) {
+    if (!dfn.id) {
+      if (dfn.dataset.idl) {
+        addId(dfn, "dom", (dfnFor ? dfnFor + "-" : "") + title);
+      } else {
+        addId(dfn, "dfn", title);
+      }
     }
   }
 }

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -95,6 +95,10 @@ function mapTitleToDfns(definitionMap) {
   return titleToDfns;
 }
 
+/**
+ * @param {Record<string, HTMLElement[]>} definitionMap
+ * @param {string} title
+ */
 function collectDfns(definitionMap, title) {
   /** @type {Record<string, HTMLElement>} */
   const result = {};
@@ -120,15 +124,24 @@ function collectDfns(definitionMap, title) {
       }
     }
     result[dfnFor] = dfn;
-    if (!dfn.id) {
-      if (dfn.dataset.idl) {
-        addId(dfn, "dom", (dfnFor ? dfnFor + "-" : "") + title);
-      } else {
-        addId(dfn, "dfn", title);
-      }
-    }
+    assignDfnId(dfn, title);
   });
   return { result, duplicates };
+}
+
+/**
+ * @param {HTMLElement} dfn
+ * @param {string} title
+ */
+function assignDfnId(dfn, title) {
+  if (!dfn.id) {
+    const { dfnFor } = dfn.dataset;
+    if (dfn.dataset.idl) {
+      addId(dfn, "dom", (dfnFor ? dfnFor + "-" : "") + title);
+    } else {
+      addId(dfn, "dfn", title);
+    }
+  }
 }
 
 /**

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -84,7 +84,6 @@ function mapTitleToDfns(definitionMap) {
   Object.keys(definitionMap).forEach(title => {
     const { result, duplicates } = collectDfns(definitionMap, title);
     titleToDfns[title] = result;
-    assignDfnIds(result, title);
     if (duplicates.length > 0) {
       showInlineError(
         duplicates,
@@ -125,22 +124,22 @@ function collectDfns(definitionMap, title) {
       }
     }
     result[dfnFor] = dfn;
+    assignDfnId(dfn, title);
   });
   return { result, duplicates };
 }
 
 /**
- * @param {Record<string, HTMLElement>} dfns
+ * @param {HTMLElement} dfn
  * @param {string} title
  */
-function assignDfnIds(dfns, title) {
-  for (const [dfnFor, dfn] of Object.entries(dfns)) {
-    if (!dfn.id) {
-      if (dfn.dataset.idl) {
-        addId(dfn, "dom", (dfnFor ? dfnFor + "-" : "") + title);
-      } else {
-        addId(dfn, "dfn", title);
-      }
+function assignDfnId(dfn, title) {
+  if (!dfn.id) {
+    const { dfnFor } = dfn.dataset;
+    if (dfn.dataset.idl) {
+      addId(dfn, "dom", (dfnFor ? dfnFor + "-" : "") + title);
+    } else {
+      addId(dfn, "dfn", title);
     }
   }
 }

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -80,15 +80,15 @@ export async function run(conf) {
     });
     if (!foundDfn && linkTargets.length !== 0) {
       // ignore WebIDL
-      if (!ant.closest("pre.idl")) {
-        if (ant.dataset.cite === "") {
-          badLinks.push(ant);
-        } else {
-          possibleExternalLinks.push(ant);
-        }
+      if (ant.closest("pre.idl")) {
+        ant.replaceWith(...ant.childNodes);
         return;
       }
-      ant.replaceWith(...ant.childNodes);
+      if (ant.dataset.cite === "") {
+        badLinks.push(ant);
+      } else {
+        possibleExternalLinks.push(ant);
+      }
     }
   });
 

--- a/tests/spec/core/link-to-dfn-spec.js
+++ b/tests/spec/core/link-to-dfn-spec.js
@@ -76,4 +76,36 @@ describe("Core — Link to definitions", () => {
     expect(dfn3.classList).toContain("respec-offending-element");
     expect(dfn3.title).toBe("test1");
   });
+
+  it("should not have data-dfn-for if not an IDL definition", async () => {
+    const bodyText = `
+      <section>
+        <h2>Test Section</h2>
+        <dfn data-dfn-for="Foo">Test1</dfn>
+      </section>`;
+    const ops = {
+      config: makeBasicConfig(),
+      body: makeDefaultBody() + bodyText,
+    };
+    const doc = await makeRSDoc(ops);
+    const [dfn] = doc.getElementsByTagName("dfn");
+    expect(dfn.dataset.dfnFor).toBeUndefined();
+  });
+
+  it("should get ID from the first match", async () => {
+    const bodyText = `
+      <section>
+        <h2>Test Section</h2>
+        <dfn data-lt="Test2">Test1</dfn>
+        <a>Test2</a>
+        <a>Test1</a>
+      </section>`;
+    const ops = {
+      config: makeBasicConfig(),
+      body: makeDefaultBody() + bodyText,
+    };
+    const doc = await makeRSDoc(ops);
+    const [dfn] = doc.getElementsByTagName("dfn");
+    expect(dfn.id).toBe("dfn-test2");
+  });
 });

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -225,9 +225,9 @@ describe("Core - WebIDL", () => {
     expect(interfaces[2].id).toEqual("idl-def-undocinterface");
     expect(interfaces[2].querySelector(".idlID a")).toBeNull();
     const namespace = target.querySelector(".idlNamespace");
-    expect(
-      namespace.querySelector(".idlID a").getAttribute("href")
-    ).toEqual("#dom-afterglow");
+    expect(namespace.querySelector(".idlID a").getAttribute("href")).toEqual(
+      "#dom-afterglow"
+    );
   });
 
   it("should handle constructors", () => {


### PR DESCRIPTION
Following #1948 

Adding jsconfig.json to correctly `@ts-check` latest ECMAScript native functions.