### PR TITLE
fix(core/dfn-finder): do not warn for typedefs

### DIFF
--- a/src/core/dfn-finder.js
+++ b/src/core/dfn-finder.js
@@ -44,7 +44,7 @@ export function findDfn(
   if (dfn) {
     return dfn;
   }
-  const showWarnings = name && !suppressWarnings;
+  const showWarnings = name && !(suppressWarnings || defn.type === "typedef");
   if (showWarnings) {
     const styledName = defn.type === "operation" ? `${name}()` : name;
     const ofParent = parent ? ` \`${parent}\`'s` : "";


### PR DESCRIPTION
Closes #1208 

Currently no way to test this (while #2004 may introduce one).