### PR TITLE
fix(w3c/style): w3c style must be last when exporting

### DIFF
--- a/src/w3c/style.js
+++ b/src/w3c/style.js
@@ -103,6 +103,15 @@ if (!document.head.querySelector("meta[name=viewport]")) {
 
 document.head.prepend(elements);
 
+function styleMover(linkURL) {
+  return exportDoc => {
+    const w3cStyle = exportDoc.querySelector(`head link[href="${linkURL}"]`);
+    exportDoc
+      .querySelector("head")
+      .insertAdjacentElement("beforeend", w3cStyle);
+  };
+}
+
 export function run(conf) {
   if (!conf.specStatus) {
     const warn = "`respecConfig.specStatus` missing. Defaulting to 'base'.";
@@ -156,6 +165,8 @@ export function run(conf) {
   }
   const finalVersionPath = version ? `${version}/` : "";
   const finalStyleURL = `https://www.w3.org/StyleSheets/TR/${finalVersionPath}${styleFile}`;
-
   linkCSS(document, finalStyleURL);
+  // Make sure the W3C stylesheet is the last stylesheet, as required by W3C Pub Rules.
+  const moveStyle = styleMover(finalStyleURL);
+  sub("beforesave", moveStyle);
 }


### PR DESCRIPTION
fixes #2140 

@saschanaz I had trouble testing this and I'm bit short on time today 😭 - but need to get this out as it's blocking publications 🔥. I've manually confirmed that it works tho. 

![screenshot 2019-03-06 14 44 54](https://user-images.githubusercontent.com/870154/53854645-6dfcee80-401e-11e9-911e-41c79fa2e318.png)

The problem I encountered is that the `pubsubhub` exports seem to be different in the test suite. That is, everything works fine, but when ReSpec tries to `pub("beforesave")` all the subscriptions have vanished. It's very strange. 

CC @sidvishnoi ... maybe encountered the same issue when he wrote this module? 