### PR TITLE
fix(tools/respecDocWriter): handle console messages earlier 

### DIFF
--- a/tests/headless.js
+++ b/tests/headless.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// @ts-check
 /*eslint-env node*/
 "use strict";
 const port = 5000;
@@ -9,17 +10,6 @@ const testURLs = [
 const colors = require("colors");
 const { exec } = require("child_process");
 const moment = require("moment");
-colors.setTheme({
-  data: "grey",
-  debug: "cyan",
-  error: "red",
-  help: "cyan",
-  info: "green",
-  input: "grey",
-  prompt: "grey",
-  verbose: "cyan",
-  warn: "yellow",
-});
 
 const handler = require("serve-handler");
 const http = require("http");
@@ -62,13 +52,13 @@ async function runRespec2html() {
   let testCount = 1;
   for (const exe of executables) {
     try {
-      const testInfo = colors.info(`(test ${testCount++}/${testURLs.length})`);
+      const testInfo = colors.green(`(test ${testCount++}/${testURLs.length})`);
       const msg = ` 👷‍♀️  ${exe.cmd} ${testInfo}`;
       debug(msg);
       await exe.run();
     } catch (err) {
       // eslint-disable-next-line no-console
-      console.error(colors.error(err));
+      console.error(colors.red(err));
       errors.add(exe.cmd);
     }
   }
@@ -80,7 +70,7 @@ async function runRespec2html() {
 
 function debug(msg) {
   // eslint-disable-next-line no-console
-  console.log(colors.debug(`${colors.input(moment().format("LTS"))} ${msg}`));
+  console.log(colors.grey(moment().format("LTS")) + colors.cyan(` ${msg}`));
 }
 
 async function run() {

--- a/tests/headless.js
+++ b/tests/headless.js
@@ -35,10 +35,8 @@ function toExecutable(cmd) {
 }
 
 async function runRespec2html() {
-  const server = http.createServer((request, response) => {
-    return handler(request, response);
-  });
-  server.listen(port, () => {});
+  const server = http.createServer(handler);
+  server.listen(port);
 
   const errors = new Set();
   // Incrementally spawn processes and add them to process counter.

--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -75,10 +75,10 @@ async function fetchAndWrite(
   });
   try {
     const page = await browser.newPage();
-    const url = new URL(src);
-    const response = await page.goto(url, { timeout });
     const handleConsoleMessages = makeConsoleMsgHandler(page);
     handleConsoleMessages(whenToHalt);
+    const url = new URL(src);
+    const response = await page.goto(url, { timeout });
     if (
       !response.ok() &&
       response.status() /* workaround: 0 means ok for local files */


### PR DESCRIPTION
Webpack-built ReSpec can finish things before `document.onload` fires, and this currently causes unexpected console error ignorance even with `-e -w`. Attaching event listener before navigation fixes the bug.