### PR TITLE
fix(core/structure): trim section titles

### DIFF
--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -222,12 +222,14 @@ function createTableOfContents(ol, conf) {
  * @param {Record<string, SectionInfo>} secMap
  */
 function updateEmptyAnchors(secMap) {
-  document.querySelectorAll("a[href^='#']:not(.tocxref)").forEach(anchor => {
-    if (anchor.innerHTML !== "") {
-      return;
-    }
-    const id = anchor.getAttribute("href").slice(1);
-    if (secMap[id]) {
+  [...document.querySelectorAll("a[href^='#']:not(.tocxref)")]
+    .filter(
+      anchor =>
+        anchor.textContent === "" &&
+        anchor.getAttribute("href").slice(1) in secMap
+    )
+    .forEach(anchor => {
+      const id = anchor.getAttribute("href").slice(1);
       const { secno, title } = secMap[id];
       anchor.classList.add("sec-ref");
       if (anchor.classList.contains("sectionRef")) {
@@ -236,7 +238,6 @@ function updateEmptyAnchors(secMap) {
       if (secno) {
         anchor.append(hyperHTML`<span class='secno'>§ ${secno}</span>`, " ");
       }
-      anchor.append(hyperHTML`<span class='sec-title'>${title}</span>`);
-    }
-  });
+      anchor.append(hyperHTML`<span class='sec-title'>${title.trim()}</span>`);
+    });
 }

--- a/tests/spec/core/section-refs-spec.js
+++ b/tests/spec/core/section-refs-spec.js
@@ -4,13 +4,16 @@ describe("Core - Section References", () => {
   it("should have produced the section reference", async () => {
     const ops = {
       config: makeBasicConfig(),
-      body: `${makeDefaultBody()}<section id='ONE'><h2>ONE</h2></section><section id='TWO'><a href='#ONE' class='sectionRef'></a></section>`,
+      body: `${makeDefaultBody()}
+        <section id='ONE'>
+          <h2>
+            ONE
+          </h2>
+        </section>
+        <section id='TWO'><a href='#ONE' class='sectionRef'></a></section>`,
     };
     const doc = await makeRSDoc(ops);
-    const one = doc.getElementById("ONE");
     const two = doc.getElementById("TWO");
-    const tit = one.children[0].textContent;
-
-    expect(two.querySelector("a").textContent).toEqual(`section § ${tit}`);
+    expect(two.querySelector("a").textContent).toBe("section § 1. ONE");
   });
 });


### PR DESCRIPTION
Removes extra whitespace that can occur in the titles (also refactor code a little bit). 

![screenshot 2019-01-31 17 23 38](https://user-images.githubusercontent.com/870154/52034658-fcdc9e00-257c-11e9-83ab-614f93bb2247.png)