### PR TITLE
feat(w3c/defaults): enable pluralize by default

### DIFF
--- a/src/w3c/defaults.js
+++ b/src/w3c/defaults.js
@@ -66,7 +66,7 @@ const w3cDefaults = {
     "local-refs-exist": true,
     "check-internal-slots": false,
   },
-  pluralize: false,
+  pluralize: true,
   highlightVars: true,
   doJsonLd: false,
   license: "w3c-software-doc",

--- a/src/w3c/defaults.js
+++ b/src/w3c/defaults.js
@@ -96,6 +96,7 @@ function computeProps(conf) {
 }
 
 export function run(conf) {
+  if (conf.specStatus === "unofficial") return;
   // assign the defaults
   Object.assign(conf, {
     ...w3cDefaults,

--- a/tests/spec/core/pluralize-spec.js
+++ b/tests/spec/core/pluralize-spec.js
@@ -106,6 +106,26 @@ describe("Core - Pluralize", () => {
     ).toBeTruthy();
   });
 
+  it("does nothing if conf.pluralize is not defined", async () => {
+    const body = `
+      <section id="section">
+        <dfn>foo</dfn> can be referenced
+        as <a>foo</a>
+        but not as <a>foos</a>
+      </section>
+    `;
+    const ops = makeStandardOps({ specStatus: "unofficial" }, body);
+    const doc = await makeRSDoc(ops);
+
+    const { id: dfnId } = doc.querySelector("#section dfn");
+    expect(dfnId).toBe("dfn-foo");
+    const [validLink, invalidLink] = [...doc.querySelectorAll("#section a")];
+    expect(validLink.getAttribute("href")).toEqual("#dfn-foo");
+    expect(
+      invalidLink.classList.contains("respec-offending-element")
+    ).toBeTruthy();
+  });
+
   it("doesn't pluralize when [data-lt-noDefault] is defined", async () => {
     const body = `
       <section id="section">

--- a/tests/spec/core/pluralize-spec.js
+++ b/tests/spec/core/pluralize-spec.js
@@ -106,26 +106,6 @@ describe("Core - Pluralize", () => {
     ).toBeTruthy();
   });
 
-  it("does nothing if conf.pluralize is not defined", async () => {
-    const body = `
-      <section id="section">
-        <dfn>foo</dfn> can be referenced
-        as <a>foo</a>
-        but not as <a>foos</a>
-      </section>
-    `;
-    const ops = makeStandardOps(null, body);
-    const doc = await makeRSDoc(ops);
-
-    const { id: dfnId } = doc.querySelector("#section dfn");
-    expect(dfnId).toBe("dfn-foo");
-    const [validLink, invalidLink] = [...doc.querySelectorAll("#section a")];
-    expect(validLink.getAttribute("href")).toEqual("#dfn-foo");
-    expect(
-      invalidLink.classList.contains("respec-offending-element")
-    ).toBeTruthy();
-  });
-
   it("doesn't pluralize when [data-lt-noDefault] is defined", async () => {
     const body = `
       <section id="section">

--- a/tests/spec/w3c/defaults-spec.js
+++ b/tests/spec/w3c/defaults-spec.js
@@ -35,7 +35,7 @@ describe("W3C — Defaults", () => {
           "check-internal-slots": true,
         },
         license: "c0",
-        specStatus: "unofficial",
+        specStatus: "ED",
         shortName: "foo",
         highlightVars: false,
       },
@@ -54,6 +54,6 @@ describe("W3C — Defaults", () => {
     });
     expect(rsConf.highlightVars).toEqual(false);
     expect(rsConf.license).toEqual("c0");
-    expect(rsConf.specStatus).toEqual("unofficial");
+    expect(rsConf.specStatus).toEqual("ED");
   });
 });


### PR DESCRIPTION
We've been running with this for a few months in various specs and it's working pretty well, so feel confident enabling by default. 