### PR TITLE
fix(w3c/conformance): always emit an end event

### DIFF
--- a/src/core/pubsubhub.js
+++ b/src/core/pubsubhub.js
@@ -16,7 +16,7 @@ export function pub(topic, ...data) {
   }
   Array.from(subscriptions.get(topic)).forEach(cb => {
     try {
-      cb.apply(undefined, data);
+      cb(...data);
     } catch (err) {
       pub(
         "error",

--- a/src/w3c/conformance.js
+++ b/src/w3c/conformance.js
@@ -1,3 +1,4 @@
+// @ts-check
 // Module w3c/conformance
 // Handle the conformance section properly.
 import html from "hyperhtml";
@@ -7,9 +8,11 @@ import { renderInlineCitation } from "../core/render-biblio";
 import { rfc2119Usage } from "../core/inlines";
 export const name = "w3c/conformance";
 
-export function run(conf) {
-  const conformance = document.querySelector("section#conformance");
-  if (!conformance) return;
+/**
+ * @param {Element} conformance
+ * @param {*} conf
+ */
+function processConformance(conformance, conf) {
   const terms = [...Object.keys(rfc2119Usage)];
   // Add RFC2119 to blibliography
   if (terms.length) conf.normativeReferences.add("RFC2119");
@@ -37,6 +40,13 @@ export function run(conf) {
       : null}
   `;
   conformance.prepend(...content.childNodes);
+}
+
+export function run(conf) {
+  const conformance = document.querySelector("section#conformance");
+  if (conformance) {
+    processConformance(conformance, conf);
+  }
   // Added message for legacy compat with Aria specs
   // See https://github.com/w3c/respec/issues/793
   pub("end", name);

--- a/tests/about-blank.html
+++ b/tests/about-blank.html
@@ -1,2 +1,0 @@
-<!DOCTYPE html>
-<meta charset='utf-8'>

--- a/tests/spec/SpecHelper.js
+++ b/tests/spec/SpecHelper.js
@@ -6,7 +6,7 @@ const iframes = [];
 /**
  * @return {Promise<Document>}
  */
-function makeRSDoc(opts = {}, src = "about-blank.html", style = "") {
+function makeRSDoc(opts = {}, src, style = "") {
   return new Promise((resolve, reject) => {
     const ifr = document.createElement("iframe");
     // reject when DEFAULT_TIMEOUT_INTERVAL passes
@@ -15,7 +15,9 @@ function makeRSDoc(opts = {}, src = "about-blank.html", style = "") {
     }, jasmine.DEFAULT_TIMEOUT_INTERVAL);
     ifr.addEventListener("load", async () => {
       const doc = ifr.contentDocument;
-      decorateDocument(doc, opts);
+      if (src) {
+        decorateDocument(doc, opts);
+      }
       if (doc.respecIsReady) {
         await doc.respecIsReady;
         resolve(doc);
@@ -45,6 +47,10 @@ function makeRSDoc(opts = {}, src = "about-blank.html", style = "") {
     }
     if (src) {
       ifr.src = src;
+    } else {
+      const doc = document.implementation.createHTMLDocument();
+      decorateDocument(doc, opts);
+      ifr.srcdoc = doc.documentElement.outerHTML;
     }
     // trigger load
     document.body.appendChild(ifr);

--- a/tests/spec/core/examples-spec.js
+++ b/tests/spec/core/examples-spec.js
@@ -145,7 +145,7 @@ describe("Core — Examples", () => {
     const ops = makeStandardOps({}, body);
     const doc = await makeRSDoc(ops);
     const mybutton = doc.getElementById("mybutton");
-    expect(mybutton.onclick).toBeDefined();
+    expect(mybutton.onclick).toBeTruthy();
   });
 });
 

--- a/tests/spec/w3c/conformance-spec.js
+++ b/tests/spec/w3c/conformance-spec.js
@@ -54,4 +54,22 @@ describe("W3C — Conformance", () => {
     const doc = await makeRSDoc(ops);
     expect(doc.querySelectorAll("#conformance .rfc2119").length).toEqual(0);
   });
+
+  it("emits end event", async () => {
+    const ops = {
+      config: makeBasicConfig(),
+      body: `${makeDefaultBody()}
+        <script>
+          require(["core/pubsubhub"], ({ sub }) => {
+            sub("end", name => {
+              if (name === "w3c/conformance") {
+                document.title = "hello";
+              }
+            })
+          })
+        </script>`,
+    };
+    const doc = await makeRSDoc(ops);
+    expect(doc.title).toBe("hello");
+  });
 });

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -582,7 +582,9 @@ describe("W3C — Headers", () => {
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
       expect(
-        contains(doc.querySelector(".head"), "a", "LABEL")[0].getAttribute("href")
+        contains(doc.querySelector(".head"), "a", "LABEL")[0].getAttribute(
+          "href"
+        )
       ).toBe("URI");
     });
   });

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -567,38 +567,40 @@ describe("W3C — Headers", () => {
     });
   });
 
-  describe("alternateFormats", () => {});
-  it("takes alternateFormats into account", async () => {
-    const ops = makeStandardOps();
-    const newProps = {
-      specStatus: "FPWD",
-      alternateFormats: [
-        {
-          uri: "URI",
-          label: "LABEL",
-        },
-      ],
-    };
-    Object.assign(ops.config, newProps);
-    const doc = await makeRSDoc(ops);
-    expect(
-      contains(doc.querySelector(".head"), "a", "LABEL")[0].getAttribute("href")
-    ).toBe("URI");
+  describe("alternateFormats", () => {
+    it("takes alternateFormats into account", async () => {
+      const ops = makeStandardOps();
+      const newProps = {
+        specStatus: "FPWD",
+        alternateFormats: [
+          {
+            uri: "URI",
+            label: "LABEL",
+          },
+        ],
+      };
+      Object.assign(ops.config, newProps);
+      const doc = await makeRSDoc(ops);
+      expect(
+        contains(doc.querySelector(".head"), "a", "LABEL")[0].getAttribute("href")
+      ).toBe("URI");
+    });
   });
 
-  describe("testSuiteURI", () => {});
-  it("takes testSuiteURI into account", async () => {
-    const ops = makeStandardOps();
-    const newProps = {
-      specStatus: "REC",
-      testSuiteURI: "URI",
-    };
-    Object.assign(ops.config, newProps);
-    const doc = await makeRSDoc(ops);
-    const terms = doc.querySelectorAll("dt");
-    expect(terms[3].textContent).toBe("Test suite:");
-    expect(terms[3].nextElementSibling.localName).toBe("dd");
-    expect(terms[3].nextElementSibling.textContent).toBe("URI");
+  describe("testSuiteURI", () => {
+    it("takes testSuiteURI into account", async () => {
+      const ops = makeStandardOps();
+      const newProps = {
+        specStatus: "REC",
+        testSuiteURI: "my:uri",
+      };
+      Object.assign(ops.config, newProps);
+      const doc = await makeRSDoc(ops);
+      const terms = doc.querySelectorAll("dt");
+      expect(terms[3].textContent).toBe("Test suite:");
+      expect(terms[3].nextElementSibling.localName).toBe("dd");
+      expect(terms[3].nextElementSibling.textContent).toBe("my:uri");
+    });
   });
 
   describe("implementationReportURI", () => {


### PR DESCRIPTION
Also fixed a problem where `makeRSDoc()` doesn't run inline `<script>` because of timing problem. (ReSpec typically waits until all DOM elements including inline `<script>` load, but currently `makeRSDoc` inserts ReSpec and scripts after the document load.)

Fixes #2147 