### PR TITLE
refactor: use package names for external dependencies

### DIFF
--- a/js/profile-w3c-common.js
+++ b/js/profile-w3c-common.js
@@ -7,8 +7,14 @@ window.addEventListener("error", ev => {
 // this is only set in a build, not at all in the dev environment
 require.config({
   paths: {
+    clipboard: "deps/clipboard",
+    hyperhtml: "deps/hyperhtml",
+    "idb-keyval": "deps/idb",
     jquery: "deps/jquery",
+    marked: "deps/marked",
+    pluralize: "deps/pluralize",
     text: "deps/text",
+    webidl2: "deps/webidl2",
   },
   shim: {
     shortcut: {

--- a/src/core/best-practices.js
+++ b/src/core/best-practices.js
@@ -4,7 +4,7 @@
 // Best practices are marked up with span.practicelab.
 import { addId } from "./utils";
 import css from "text!./css/bp.css";
-import hyperHTML from "../deps/hyperhtml";
+import hyperHTML from "hyperhtml";
 import { pub } from "./pubsubhub";
 
 export const name = "core/best-practices";

--- a/src/core/caniuse.js
+++ b/src/core/caniuse.js
@@ -6,7 +6,7 @@
 import { createResourceHint, fetchAndCache, semverCompare } from "./utils";
 import { pub, sub } from "./pubsubhub";
 import caniuseCss from "text!./css/caniuse.css";
-import hyperHTML from "../deps/hyperhtml";
+import hyperHTML from "hyperhtml";
 
 export const name = "core/caniuse";
 

--- a/src/core/data-cite.js
+++ b/src/core/data-cite.js
@@ -15,7 +15,7 @@
  */
 import { refTypeFromContext, showInlineWarning, wrapInner } from "./utils";
 import { resolveRef, updateFromNetwork } from "./biblio";
-import hyperHTML from "../deps/hyperhtml";
+import hyperHTML from "hyperhtml";
 export const name = "core/data-cite";
 
 function requestLookup(conf) {

--- a/src/core/data-tests.js
+++ b/src/core/data-tests.js
@@ -9,7 +9,7 @@
  * Docs: https://github.com/w3c/respec/wiki/data-tests
  */
 import { lang as defaultLang } from "./l10n";
-import hyperHTML from "../deps/hyperhtml";
+import hyperHTML from "hyperhtml";
 import { pub } from "./pubsubhub";
 const l10n = {
   en: {

--- a/src/core/examples.js
+++ b/src/core/examples.js
@@ -7,7 +7,7 @@
 
 import { addId, reindent } from "./utils";
 import css from "text!./css/examples.css";
-import hyperHTML from "../deps/hyperhtml";
+import hyperHTML from "hyperhtml";
 import { pub } from "./pubsubhub";
 
 export const name = "core/examples";

--- a/src/core/exporter.js
+++ b/src/core/exporter.js
@@ -6,7 +6,7 @@
  */
 
 import { expose } from "./expose-modules";
-import hyperHTML from "../deps/hyperhtml";
+import hyperHTML from "hyperhtml";
 import { pub } from "./pubsubhub";
 import { removeReSpec } from "./utils";
 

--- a/src/core/figures.js
+++ b/src/core/figures.js
@@ -4,7 +4,7 @@
 // Generates a Table of Figures wherever there is a #tof element.
 
 import { addId, renameElement, showInlineWarning, wrapInner } from "./utils";
-import hyperHTML from "../deps/hyperhtml";
+import hyperHTML from "hyperhtml";
 
 export const name = "core/figures";
 

--- a/src/core/id-headers.js
+++ b/src/core/id-headers.js
@@ -4,7 +4,7 @@
 
 export const name = "core/id-headers";
 import { addId } from "./utils";
-import hyperHTML from "../deps/hyperhtml";
+import hyperHTML from "hyperhtml";
 
 export function run(conf) {
   document

--- a/src/core/inline-idl-parser.js
+++ b/src/core/inline-idl-parser.js
@@ -13,7 +13,7 @@
  *  { base: "Dictionary", member: "member" }
  */
 
-import hyperHTML from "../deps/hyperhtml";
+import hyperHTML from "hyperhtml";
 
 const methodRegex = /\((.*)\)$/;
 const idlSplitRegex = /\b\.\b|\.(?=\[\[)/;

--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -14,7 +14,7 @@
 //    key word was used.  NOTE: While each member is a counter, at this time
 //    the counter is not used.
 import { getTextNodes, refTypeFromContext, showInlineWarning } from "./utils";
-import hyperHTML from "../deps/hyperhtml";
+import hyperHTML from "hyperhtml";
 import { idlStringToHtml } from "./inline-idl-parser";
 import { pub } from "./pubsubhub";
 export const name = "core/inlines";

--- a/src/core/issues-notes.js
+++ b/src/core/issues-notes.js
@@ -12,7 +12,7 @@
 // manually numbered, a link to the issue is created using issueBase and the issue number
 import { addId, fetchAndCache, parents } from "./utils";
 import css from "text!./css/issues-notes.css";
-import hyperHTML from "../deps/hyperhtml";
+import hyperHTML from "hyperhtml";
 import { pub } from "./pubsubhub";
 export const name = "core/issues-notes";
 

--- a/src/core/pluralize.js
+++ b/src/core/pluralize.js
@@ -7,7 +7,7 @@ import {
   isSingular,
   plural as pluralOf,
   singular as singularOf,
-} from "../deps/pluralize";
+} from "pluralize";
 import { norm as normalize } from "./utils";
 import { registerDefinition } from "./dfn-map";
 

--- a/src/core/render-biblio.js
+++ b/src/core/render-biblio.js
@@ -2,7 +2,7 @@
 // renders the biblio data pre-processed in core/biblio
 
 import { addId } from "./utils";
-import hyperHTML from "../deps/hyperhtml";
+import hyperHTML from "hyperhtml";
 import { pub } from "./pubsubhub";
 
 export const name = "core/render-biblio";

--- a/src/core/requirements.js
+++ b/src/core/requirements.js
@@ -9,7 +9,7 @@
 // 2.  It allows referencing requirements by their ID simply using an empty <a>
 //     element with its href pointing to the requirement it should be referencing
 //     and a class of "reqRef".
-import hyperHTML from "../deps/hyperhtml";
+import hyperHTML from "hyperhtml";
 import { pub } from "./pubsubhub";
 
 export const name = "core/requirements";

--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -10,7 +10,7 @@
 //  - maxTocLevel: only generate a TOC so many levels deep
 
 import { addId, children, parents, renameElement } from "./utils";
-import hyperHTML from "../deps/hyperhtml";
+import hyperHTML from "hyperhtml";
 
 const lowerHeaderTags = ["h2", "h3", "h4", "h5", "h6"];
 const headerTags = ["h1", ...lowerHeaderTags];

--- a/src/core/ui.js
+++ b/src/core/ui.js
@@ -10,7 +10,7 @@
 //  - once we have something decent, merge, ship as 3.2.0
 
 import css from "text!../ui/ui.css";
-import hyperHTML from "../deps/hyperhtml";
+import hyperHTML from "hyperhtml";
 import { markdownToHtml } from "./utils";
 import shortcut from "../shortcut";
 import { sub } from "./pubsubhub";

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -3,7 +3,7 @@
 // Module core/utils
 // As the name implies, this contains a ragtag gang of methods that just don't fit
 // anywhere else.
-import marked from "../deps/marked";
+import marked from "marked";
 import { pub } from "./pubsubhub";
 export const name = "core/utils";
 

--- a/src/core/webidl-clipboard.js
+++ b/src/core/webidl-clipboard.js
@@ -5,7 +5,7 @@
  * well-formatted IDL to the clipboard.
  *
  */
-import Clipboard from "../deps/clipboard";
+import Clipboard from "clipboard";
 import svgClipboard from "text!./images/clipboard.svg";
 export const name = "core/webidl-clipboard";
 

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -7,10 +7,10 @@
 import { flatten, normalizePadding, reindent } from "./utils";
 import css from "text!./css/webidl.css";
 import { findDfn } from "./dfn-finder";
-import hyperHTML from "../deps/hyperhtml";
+import hyperHTML from "hyperhtml";
 import { pub } from "./pubsubhub";
 import { registerDefinition } from "./dfn-map";
-import webidl2 from "../deps/webidl2";
+import webidl2 from "webidl2";
 import webidl2writer from "../deps/webidl2writer";
 
 export const name = "core/webidl";

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -4,7 +4,7 @@
 //   so later they can be handled by core/link-to-dfn.
 // https://github.com/w3c/respec/issues/1662
 
-import * as IDB from "../deps/idb";
+import * as IDB from "idb-keyval";
 import {
   nonNormativeSelector,
   norm as normalize,

--- a/src/type-helper.d.ts
+++ b/src/type-helper.d.ts
@@ -9,3 +9,8 @@ interface Element {
    */
   closest<T extends Element>(selector: string): T | null;
 }
+
+declare module "text!*" {
+  const value: string;
+  export default value;
+}

--- a/src/ui/about-respec.js
+++ b/src/ui/about-respec.js
@@ -1,7 +1,7 @@
 // Module ui/about-respec
 // A simple about dialog with pointer to the help
 import { l10n, lang } from "../core/l10n";
-import hyperHTML from "../deps/hyperhtml";
+import hyperHTML from "hyperhtml";
 import { ui } from "../core/ui";
 
 // window.respecVersion is added at build time (see tools/builder.js)

--- a/src/ui/dfn-list.js
+++ b/src/ui/dfn-list.js
@@ -2,7 +2,7 @@
 // Displays all definitions with links to the defining element.
 import { l10n, lang } from "../core/l10n";
 import { definitionMap } from "../core/dfn-map";
-import hyperHTML from "../deps/hyperhtml";
+import hyperHTML from "hyperhtml";
 import { ui } from "../core/ui";
 
 const button = ui.addCommand(

--- a/src/ui/save-html.js
+++ b/src/ui/save-html.js
@@ -1,7 +1,7 @@
 // Module ui/save-html
 // Saves content to HTML when asked to
 import { l10n, lang } from "../core/l10n";
-import hyperHTML from "../deps/hyperhtml";
+import hyperHTML from "hyperhtml";
 import { pub } from "../core/pubsubhub";
 import { rsDocToDataURL } from "../core/exporter";
 import { ui } from "../core/ui";

--- a/src/ui/search-specref.js
+++ b/src/ui/search-specref.js
@@ -1,7 +1,7 @@
 // Module ui/search-specref
 // Search Specref database
 import { l10n, lang } from "../core/l10n";
-import hyperHTML from "../deps/hyperhtml";
+import hyperHTML from "hyperhtml";
 import { ui } from "../core/ui";
 import { wireReference } from "../core/biblio";
 

--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -95,7 +95,7 @@ import { ISODate, concatDate, joinAnd } from "../core/utils";
 import cgbgHeadersTmpl from "./templates/cgbg-headers";
 import cgbgSotdTmpl from "./templates/cgbg-sotd";
 import headersTmpl from "./templates/headers";
-import hyperHTML from "../deps/hyperhtml";
+import hyperHTML from "hyperhtml";
 import { pub } from "../core/pubsubhub";
 import sotdTmpl from "./templates/sotd";
 

--- a/src/w3c/informative.js
+++ b/src/w3c/informative.js
@@ -1,6 +1,6 @@
 // Module w3c/informative
 // Mark specific sections as informative, based on CSS
-import hyperHTML from "../deps/hyperhtml";
+import hyperHTML from "hyperhtml";
 export const name = "w3c/informative";
 
 export function run() {

--- a/src/w3c/templates/cgbg-headers.js
+++ b/src/w3c/templates/cgbg-headers.js
@@ -1,4 +1,4 @@
-import hyperHTML from "../../deps/hyperhtml";
+import hyperHTML from "hyperhtml";
 import showLink from "./show-link";
 import showLogo from "./show-logo";
 import showPeople from "./show-people";

--- a/src/w3c/templates/cgbg-sotd.js
+++ b/src/w3c/templates/cgbg-sotd.js
@@ -1,4 +1,4 @@
-import hyperHTML from "../../deps/hyperhtml";
+import hyperHTML from "hyperhtml";
 
 export default conf => {
   const html = hyperHTML;

--- a/src/w3c/templates/conformance.js
+++ b/src/w3c/templates/conformance.js
@@ -1,4 +1,4 @@
-import hyperHTML from "../../deps/hyperhtml";
+import hyperHTML from "hyperhtml";
 
 export default () => {
   const html = hyperHTML;

--- a/src/w3c/templates/headers.js
+++ b/src/w3c/templates/headers.js
@@ -1,4 +1,4 @@
-import hyperHTML from "../../deps/hyperhtml";
+import hyperHTML from "hyperhtml";
 import { pub } from "../../core/pubsubhub";
 import showLink from "./show-link";
 import showLogo from "./show-logo";

--- a/src/w3c/templates/show-link.js
+++ b/src/w3c/templates/show-link.js
@@ -1,4 +1,4 @@
-import hyperHTML from "../../deps/hyperhtml";
+import hyperHTML from "hyperhtml";
 import { pub } from "../../core/pubsubhub";
 const html = hyperHTML;
 

--- a/src/w3c/templates/show-logo.js
+++ b/src/w3c/templates/show-logo.js
@@ -1,4 +1,4 @@
-import hyperHTML from "../../deps/hyperhtml";
+import hyperHTML from "hyperhtml";
 import { showInlineWarning } from "../../core/utils";
 
 export default obj => {

--- a/src/w3c/templates/show-people.js
+++ b/src/w3c/templates/show-people.js
@@ -1,4 +1,4 @@
-import hyperHTML from "../../deps/hyperhtml";
+import hyperHTML from "hyperhtml";
 
 export default (conf, name, items = []) => {
   const html = hyperHTML;

--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -1,4 +1,4 @@
-import hyperHTML from "../../deps/hyperhtml";
+import hyperHTML from "hyperhtml";
 
 export default conf => {
   const html = hyperHTML;

--- a/tests/test-main.js
+++ b/tests/test-main.js
@@ -19,5 +19,13 @@ require.config({
   paths: {
     core: "/base/js/core",
     w3c: "/base/js/w3c",
+    clipboard: "deps/clipboard",
+    hyperhtml: "deps/hyperhtml",
+    "idb-keyval": "deps/idb",
+    jquery: "deps/jquery",
+    marked: "deps/marked",
+    pluralize: "deps/pluralize",
+    text: "deps/text",
+    webidl2: "deps/webidl2",
   },
 });

--- a/tools/builder.js
+++ b/tools/builder.js
@@ -142,7 +142,10 @@ const Builder = {
     const buildDir = path.resolve(__dirname, "../builds/");
     const workerDir = path.resolve(__dirname, "../worker/");
     await fsp.emptyDir(buildDir);
-    await promisify(webpack)(config);
+    const stats = await promisify(webpack)(config);
+    if (stats.hasErrors()) {
+      throw new Error(stats.toJson().errors);
+    }
     await appendBoilerplate(outPath, buildVersion, name);
     // copy respec-worker
     await fsp.copyFile(


### PR DESCRIPTION
Because currently external dependencies can only be automatically typed through their package names with TypeScript.

Importing with package name blocks migration to ES modules, but those dependencies are not ES module compatible anyway. There is a discussion [to enable import-by-package-name with native ES modules](https://github.com/domenic/import-maps) so I hope we get a fix soon.