### PR TITLE
Reindent innerHTML of children of aside tag

### DIFF
--- a/src/core/examples.js
+++ b/src/core/examples.js
@@ -58,6 +58,11 @@ export function run(conf) {
       const { id } = example;
       const selfLink = div.querySelector("a.self-link");
       selfLink.href = `#${id}`;
+      const children = Array.from(example.children);
+      children.forEach(child => {
+        console.log(child.innerHTML);
+        child.innerHTML = reindent(child.innerHTML);
+      });
       pub("example", report);
     } else {
       const inAside = !!example.closest("aside");
@@ -65,7 +70,6 @@ export function run(conf) {
 
       const reindentedHtml = reindent(example.innerHTML);
       example.innerHTML = report.content = reindentedHtml;
-
       // wrap
       example.classList.remove("example", "illegal-example");
       // relocate the id to the div

--- a/src/core/examples.js
+++ b/src/core/examples.js
@@ -60,7 +60,6 @@ export function run(conf) {
       selfLink.href = `#${id}`;
       const children = Array.from(example.children);
       children.forEach(child => {
-        console.log(child.innerHTML);
         child.innerHTML = reindent(child.innerHTML);
       });
       pub("example", report);
@@ -70,6 +69,7 @@ export function run(conf) {
 
       const reindentedHtml = reindent(example.innerHTML);
       example.innerHTML = report.content = reindentedHtml;
+
       // wrap
       example.classList.remove("example", "illegal-example");
       // relocate the id to the div

--- a/tests/spec/core/examples-spec.js
+++ b/tests/spec/core/examples-spec.js
@@ -44,6 +44,21 @@ describe("Core — Examples", () => {
     expect(example.getAttribute("title")).toBeNull();
     expect(example.textContent).toBe("Example 1: EX\n{\n  CONTENT\n}\n  ");
   });
+  it("processes children of aside examples", async () => {
+    const ops = {
+      config: makeBasicConfig(),
+      body: `${makeDefaultBody()}<article>
+           <aside class="example">
+            <pre class="js">
+            // Whitespace before this text should be removed
+            </pre>
+           </aside>
+         </article>`,
+    };
+    const doc = await makeRSDoc(ops);
+    const example = doc.querySelector("pre.hljs");
+    expect(example.textContent).toBe("// Whitespace before this text should be removed");
+  });
   it("self-links examples made from asides", async () => {
     const body = `
       <aside class="example"></aside>

--- a/tests/spec/core/examples-spec.js
+++ b/tests/spec/core/examples-spec.js
@@ -47,17 +47,25 @@ describe("Core — Examples", () => {
   it("processes children of aside examples", async () => {
     const ops = {
       config: makeBasicConfig(),
-      body: `${makeDefaultBody()}<article>
+      body: `${makeDefaultBody()}
            <aside class="example">
             <pre class="js">
             // Whitespace before this text should be removed
             </pre>
-           </aside>
-         </article>`,
+            <pre>
+                  // this one should also have its whitespace removed
+            </pre>
+            <pre>
+                                this one should also have its whitespace removed
+            </pre>
+           </aside>`,
     };
     const doc = await makeRSDoc(ops);
-    const example = doc.querySelector("pre.hljs");
-    expect(example.textContent).toBe("// Whitespace before this text should be removed");
+    const example = doc.querySelectorAll("pre.hljs");
+    expect(example.length).toBe(3);
+    expect(example[0].textContent).toBe("// Whitespace before this text should be removed");
+    expect(example[1].textContent).toBe("// this one should also have its whitespace removed");
+    expect(example[2].textContent).toBe("this one should also have its whitespace removed");
   });
   it("self-links examples made from asides", async () => {
     const body = `


### PR DESCRIPTION
Fixes https://github.com/w3c/respec/issues/2034 
I have currently re-indented all children of `aside` tag. Please let me know if it is to be done only on the `pre` tags which are children of `aside`. 