### PR TITLE
fix(core/dfn-finder): always enumerate every alternative form for operations

### DIFF
--- a/src/core/dfn-finder.js
+++ b/src/core/dfn-finder.js
@@ -118,12 +118,11 @@ function findOperationDfn(defn, parent, name, definitionMap) {
   if (!dfn) {
     return;
   }
-  addAlternativeNames(dfn, [
-    asFullyQualifiedName,
-    asQualifiedName,
-    asMethodName,
-    asLocalName,
-  ], definitionMap);
+  addAlternativeNames(
+    dfn,
+    [asFullyQualifiedName, asQualifiedName, asMethodName, asLocalName],
+    definitionMap
+  );
   return dfn;
 }
 

--- a/src/core/dfn-finder.js
+++ b/src/core/dfn-finder.js
@@ -86,15 +86,11 @@ function findAttributeDfn(defn, parent, name, definitionMap) {
   const parentLow = parent.toLowerCase();
   const asLocalName = name.toLowerCase();
   const asQualifiedName = parentLow + "." + asLocalName;
-  let dfn;
-  if (definitionMap[asQualifiedName] || definitionMap[asLocalName]) {
-    dfn = findNormalDfn(defn, parent, asLocalName, definitionMap);
-  }
+  const dfn = findNormalDfn(defn, parent, asLocalName, definitionMap);
   if (!dfn) {
-    // try finding dfn using name, using normal search path...
-    return findNormalDfn(defn, parent, name, definitionMap);
+    return;
   }
-  addAlternativeNames(dfn, [asQualifiedName, asLocalName]);
+  addAlternativeNames(dfn, [asQualifiedName, asLocalName], definitionMap);
   return dfn;
 }
 
@@ -116,45 +112,31 @@ function findOperationDfn(defn, parent, name, definitionMap) {
   const asQualifiedName = parentLow + "." + asLocalName;
   const asFullyQualifiedName = asQualifiedName + "()";
 
-  if (
-    definitionMap[asMethodName] ||
-    definitionMap[asFullyQualifiedName.toLowerCase()]
-  ) {
-    const lookupName = definitionMap[asMethodName]
-      ? asMethodName
-      : asFullyQualifiedName;
-    const dfn = findNormalDfn(defn, parent, lookupName, definitionMap);
-    if (!dfn) {
-      // try finding dfn using name, using normal search path...
-      return findNormalDfn(defn, parent, name, definitionMap);
-    }
-    addAlternativeNames(dfn, [
-      asFullyQualifiedName,
-      asQualifiedName,
-      lookupName,
-      asLocalName,
-    ]);
-    registerDefinitionMapping(dfn, asLocalName, definitionMap);
-    return dfn;
-  }
-  // no method alias, so let's find the dfn and add it
-  const dfn = findNormalDfn(defn, parent, name, definitionMap);
+  const dfn =
+    findNormalDfn(defn, parent, asMethodName, definitionMap) ||
+    findNormalDfn(defn, parent, name, definitionMap);
   if (!dfn) {
     return;
   }
-  addAlternativeNames(dfn, [asMethodName, name]);
-  registerDefinitionMapping(dfn, asMethodName, definitionMap);
+  addAlternativeNames(dfn, [
+    asFullyQualifiedName,
+    asQualifiedName,
+    asMethodName,
+    asLocalName,
+  ], definitionMap);
   return dfn;
 }
 
 /**
  * @param {HTMLElement} dfn
  * @param {string[]} names
+ * @param {Record<string, HTMLElement[]>} definitionMap
  */
-function addAlternativeNames(dfn, names) {
+function addAlternativeNames(dfn, names, definitionMap) {
   const lt = dfn.dataset.lt ? dfn.dataset.lt.split("|") : [];
   lt.push(...names);
   dfn.dataset.lt = [...new Set(lt)].join("|");
+  registerDefinitionMapping(dfn, names, definitionMap);
 }
 
 /**
@@ -179,7 +161,7 @@ function findNormalDfn(defn, parent, name, definitionMap) {
       dfns = dfnForArray;
       // Found it: register with its local name
       delete definitionMap[resolvedName];
-      registerDefinitionMapping(dfns[0], nameLow, definitionMap);
+      registerDefinitionMapping(dfns[0], [nameLow], definitionMap);
     }
   }
   if (dfns.length > 1) {

--- a/src/core/dfn.js
+++ b/src/core/dfn.js
@@ -27,11 +27,11 @@ export function run(conf) {
  * @param {Record<string, HTMLElement[]>} definitionMap
  */
 export function registerDefinitionMapping(dfn, names, definitionMap) {
-  names.forEach(name => {
+  for (const name of names) {
     if (!definitionMap[name]) {
       definitionMap[name] = [dfn];
     } else if (!definitionMap[name].includes(dfn)) {
       definitionMap[name].push(dfn);
     }
-  });
+  };
 }

--- a/src/core/dfn.js
+++ b/src/core/dfn.js
@@ -33,5 +33,5 @@ export function registerDefinitionMapping(dfn, names, definitionMap) {
     } else if (!definitionMap[name].includes(dfn)) {
       definitionMap[name].push(dfn);
     }
-  };
+  }
 }

--- a/src/core/dfn.js
+++ b/src/core/dfn.js
@@ -16,22 +16,22 @@ export function run(conf) {
     }
     // TODO: we should probably use weakmaps and weaksets here to avoid leaks.
     const titles = getDfnTitles(dfn, { isDefinition: true });
-    titles.forEach(title => {
-      return registerDefinitionMapping(dfn, title, conf.definitionMap);
-    });
+    registerDefinitionMapping(dfn, titles, conf.definitionMap);
   });
 }
 
 /**
  *
  * @param {HTMLElement} dfn
- * @param {string} name
+ * @param {string[]} name
  * @param {Record<string, HTMLElement[]>} definitionMap
  */
-export function registerDefinitionMapping(dfn, name, definitionMap) {
-  if (!definitionMap[name]) {
-    definitionMap[name] = [dfn];
-  } else if (!definitionMap[name].includes(dfn)) {
-    definitionMap[name].push(dfn);
-  }
+export function registerDefinitionMapping(dfn, names, definitionMap) {
+  names.forEach(name => {
+    if (!definitionMap[name]) {
+      definitionMap[name] = [dfn];
+    } else if (!definitionMap[name].includes(dfn)) {
+      definitionMap[name].push(dfn);
+    }
+  });
 }

--- a/tests/spec/core/dfn-finder-spec.js
+++ b/tests/spec/core/dfn-finder-spec.js
@@ -23,4 +23,29 @@ describe("Core — Definition finder", () => {
     expect(dfn.dataset.lt).toBe("bar()|bar|foo.bar()|foo.bar");
     expect(dfn.classList.contains("respec-offending-element")).toBeFalsy();
   });
+
+  it("should enumerate operation alternative names", async () => {
+    const bodyText = `
+      <section data-dfn-for="Foo">
+        <h2>Test section</h2>
+        <pre class="idl">
+          [Exposed=Window]
+          interface Foo {
+            void bar();
+            void baz();
+          };
+        </pre>
+        <dfn id="bar">bar</dfn>
+        <dfn id="baz">baz()</dfn>
+      </section>`;
+    const ops = {
+      config: makeBasicConfig(),
+      body: makeDefaultBody() + bodyText,
+    };
+    const doc = await makeRSDoc(ops);
+    const bar = doc.getElementById("bar");
+    expect(bar.dataset.lt).toBe("foo.bar()|foo.bar|bar()|bar");
+    const baz = doc.getElementById("baz");
+    expect(baz.dataset.lt).toBe("foo.baz()|foo.baz|baz()|baz");
+  });
 });


### PR DESCRIPTION
This fixes https://github.com/w3c/respec/issues/1878#issuecomment-437748048:

>>Removing data-lt solves the issue but also removes gamepadhapticactuator.pulse()|gamepadhapticactuator.pulse. Is this expected?
>
>No. We should fix that.