### PR TITLE
refactor(tests/spec): remove jQuery

### DIFF
--- a/tests/spec/core/dfn-spec.js
+++ b/tests/spec/core/dfn-spec.js
@@ -9,7 +9,7 @@ describe("Core — Definitions", () => {
         "<section id='dfn'><dfn>text</dfn><a>text</a></section>",
     };
     const doc = await makeRSDoc(ops);
-    const sec = doc.querySelector("#dfn");
+    const sec = doc.getElementById("dfn");
     expect(sec.querySelector("dfn").id).toEqual("dfn-text");
     expect(sec.querySelector("a").getAttribute("href")).toEqual("#dfn-text");
   });
@@ -32,7 +32,7 @@ describe("Core — Definitions", () => {
     };
 
     const doc = await makeRSDoc(ops);
-    const sec = doc.querySelector("#dfn");
+    const sec = doc.getElementById("dfn");
     const anchors = [...sec.children].filter(node => node.localName === "a");
     expect(anchors[0].childNodes[0].textContent).toEqual("outerCode");
     expect(anchors[0].childNodes[0].nodeName).toEqual("CODE");

--- a/tests/spec/core/dfn-spec.js
+++ b/tests/spec/core/dfn-spec.js
@@ -9,9 +9,9 @@ describe("Core — Definitions", () => {
         "<section id='dfn'><dfn>text</dfn><a>text</a></section>",
     };
     const doc = await makeRSDoc(ops);
-    const $sec = $("#dfn", doc);
-    expect($sec.find("dfn").attr("id")).toEqual("dfn-text");
-    expect($sec.find("a").attr("href")).toEqual("#dfn-text");
+    const sec = doc.querySelector("#dfn");
+    expect(sec.querySelector("dfn").id).toEqual("dfn-text");
+    expect(sec.querySelector("a").getAttribute("href")).toEqual("#dfn-text");
   });
 
   it("makes links <code> when their definitions are <code>", async () => {
@@ -30,17 +30,28 @@ describe("Core — Definitions", () => {
           <a>partial inner code</a>
         </section>`,
     };
+
+    const getNodeArray = NodeList => Array.prototype.slice.call(NodeList);
+
     const doc = await makeRSDoc(ops);
     const $sec = $("#dfn", doc);
-    expect($sec.find("a:contains('outerCode')").contents()[0].nodeName).toEqual(
-      "CODE"
-    );
-    expect($sec.find("a:contains('outerPre')").contents()[0].nodeName).toEqual(
-      "CODE"
-    );
-    expect($sec.find("a:contains('innerCode')").contents()[0].nodeName).toEqual(
-      "CODE"
-    );
+    const sec = doc.querySelector("#dfn");
+    const findAnchorChild = (
+      string,
+      anchorArray = getNodeArray(sec.querySelectorAll("a"))
+    ) =>
+      anchorArray.reduce((result, anchor) => {
+        const innerFind = getNodeArray(anchor.children).filter(element =>
+          element.textContent.includes(string)
+        )[0];
+        if (innerFind !== undefined) result.push(innerFind);
+        else if (anchor.textContent.includes(string)) result.push(anchor);
+        return result;
+      }, []);
+
+    expect(findAnchorChild("outerCode")[0].nodeName).toEqual("CODE");
+    expect(findAnchorChild("outerPre")[0].nodeName).toEqual("CODE");
+    expect(findAnchorChild("innerCode")[0].nodeName).toEqual("CODE");
     expect($sec.find("a:contains('partial')").contents()[0].nodeName).toEqual(
       "#text"
     );

--- a/tests/spec/core/dfn-spec.js
+++ b/tests/spec/core/dfn-spec.js
@@ -31,30 +31,17 @@ describe("Core — Definitions", () => {
         </section>`,
     };
 
-    const getNodeArray = NodeList => Array.prototype.slice.call(NodeList);
-
     const doc = await makeRSDoc(ops);
-    const $sec = $("#dfn", doc);
     const sec = doc.querySelector("#dfn");
-    const findAnchorChild = (
-      string,
-      anchorArray = getNodeArray(sec.querySelectorAll("a"))
-    ) =>
-      anchorArray.reduce((result, anchor) => {
-        const innerFind = getNodeArray(anchor.children).filter(element =>
-          element.textContent.includes(string)
-        )[0];
-        if (innerFind !== undefined) result.push(innerFind);
-        else if (anchor.textContent.includes(string)) result.push(anchor);
-        return result;
-      }, []);
-
-    expect(findAnchorChild("outerCode")[0].nodeName).toEqual("CODE");
-    expect(findAnchorChild("outerPre")[0].nodeName).toEqual("CODE");
-    expect(findAnchorChild("innerCode")[0].nodeName).toEqual("CODE");
-    expect($sec.find("a:contains('partial')").contents()[0].nodeName).toEqual(
-      "#text"
-    );
+    const anchors = [...sec.children].filter(node => node.localName === "a");
+    expect(anchors[0].childNodes[0].textContent).toEqual("outerCode");
+    expect(anchors[0].childNodes[0].nodeName).toEqual("CODE");
+    expect(anchors[1].childNodes[0].textContent).toEqual("outerPre");
+    expect(anchors[1].childNodes[0].nodeName).toEqual("CODE");
+    expect(anchors[2].childNodes[0].textContent).toEqual("innerCode");
+    expect(anchors[2].childNodes[0].nodeName).toEqual("CODE");
+    expect(anchors[3].childNodes[0].textContent).toEqual("partial inner code");
+    expect(anchors[3].childNodes[0].nodeName).toEqual("#text");
   });
 
   it("links <code> for IDL, but not when text doesn't match", async () => {

--- a/tests/spec/core/informative-spec.js
+++ b/tests/spec/core/informative-spec.js
@@ -9,9 +9,9 @@ describe("Core — Informative", () => {
         "<section class='informative'><h2>TITLE</h2></section>",
     };
     const doc = await makeRSDoc(ops);
-    const $sec = $("div.informative, section.informative", doc);
-    expect($sec.find("p").length).toEqual(1);
-    expect($sec.find("p em").length).toEqual(1);
-    expect($sec.find("p em").text()).toEqual("This section is non-normative.");
+    const sec = doc.querySelector("div.informative, section.informative");
+    expect(sec.querySelectorAll("p").length).toEqual(1);
+    expect(sec.querySelectorAll("p em").length).toEqual(1);
+    expect(sec.querySelector("p em").textContent).toEqual("This section is non-normative.");
   });
 });

--- a/tests/spec/core/informative-spec.js
+++ b/tests/spec/core/informative-spec.js
@@ -12,6 +12,8 @@ describe("Core — Informative", () => {
     const sec = doc.querySelector("div.informative, section.informative");
     expect(sec.querySelectorAll("p").length).toEqual(1);
     expect(sec.querySelectorAll("p em").length).toEqual(1);
-    expect(sec.querySelector("p em").textContent).toEqual("This section is non-normative.");
+    expect(sec.querySelector("p em").textContent).toEqual(
+      "This section is non-normative."
+    );
   });
 });

--- a/tests/spec/core/section-refs-spec.js
+++ b/tests/spec/core/section-refs-spec.js
@@ -9,9 +9,10 @@ describe("Core - Section References", () => {
         "<section id='ONE'><h2>ONE</h2></section><section id='TWO'><a href='#ONE' class='sectionRef'></a></section>",
     };
     const doc = await makeRSDoc(ops);
-    const $one = $("#ONE", doc);
-    const $two = $("#TWO", doc);
-    const tit = $one.find("> :first-child").text();
-    expect($two.find("a").text()).toEqual("section " + tit);
+    const one = doc.querySelector("#ONE");
+    const two = doc.querySelector("#TWO");
+    const tit = one.children[0].textContent;
+
+    expect(two.querySelector("a").textContent).toEqual("section " + tit);
   });
 });

--- a/tests/spec/core/structure-spec.js
+++ b/tests/spec/core/structure-spec.js
@@ -78,12 +78,17 @@ describe("Core - Structure", () => {
     expect(toc.querySelector("h2").textContent).toEqual("Table of Contents");
     expect(doc.querySelectorAll("#toc > ol > li").length).toEqual(3);
     expect(toc.querySelectorAll("li").length).toEqual(11);
-    expect(doc.querySelector("#toc > ol > li > a").textContent).toEqual("1. ONE");
+    expect(doc.querySelector("#toc > ol > li > a").textContent).toEqual(
+      "1. ONE"
+    );
     expect(toc.querySelector("a[href='#four']").textContent).toEqual(
       "1.1.1.1 FOUR"
     );
 
-    expect(doc.querySelector("#toc > ol > li").nextSibling.querySelector("a").textContent).toEqual("A. ONE");
+    expect(
+      doc.querySelector("#toc > ol > li").nextSibling.querySelector("a")
+        .textContent
+    ).toEqual("A. ONE");
 
     expect(toc.querySelector("a[href='#four-0']").textContent).toEqual(
       "A.1.1.1 FOUR"

--- a/tests/spec/core/structure-spec.js
+++ b/tests/spec/core/structure-spec.js
@@ -52,17 +52,29 @@ describe("Core - Structure", () => {
     };
     ops.config.tocIntroductory = true;
     const doc = await makeRSDoc(ops);
-    const $toc = $("#toc", doc);
-    expect($toc.find("h2").text()).toEqual("Table of Contents");
-    expect($toc.find("> ol > li").length).toEqual(6);
-    expect($toc.find("li").length).toEqual(18);
+    const toc = doc.querySelector("#toc");
+    expect(toc.querySelector("h2").textContent).toEqual("Table of Contents");
+    const heirLI = Array.prototype.slice
+      .call(toc.children)
+      .reduce((result, child) => {
+        if (child.nodeName !== "OL") return result;
+        const childrenLi = [...child.children].filter(
+          element => element.nodeName === "LI"
+        );
+        return [...result, ...childrenLi];
+      }, []);
+    expect(heirLI.length).toEqual(6);
+    expect(toc.querySelectorAll("li").length).toEqual(18);
+    expect(heirLI[0].textContent).toEqual("Abstract");
     expect(
-      $toc
-        .find("> ol > li a")
-        .first()
-        .text()
-    ).toEqual("Abstract");
-    expect($toc.find("> ol > li a[href='#intro']").length).toEqual(1);
+      heirLI.reduce(
+        (result, element) => [
+          ...result,
+          ...element.querySelectorAll("a[href='#intro']"),
+        ],
+        []
+      ).length
+    ).toEqual(1);
   });
 
   it("should limit ToC depth with maxTocLevel", async () => {
@@ -72,26 +84,37 @@ describe("Core - Structure", () => {
     };
     ops.config.maxTocLevel = 4;
     const doc = await makeRSDoc(ops);
-    const $toc = $("#toc", doc);
-    expect($toc.find("h2").text()).toEqual("Table of Contents");
-    expect($toc.find("> ol > li").length).toEqual(3);
-    expect($toc.find("li").length).toEqual(11);
+    const toc = doc.querySelector("#toc");
+    expect(toc.querySelector("h2").textContent).toEqual("Table of Contents");
+    const heirLI = Array.prototype.slice
+      .call(toc.children)
+      .reduce((result, child) => {
+        if (child.nodeName !== "OL") return result;
+        const childrenLi = [...child.children].filter(
+          element => element.nodeName === "LI"
+        );
+        return [...result, ...childrenLi];
+      }, []);
+    expect(heirLI.length).toEqual(3);
+    expect(toc.querySelectorAll("li").length).toEqual(11);
     expect(
-      $toc
-        .find("> ol > li a")
-        .first()
-        .text()
+      heirLI.reduce(
+        (result, element) => [...result, ...element.querySelectorAll("a")],
+        []
+      )[0].textContent
     ).toEqual("1. ONE");
-    expect($toc.find("a[href='#four']").text()).toEqual("1.1.1.1 FOUR");
+    expect(toc.querySelector("a[href='#four']").textContent).toEqual(
+      "1.1.1.1 FOUR"
+    );
+
     expect(
-      $toc
-        .find("> ol > li")
-        .first()
-        .next()
-        .find("> a")
-        .text()
+      [...heirLI[0].nextSibling.children].filter(
+        element => element.nodeName === "A"
+      )[0].textContent
     ).toEqual("A. ONE");
-    expect($toc.find("a[href='#four-0']").text()).toEqual("A.1.1.1 FOUR");
+    expect(toc.querySelector("a[href='#four-0']").textContent).toEqual(
+      "A.1.1.1 FOUR"
+    );
     // should still add section number to the original header
     expect(doc.getElementById("x1-1-1-1-1-five").textContent).toBe(
       "1.1.1.1.1 FIVE"

--- a/tests/spec/core/structure-spec.js
+++ b/tests/spec/core/structure-spec.js
@@ -1,5 +1,12 @@
 "use strict";
 describe("Core - Structure", () => {
+  let utils;
+  beforeAll(done => {
+    require(["core/utils"], u => {
+      utils = u;
+      done();
+    });
+  });
   const body =
     makeDefaultBody() +
     "<section class='introductory'><h2>INTRO</h2></section>" +
@@ -54,15 +61,7 @@ describe("Core - Structure", () => {
     const doc = await makeRSDoc(ops);
     const toc = doc.querySelector("#toc");
     expect(toc.querySelector("h2").textContent).toEqual("Table of Contents");
-    const heirLI = Array.prototype.slice
-      .call(toc.children)
-      .reduce((result, child) => {
-        if (child.nodeName !== "OL") return result;
-        const childrenLi = [...child.children].filter(
-          element => element.nodeName === "LI"
-        );
-        return [...result, ...childrenLi];
-      }, []);
+    const heirLI = [...utils.children(toc, "ol > li")];
     expect(heirLI.length).toEqual(6);
     expect(toc.querySelectorAll("li").length).toEqual(18);
     expect(heirLI[0].textContent).toEqual("Abstract");
@@ -84,7 +83,7 @@ describe("Core - Structure", () => {
     };
     ops.config.maxTocLevel = 4;
     const doc = await makeRSDoc(ops);
-    const toc = doc.querySelector("#toc");
+    const toc = doc.getElementById("toc");
     expect(toc.querySelector("h2").textContent).toEqual("Table of Contents");
     const heirLI = Array.prototype.slice
       .call(toc.children)

--- a/tests/spec/core/structure-spec.js
+++ b/tests/spec/core/structure-spec.js
@@ -61,19 +61,10 @@ describe("Core - Structure", () => {
     const doc = await makeRSDoc(ops);
     const toc = doc.querySelector("#toc");
     expect(toc.querySelector("h2").textContent).toEqual("Table of Contents");
-    const heirLI = [...utils.children(toc, "ol > li")];
-    expect(heirLI.length).toEqual(6);
+    expect(utils.children(toc, "ol > li").length).toEqual(6);
     expect(toc.querySelectorAll("li").length).toEqual(18);
-    expect(heirLI[0].textContent).toEqual("Abstract");
-    expect(
-      heirLI.reduce(
-        (result, element) => [
-          ...result,
-          ...element.querySelectorAll("a[href='#intro']"),
-        ],
-        []
-      ).length
-    ).toEqual(1);
+    expect(toc.querySelector("ol > li").textContent).toEqual("Abstract");
+    expect(utils.children(toc, "ol > li a[href='#intro']").length).toEqual(1);
   });
 
   it("should limit ToC depth with maxTocLevel", async () => {
@@ -85,32 +76,15 @@ describe("Core - Structure", () => {
     const doc = await makeRSDoc(ops);
     const toc = doc.getElementById("toc");
     expect(toc.querySelector("h2").textContent).toEqual("Table of Contents");
-    const heirLI = Array.prototype.slice
-      .call(toc.children)
-      .reduce((result, child) => {
-        if (child.nodeName !== "OL") return result;
-        const childrenLi = [...child.children].filter(
-          element => element.nodeName === "LI"
-        );
-        return [...result, ...childrenLi];
-      }, []);
-    expect(heirLI.length).toEqual(3);
+    expect(doc.querySelectorAll("#toc > ol > li").length).toEqual(3);
     expect(toc.querySelectorAll("li").length).toEqual(11);
-    expect(
-      heirLI.reduce(
-        (result, element) => [...result, ...element.querySelectorAll("a")],
-        []
-      )[0].textContent
-    ).toEqual("1. ONE");
+    expect(doc.querySelector("#toc > ol > li > a").textContent).toEqual("1. ONE");
     expect(toc.querySelector("a[href='#four']").textContent).toEqual(
       "1.1.1.1 FOUR"
     );
 
-    expect(
-      [...heirLI[0].nextSibling.children].filter(
-        element => element.nodeName === "A"
-      )[0].textContent
-    ).toEqual("A. ONE");
+    expect(doc.querySelector("#toc > ol > li").nextSibling.querySelector("a").textContent).toEqual("A. ONE");
+
     expect(toc.querySelector("a[href='#four-0']").textContent).toEqual(
       "A.1.1.1 FOUR"
     );

--- a/tests/spec/core/utils-spec.js
+++ b/tests/spec/core/utils-spec.js
@@ -297,7 +297,9 @@ describe("Core - Utils", () => {
     it("adds several link elements", () => {
       utils.linkCSS(document, ["BOGUS", "BOGUS", "BOGUS"]);
       expect(document.querySelectorAll("link[href='BOGUS']").length).toEqual(3);
-      [...document.querySelectorAll("link[href='BOGUS']")].forEach(element => element.remove());
+      [...document.querySelectorAll("link[href='BOGUS']")].forEach(element =>
+        element.remove()
+      );
     });
   });
 

--- a/tests/spec/core/utils-spec.js
+++ b/tests/spec/core/utils-spec.js
@@ -297,9 +297,9 @@ describe("Core - Utils", () => {
     it("adds several link elements", () => {
       utils.linkCSS(document, ["BOGUS", "BOGUS", "BOGUS"]);
       expect(document.querySelectorAll("link[href='BOGUS']").length).toEqual(3);
-      [...document.querySelectorAll("link[href='BOGUS']")].forEach(element =>
-        element.remove()
-      );
+      document
+        .querySelectorAll("link[href='BOGUS']")
+        .forEach(element => element.remove());
     });
   });
 

--- a/tests/spec/core/utils-spec.js
+++ b/tests/spec/core/utils-spec.js
@@ -290,14 +290,14 @@ describe("Core - Utils", () => {
   describe("linkCSS", () => {
     it("adds a link element", () => {
       utils.linkCSS(document, "BOGUS");
-      expect($("link[href='BOGUS']").length).toEqual(1);
-      $("link[href='BOGUS']").remove();
+      expect(document.querySelectorAll("link[href='BOGUS']").length).toEqual(1);
+      document.querySelector("link[href='BOGUS']").remove();
     });
 
     it("adds several link elements", () => {
       utils.linkCSS(document, ["BOGUS", "BOGUS", "BOGUS"]);
-      expect($("link[href='BOGUS']").length).toEqual(3);
-      $("link[href='BOGUS']").remove();
+      expect(document.querySelectorAll("link[href='BOGUS']").length).toEqual(3);
+      [...document.querySelectorAll("link[href='BOGUS']")].forEach(element => element.remove());
     });
   });
 

--- a/tests/spec/w3c/conformance-spec.js
+++ b/tests/spec/w3c/conformance-spec.js
@@ -42,9 +42,7 @@ describe("W3C — Conformance", () => {
         </section>`,
     };
     const doc = await makeRSDoc(ops);
-    const c = doc.querySelector("#conformance");
-    const d = c.querySelectorAll(".rfc2119");
-    expect(d.length).toEqual(3);
+    expect(doc.querySelectorAll("#conformance .rfc2119").length).toEqual(3);
   });
 
   it("omits the 2119 reference when there are no terms", async () => {
@@ -60,8 +58,6 @@ describe("W3C — Conformance", () => {
         </section>`,
     };
     const doc = await makeRSDoc(ops);
-    const c = doc.querySelector("#conformance");
-    const d = c.querySelectorAll(".rfc2119");
-    expect(d.length).toEqual(0);
+    expect(doc.querySelectorAll("#conformance .rfc2119").length).toEqual(0);
   });
 });

--- a/tests/spec/w3c/conformance-spec.js
+++ b/tests/spec/w3c/conformance-spec.js
@@ -42,9 +42,9 @@ describe("W3C — Conformance", () => {
         </section>`,
     };
     const doc = await makeRSDoc(ops);
-    const $c = $("#conformance", doc);
-    const $d = $(".rfc2119", $c);
-    expect($d.length).toEqual(3);
+    const c = doc.querySelector("#conformance");
+    const d = c.querySelectorAll(".rfc2119");
+    expect(d.length).toEqual(3);
   });
 
   it("omits the 2119 reference when there are no terms", async () => {
@@ -60,8 +60,8 @@ describe("W3C — Conformance", () => {
         </section>`,
     };
     const doc = await makeRSDoc(ops);
-    const $c = $("#conformance", doc);
-    const $d = $(".rfc2119", $c);
-    expect($d.length).toEqual(0);
+    const c = doc.querySelector("#conformance");
+    const d = c.querySelectorAll(".rfc2119");
+    expect(d.length).toEqual(0);
   });
 });


### PR DESCRIPTION
I am working on #1846 removing jquery from test files. ```w3c/headers-spec``` has a pretty huge number of occurences. Might as well do them in a separate PR. Meanwhile I would appreciate if you could review these files @saschanaz @sidvishnoi @marcoscaceres :smile: 