### PR TITLE
refactor(core/issue-notes): remove jquery

### DIFF
--- a/src/core/issues-notes.js
+++ b/src/core/issues-notes.js
@@ -10,7 +10,7 @@
 // numbered to avoid involuntary clashes.
 // If the configuration has issueBase set to a non-empty string, and issues are
 // manually numbered, a link to the issue is created using issueBase and the issue number
-import { addId, fetchAndCache } from "./utils";
+import { addId, fetchAndCache, parents } from "./utils";
 import css from "../deps/text!core/css/issues-notes.css";
 import hyperHTML from "../deps/hyperhtml";
 import { pub } from "./pubsubhub";
@@ -120,7 +120,7 @@ function handleIssues(ins, ghIssues, conf) {
             issueList.append(li);
           }
         }
-        tit.querySelector("span").innerHTML = text;
+        tit.querySelector("span").textContent = text;
         if (ghIssue && report.title && githubAPI) {
           if (ghIssue.state === "closed") div.classList.add("closed");
           const labelsGroup = Array.from(ghIssue.labels || [])
@@ -165,7 +165,7 @@ function handleIssues(ins, ghIssues, conf) {
           body = hyperHTML`${ghIssue.body_html}`;
         }
         div.append(body);
-        const level = getCount(tit);
+        const level = parents(tit, "section").length + 2;
         tit.setAttribute("aria-level", level);
       }
       pub(report.type, report);
@@ -176,7 +176,7 @@ function handleIssues(ins, ghIssues, conf) {
       issueSummaryElement.innerHTML = issueSummary.innerHTML;
   } else if (issueSummaryElement) {
     pub("warn", "Using issue summary (#issue-summary) but no issues found.");
-    issueSummaryElement.parentNode.removeChild(issueSummaryElement);
+    issueSummaryElement.remove();
   }
 }
 
@@ -237,16 +237,6 @@ function createLabel(label) {
     class="${cssClasses}"
     style="${style}"
     href="${href}">${name}</a>`;
-}
-
-function getCount(currentEl) {
-  let el = currentEl;
-  let count = 0;
-  while (el !== null) {
-    if (el.tagName === "SECTION") count++;
-    el = el.parentElement;
-  }
-  return count + 2;
 }
 
 async function processResponse(response, issueNumber) {

--- a/src/core/issues-notes.js
+++ b/src/core/issues-notes.js
@@ -86,11 +86,17 @@ function handleIssues(ins, ghIssues, conf) {
               text += " " + dataNum;
               // Set issueBase to cause issue to be linked to the external issue tracker
               if (!isFeatureAtRisk && issueBase) {
-                tit.querySelector(".issue-number").innerHTMl =
-                  "<a href='" + issueBase + dataNum + "'/>";
+                const span = tit.querySelector("span");
+                const a = hyperHTML`<a href='${issueBase + dataNum}'/>`;
+                span.parentNode.insertBefore(a, span);
+                a.append(span);
+                console.log(a.parentNode);
               } else if (isFeatureAtRisk && conf.atRiskBase) {
-                tit.querySelector(".issue-number").innerHTML =
-                  "<a href='" + conf.atRiskBase + dataNum + "'/>";
+                const span = tit.querySelector("span");
+                const a = hyperHTML`<a href='${conf.atRiskBase + dataNum}'/>`;
+                span.parentNode.insertBefore(a, span);
+                a.append(span);
+                console.log(a.parentNode);
               }
               tit.querySelector("span").classList.add("issue-number");
               ghIssue = ghIssues.get(Number(dataNum));
@@ -108,13 +114,13 @@ function handleIssues(ins, ghIssues, conf) {
             a.setAttribute("href", "#" + div.id);
             a.append(conf.l10n.issue + " " + report.number);
             if (report.title) {
-              li.appendChild(
+              li.append(
                 hyperHTML`<span style='text-transform: none'>: ${
                   report.title
                 }</span>`
               );
             }
-            issueList.appendChild(li);
+            issueList.append(li);
           }
         }
         tit.querySelector("span").innerHTML = text;
@@ -134,17 +140,18 @@ function handleIssues(ins, ghIssues, conf) {
             })
             .map(createLabel)
             .reduce((frag, labelElem) => {
-              frag.appendChild(labelElem);
+              frag.append(labelElem);
               return frag;
             }, document.createDocumentFragment());
-          tit.appendChild(
-            hyperHTML`<span style='text-transform: none'>: ${
-              report.title
-            }</span>`.append(labelsGroup)
-          );
+          const node = hyperHTML`<span style='text-transform: none'>: ${
+            report.title
+          }</span>`;
+          node.append(labelsGroup);
+
+          tit.append(node);
           inno.removeAttribute("title");
         } else if (report.title) {
-          tit.appendChild(
+          tit.append(
             hyperHTML`<span style='text-transform: none'>: ${
               report.title
             }</span>`
@@ -152,15 +159,16 @@ function handleIssues(ins, ghIssues, conf) {
           inno.removeAttribute("title");
         }
         tit.classList.add("marker");
-        div.appendChild(tit);
+        div.append(tit);
         let body = inno;
         inno.replaceWith(div);
         body.classList.remove(report.type);
         body.removeAttribute("data-number");
-        if (ghIssue && !body.innerHTML().trim()) {
-          body = ghIssue.body_html;
+        if (ghIssue && !body.innerHTML.trim()) {
+          body = hyperHTML`${ghIssue.body_html}`;
         }
-        div.appendChild(body);
+        console.log(body);
+        div.append(body);
         const level = getCount(tit);
         tit.setAttribute("aria-level", level);
       }

--- a/src/core/issues-notes.js
+++ b/src/core/issues-notes.js
@@ -117,7 +117,7 @@ function handleIssues(ins, ghIssues, conf) {
             const li = htmlToElement("<li><a></a></li>");
             const a = li.querySelectorAll("a")[0];
             a.setAttribute("href", "#" + div.id);
-            a.innerHtml = conf.l10n.issue + " " + report.number;
+            a.append(conf.l10n.issue + " " + report.number);
             if (report.title) {
               li.appendChild(
                 htmlToElement(

--- a/src/core/issues-notes.js
+++ b/src/core/issues-notes.js
@@ -26,8 +26,7 @@ function handleIssues(ins, ghIssues, conf) {
     conf.l10n.issue_summary
   }</h2><ul></ul></div>`;
   const issueList = issueSummary.querySelector("ul");
-  Array.prototype.slice
-    .call(ins)
+  [...ins]
     .filter(issue => issue.parentElement)
     .forEach(inno => {
       const isIssue = inno.classList.contains("issue");
@@ -35,7 +34,7 @@ function handleIssues(ins, ghIssues, conf) {
       const isEdNote = inno.classList.contains("ednote");
       const isFeatureAtRisk = inno.classList.contains("atrisk");
       const isInline = inno.localName === "span";
-      const dataNum = inno.getAttribute("data-number");
+      const { number: dataNum } = inno.dataset;
       const report = {
         inline: isInline,
       };
@@ -90,13 +89,11 @@ function handleIssues(ins, ghIssues, conf) {
                 const a = hyperHTML`<a href='${issueBase + dataNum}'/>`;
                 span.parentNode.insertBefore(a, span);
                 a.append(span);
-                console.log(a.parentNode);
               } else if (isFeatureAtRisk && conf.atRiskBase) {
                 const span = tit.querySelector("span");
                 const a = hyperHTML`<a href='${conf.atRiskBase + dataNum}'/>`;
                 span.parentNode.insertBefore(a, span);
                 a.append(span);
-                console.log(a.parentNode);
               }
               tit.querySelector("span").classList.add("issue-number");
               ghIssue = ghIssues.get(Number(dataNum));
@@ -167,7 +164,6 @@ function handleIssues(ins, ghIssues, conf) {
         if (ghIssue && !body.innerHTML.trim()) {
           body = hyperHTML`${ghIssue.body_html}`;
         }
-        console.log(body);
         div.append(body);
         const level = getCount(tit);
         tit.setAttribute("aria-level", level);

--- a/src/core/issues-notes.js
+++ b/src/core/issues-notes.js
@@ -114,7 +114,6 @@ function handleIssues(ins, ghIssues, conf) {
     }
   </li>`;
           issueList.append(li);
-          issueList.append(li);
         }
       }
       tit.querySelector("span").textContent = text;

--- a/src/core/issues-notes.js
+++ b/src/core/issues-notes.js
@@ -85,12 +85,12 @@ function handleIssues(ins, ghIssues, conf) {
             if (!isFeatureAtRisk && issueBase) {
               const span = tit.querySelector("span");
               const a = hyperHTML`<a href='${issueBase + dataNum}'/>`;
-              span.parentNode.insertBefore(a, span);
+              span.before(a);
               a.append(span);
             } else if (isFeatureAtRisk && conf.atRiskBase) {
               const span = tit.querySelector("span");
               const a = hyperHTML`<a href='${conf.atRiskBase + dataNum}'/>`;
-              span.parentNode.insertBefore(a, span);
+              span.before(a);
               a.append(span);
             }
             tit.querySelector("span").classList.add("issue-number");
@@ -104,17 +104,16 @@ function handleIssues(ins, ghIssues, conf) {
         }
         if (report.number !== undefined) {
           // Add entry to #issue-summary.
-          const li = hyperHTML`<li><a></a></li>`;
-          const a = li.querySelector("a");
-          a.setAttribute("href", "#" + div.id);
-          a.append(conf.l10n.issue + " " + report.number);
-          if (report.title) {
-            li.append(
-              hyperHTML`<span style='text-transform: none'>: ${
-                report.title
-              }</span>`
-            );
-          }
+          const li = hyperHTML`
+  <li>
+    <a href="${"#" + div.id}">${conf.l10n.issue + " " + report.number}</a>
+    ${
+      report.title
+        ? hyperHTML`<span style="text-transform: none">: ${report.title}</span>`
+        : ""
+    }
+  </li>`;
+          issueList.append(li);
           issueList.append(li);
         }
       }


### PR DESCRIPTION
I did most of the refactoring. However, there is this small makeID function, as far as I understand, it's for tracking #issue on the page. It is linked to global jQuery object.
![screenshot from 2018-12-22 02-54-18](https://user-images.githubusercontent.com/33961252/50364188-e7934d80-0594-11e9-9a0b-2d81a98883c9.png)

But it's being used inside core/issues-notes.js. It further refers to another function somewhere in Utils. How do I proceed? @sidvishnoi @marcoscaceres 

refers to issue #1846 