### PR TITLE
fix(assets/issue-notes): don't uppercase boxed titles

### DIFF
--- a/assets/issues-notes.css
+++ b/assets/issues-notes.css
@@ -1,31 +1,13 @@
 /* --- ISSUES/NOTES --- */
-div.issue-title, div.note-title , div.ednote-title, div.warning-title {
-    padding-right:  1em;
-    min-width: 7.5em;
-    color: #b9ab2d;
+.issue-label {
+    text-transform: initial;
 }
-div.issue-title { color: #e05252; }
-div.note-title, div.ednote-title { color: #2b2; }
-div.warning-title { color: #f22; }
-div.note-title span, div.ednote-title span, div.warning-title span {
-    text-transform: uppercase;
-}
-div.issue-title span { text-transform: none; }
-div.note, div.issue, div.ednote, div.warning {
-    margin-top: 1em;
-    margin-bottom: 1em;
-}
+
 .warning > p:first-child { margin-top: 0 }
 .warning {
     padding: .5em;
     border-left-width: .5em;
     border-left-style: solid;
-}
-div.issue, div.note , div.ednote,  div.warning {
-    padding: 1em 1.2em 0.5em;
-    margin: 1em 0;
-    position: relative;
-    clear: both;
 }
 span.warning { padding: .1em .5em .15em; }
 


### PR DESCRIPTION
Box titles are getting uppercased. Also, there is a bunch of redundant stuff that's already provided by base.css around issues, notes, etc.   