### PR TITLE
 refactor(core/issues-notes): localize module 

### DIFF
--- a/src/core/issues-notes.js
+++ b/src/core/issues-notes.js
@@ -12,9 +12,27 @@
 // manually numbered, a link to the issue is created using issueBase and the issue number
 import { addId, fetchAndCache, joinAnd, parents } from "./utils";
 import css from "text!../../assets/issues-notes.css";
+import { lang as defaultLang } from "../core/l10n";
 import hyperHTML from "hyperhtml";
 import { pub } from "./pubsubhub";
+
 export const name = "core/issues-notes";
+
+const localizationStrings = {
+  en: {
+    issue_summary: "Issue Summary",
+  },
+  nl: {
+    issue_summary: "Lijst met issues",
+  },
+  es: {
+    issue_summary: "Resumen de la cuestión",
+  },
+};
+
+const lang = defaultLang in localizationStrings ? defaultLang : "en";
+
+const l10n = localizationStrings[lang];
 
 const MAX_GITHUB_REQUESTS = 60;
 
@@ -30,7 +48,7 @@ function handleIssues(ins, ghIssues, conf) {
   let issueNum = 0;
   const issueList = document.createElement("ul");
   const issueSummary = hyperHTML`
-    <div><h2>${conf.l10n.issue_summary}</h2>${issueList}</div>`;
+    <div><h2>${l10n.issue_summary}</h2>${issueList}</div>`;
   ins.forEach(inno => {
     const { type, displayType, isFeatureAtRisk } = getIssueType(inno, conf);
     const isIssue = type === "issue";

--- a/tests/spec/core/issues-notes-spec.js
+++ b/tests/spec/core/issues-notes-spec.js
@@ -360,3 +360,23 @@ describe("Core — Issues and Notes", () => {
     );
   });
 });
+
+it("localizes issues summary", async () => {
+  const ops = {
+    config: makeBasicConfig(),
+    htmlAttrs: {
+      lang: "es",
+    },
+    body: `
+    <section>
+      <h2>Test Issues</h2>
+      <p class="issue" data-number=123></p>
+    </section>
+    <section id="issue-summary"></section>
+    `,
+  };
+  const doc = await makeRSDoc(ops);
+  const { textContent } = doc.querySelector("#issue-summary h2");
+  expect(doc.documentElement.lang).toBe("es");
+  expect(textContent).toContain("Resumen de la cuestión");
+});


### PR DESCRIPTION
This P.R aims to add localization in respect to issue https://github.com/w3c/respec/issues/2084 for the module `issues-notes.js`. Thanks to all who review and @marcoscaceres for great assistance. Is this time to start working on W3C modules as core modules are almost done?