### PR TITLE
fix(core/reindent): export module's name

### DIFF
--- a/src/core/reindent.js
+++ b/src/core/reindent.js
@@ -3,6 +3,9 @@
  * so that indentation inside <pre> won't affect the rendered result.
  * @param {string} text IDL text
  */
+
+export const name = "core/reindent";
+
 function reindent(text) {
   if (!text) {
     return text;


### PR DESCRIPTION
Currently generating a warning, which causes ReSpec validator to "halt on warning". 