### PR TITLE
linter rule for internal slots

### DIFF
--- a/src/core/linter-rules/internal-slot-warn.js
+++ b/src/core/linter-rules/internal-slot-warn.js
@@ -1,0 +1,50 @@
+/**
+ * Linter rule "internal-slot-warn".
+ */
+import LinterRule from "../LinterRule";
+import { lang as defaultLang } from "../l10n";
+
+const name = "internal-slot-warn";
+
+const meta = {
+  en: {
+    description: "Internal slots should be preceded by a '.'",
+    howToFix: "Add a '.' between the elements mentioned.",
+    help: "See developer console.",
+  },
+};
+
+// Fall back to english, if language is missing
+const lang = defaultLang in meta ? defaultLang : "en";
+
+/**
+ * Runs linter rule.
+ * @param {Object} config The ReSpec config.
+ * @param  {Document} doc The document to be checked.
+ */
+function linterFunction(conf, doc) {
+  const offendingElements = [...doc.querySelectorAll("var+a")].filter(
+    checkElement
+  );
+
+  if (!offendingElements.length) {
+    return [];
+  }
+
+  return {
+    name,
+    offendingElements,
+    occurrences: offendingElements.length,
+    ...meta[lang],
+  };
+}
+
+export const rule = new LinterRule(name, linterFunction);
+
+function checkElement(elem) {
+  return !(
+    elem.textContent.startsWith("[[") &&
+    elem.textContent.endsWith("]]") &&
+    elem.previousSibling.textContent === "."
+  );
+}

--- a/src/w3c/defaults.js
+++ b/src/w3c/defaults.js
@@ -3,6 +3,7 @@
  */
 export const name = "w3c/defaults";
 import { rule as checkPunctuation } from "../core/linter-rules/check-punctuation";
+import { rule as internalSlotWarning } from "../core/linter-rules/internal-slot-warn";
 import linter from "../core/linter";
 import { rule as localRefsExist } from "../core/linter-rules/local-refs-exist";
 import { rule as noHeadinglessSectionsRule } from "../core/linter-rules/no-headingless-sections";
@@ -14,7 +15,8 @@ linter.register(
   privsecSectionRule,
   noHeadinglessSectionsRule,
   checkPunctuation,
-  localRefsExist
+  localRefsExist,
+  internalSlotWarning
 );
 
 const cgbg = new Set(["BG-DRAFT", "BG-FINAL", "CG-DRAFT", "CG-FINAL"]);
@@ -62,6 +64,7 @@ const w3cDefaults = {
     "no-http-props": true,
     "check-punctuation": false,
     "local-refs-exist": true,
+    "internal-slot-warn": true,
   },
   pluralize: false,
   highlightVars: true,


### PR DESCRIPTION
I am working on #1713. I created the linter rule following the other rule files. 
This `<var>bar</var>.<a>[[\Foo]]</a>` is valid but since the text inside the `<a>` does not match any `<dfn>`, warning of type `Found linkless <a> element with text "[[Foo]]" but no matching <dfn>` is thrown.

Could you review this file and suggest how to work on this issue? @saschanaz @sidvishnoi @marcoscaceres 
