### PR TITLE
fix(core/figures): use childNodes instead of <figcaption>

### DIFF
--- a/src/core/figures.js
+++ b/src/core/figures.js
@@ -78,7 +78,7 @@ function getTableOfFiguresListItem(figureId, caption) {
     renameElement(anchor, "span").removeAttribute("href");
   });
   return hyperHTML`<li class='tofline'>
-    <a class='tocxref' href='${`#${figureId}`}'>${tofCaption}</a>
+    <a class='tocxref' href='${`#${figureId}`}'>${tofCaption.childNodes}</a>
   </li>`;
 }
 

--- a/tests/spec/core/figures-spec.js
+++ b/tests/spec/core/figures-spec.js
@@ -67,6 +67,7 @@ describe("Core - Figures", () => {
     const tofHeader = tof.querySelector("h2");
     const tofItems = tof.querySelectorAll("ul li");
     const figLinks = tof.querySelectorAll("ul li a");
+    expect(tof.querySelector("figcaption")).toBeNull();
     expect(tofHeader).toBeTruthy();
     expect(tofHeader.textContent).toEqual("1. Table of Figures");
     expect(tofItems.length).toEqual(2);


### PR DESCRIPTION
A regression caused by #1943.