### PR TITLE
fix(builder): use profile name

### DIFF
--- a/tools/builder.js
+++ b/tools/builder.js
@@ -119,7 +119,7 @@ const Builder = {
     const buildVersion = await this.getRespecVersion();
     const config = {
       mode: "production",
-      entry: require.resolve("../js/profile-w3c-common.js"),
+      entry: require.resolve(`../js/profile-${name}.js`),
       output: {
         path: buildPath,
         filename: outFile,


### PR DESCRIPTION
**Purpose**: use profile name instead w3c-common in `builder`.
**Tests**: No, I couldn't look for were to add test for `builder.js` here.
Fixes #2103