### PR TITLE
fix: add a symlink for sourcemap

### DIFF
--- a/builds/respec-w3c-common.build.js.map
+++ b/builds/respec-w3c-common.build.js.map
@@ -1,0 +1,1 @@
+respec-w3c-common.js.map

--- a/src/core/examples.js
+++ b/src/core/examples.js
@@ -45,7 +45,7 @@ export function run(conf) {
       number,
       illegal,
     };
-    const title = example.title;
+    const { title } = example;
     if (example.localName === "aside") {
       ++number;
       const div = makeTitle(conf, example, number, report);

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -139,7 +139,7 @@ export function createResourceHint(opts) {
   }
   const url = new URL(opts.href, location.href);
   const linkElem = document.createElement("link");
-  let href = url.href;
+  let { href } = url;
   linkElem.rel = opts.hint;
   switch (linkElem.rel) {
     case "dns-prefetch":

--- a/tools/builder.js
+++ b/tools/builder.js
@@ -141,7 +141,6 @@ const Builder = {
     };
     const buildDir = path.resolve(__dirname, "../builds/");
     const workerDir = path.resolve(__dirname, "../worker/");
-    await fsp.emptyDir(buildDir);
     const stats = await promisify(webpack)(config);
     if (stats.hasErrors()) {
       throw new Error(stats.toJson().errors);


### PR DESCRIPTION
Should only be needed before a w3c-side fix for #2006.