### PR TITLE
Beihang homepage is now under https

### DIFF
--- a/src/w3c/templates/headers.js
+++ b/src/w3c/templates/headers.js
@@ -247,7 +247,7 @@ function renderOfficialCopyright(conf) {
           >ERCIM</abbr
         ></a
       >, <a href="https://www.keio.ac.jp/">Keio</a>,
-      <a href="http://ev.buaa.edu.cn/">Beihang</a>). ${noteIfDualLicense(conf)}
+      <a href="https://ev.buaa.edu.cn/">Beihang</a>). ${noteIfDualLicense(conf)}
       W3C <a href="${legalDisclaimer}">liability</a>,
       <a href="${w3cTrademark}">trademark</a> and ${linkDocumentUse(conf)} rules
       apply.


### PR DESCRIPTION
See https://github.com/w3c/specberus/pull/805 and https://github.com/w3c/specberus/issues/797