### PR TITLE
refactor: avoid using insertBefore()

### DIFF
--- a/src/core/best-practices.js
+++ b/src/core/best-practices.js
@@ -19,10 +19,7 @@ export function run() {
       bp.textContent
     }</li>`;
     ul.appendChild(li);
-    bp.insertBefore(
-      document.createTextNode(`Best Practice ${num}: `),
-      bp.firstChild
-    );
+    bp.prepend(document.createTextNode(`Best Practice ${num}: `));
   }
   const bpSummary = document.getElementById("bp-summary");
   if (bps.length) {

--- a/src/core/examples.js
+++ b/src/core/examples.js
@@ -47,7 +47,7 @@ export function run(conf) {
     if (example.localName === "aside") {
       ++number;
       const div = makeTitle(conf, example, number, report);
-      example.insertBefore(div, example.firstChild);
+      example.prepend(div);
       const id = addId(example, "ex-" + number, title);
       const selfLink = div.querySelector("a.self-link");
       selfLink.href = `#${id}`;

--- a/src/core/exporter.js
+++ b/src/core/exporter.js
@@ -83,7 +83,7 @@ function cleanup(cloneDoc) {
   `;
 
   insertions.appendChild(metaGenerator);
-  head.insertBefore(insertions, head.firstChild);
+  head.prepend(insertions);
   pub("beforesave", documentElement);
 }
 

--- a/src/core/markdown.js
+++ b/src/core/markdown.js
@@ -107,7 +107,7 @@ class Builder {
     node.appendChild(process(node));
 
     if (header) {
-      node.insertBefore(header, node.firstChild);
+      node.prepend(header);
     }
 
     parent.appendChild(node);

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -117,13 +117,7 @@ export function makeOwnerSwapper(node) {
   }
   return insertionPoint => {
     insertionPoint.ownerDocument.adoptNode(node);
-    if (insertionPoint.firstElementChild) {
-      return insertionPoint.insertBefore(
-        node,
-        insertionPoint.firstElementChild
-      );
-    }
-    insertionPoint.appendChild(node);
+    insertionPoint.prepend(node);
   };
 }
 

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -284,7 +284,7 @@ export function run(conf) {
     if (link) {
       const style = document.createElement("style");
       style.textContent = css;
-      link.parentElement.insertBefore(style, link);
+      link.before(style);
     }
   }
 

--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -509,7 +509,7 @@ export function run(conf) {
 
   // insert into document
   const header = (conf.isCGBG ? cgbgHeadersTmpl : headersTmpl)(conf);
-  document.body.insertBefore(header, document.body.firstChild);
+  document.body.prepend(header);
   document.body.classList.add("h-entry");
 
   // handle SotD

--- a/src/w3c/informative.js
+++ b/src/w3c/informative.js
@@ -8,9 +8,6 @@ export function run() {
     .map(informative => informative.querySelector("h2, h3, h4, h5, h6"))
     .filter(heading => heading)
     .forEach(heading => {
-      heading.parentNode.insertBefore(
-        hyperHTML`<p><em>This section is non-normative.</em></p>`,
-        heading.nextSibling
-      );
+      heading.after(hyperHTML`<p><em>This section is non-normative.</em></p>`);
     });
 }

--- a/src/w3c/style.js
+++ b/src/w3c/style.js
@@ -99,10 +99,10 @@ const elements = createResourceHints();
 elements.appendChild(createBaseStyle());
 if (!document.head.querySelector("meta[name=viewport]")) {
   // Make meta viewport the first element in the head.
-  elements.insertBefore(createMetaViewport(), elements.firstChild);
+  elements.prepend(createMetaViewport());
 }
 
-document.head.insertBefore(elements, document.head.firstChild);
+document.head.prepend(elements);
 
 export function run(conf) {
   if (!conf.specStatus) {


### PR DESCRIPTION
`insertBefore()` is still useful but we now have better modern methods, which only requires a single argument and thus more readable.