### PR TITLE
refactor(core/inlines) : Minor optimizations

### DIFF
--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -150,7 +150,7 @@ export function run(conf) {
         df.appendChild(node);
       } else {
         // FAIL -- not sure that this can really happen
-        throw `Found token '${t}' but it does not correspond to anything`;
+        throw new Error(`Found token '${t}' but it does not correspond to anything`);
       }
     }
     txt.parentNode.replaceChild(df, txt);

--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -129,20 +129,18 @@ export function run(conf) {
     if (subtxt.length === 1) continue;
 
     const df = document.createDocumentFragment();
-    while (subtxt.length) {
-      const t = subtxt.shift();
+    // The shift() method might have O(N) time complexity where N is subtxt.length, due to re-indexing.
+    // Using simple loop will avoid the re-indexing overhead.
+    for (let i = 0; i < subtxt.length; i++) {
+      const t = subtxt[i];
       let matched = null;
-      if (subtxt.length) matched = subtxt.shift();
+      if (i != subtxt.length - 1) {
+        matched = subtxt[i + 1];
+        i++;
+      }
       df.appendChild(document.createTextNode(t));
       if (matched) {
-        if (
-          /MUST(?:\s+NOT)?|SHOULD(?:\s+NOT)?|SHALL(?:\s+NOT)?|MAY|(?:NOT\s+)?REQUIRED|(?:NOT\s+)?RECOMMENDED|OPTIONAL/.test(
-            matched
-          )
-        ) {
-          const node = inlineRFC2119Matches(matched);
-          df.appendChild(node);
-        } else if (matched.startsWith("{{{")) {
+        if (matched.startsWith("{{{")) {
           const node = inlineXrefMatches(matched);
           df.appendChild(node);
         } else if (matched.startsWith("[[")) {
@@ -150,6 +148,13 @@ export function run(conf) {
           df.append(...nodes);
         } else if (abbrMap.has(matched)) {
           const node = inlineAbbrMatches(matched, txt, abbrMap);
+          df.appendChild(node);
+        } else if (
+          /MUST(?:\s+NOT)?|SHOULD(?:\s+NOT)?|SHALL(?:\s+NOT)?|MAY|(?:NOT\s+)?REQUIRED|(?:NOT\s+)?RECOMMENDED|OPTIONAL/.test(
+            matched
+          )
+        ) {
+          const node = inlineRFC2119Matches(matched);
           df.appendChild(node);
         } else {
           // FAIL -- not sure that this can really happen

--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -129,8 +129,6 @@ export function run(conf) {
     if (subtxt.length === 1) continue;
 
     const df = document.createDocumentFragment();
-    // The shift() method might have O(N) time complexity where N is subtxt.length, due to re-indexing.
-    // Using simple loop will avoid the re-indexing overhead.
     for (let i = 0; i < subtxt.length; i++) {
       const t = subtxt[i];
       let matched = null;

--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -150,7 +150,9 @@ export function run(conf) {
         df.appendChild(node);
       } else {
         // FAIL -- not sure that this can really happen
-        throw new Error(`Found token '${t}' but it does not correspond to anything`);
+        throw new Error(
+          `Found token '${t}' but it does not correspond to anything`
+        );
       }
     }
     txt.parentNode.replaceChild(df, txt);


### PR DESCRIPTION
I have done some minor optimizations in the inlines.js module.

1. Rather than using the JavaScript `shift()`, I have switched to simple array-indexing. Although JavaScript functions do not have an implementation standard, from what I read, most implementations would cause array re-indexing on each use of `shift()` which is somewhat inefficient.

2. I think that it is better to check for RFC 2119 keywords at the end - it is more efficient to check if a string starts with `{{{` or `[[` first than to run the entire regex expression on all strings. 

These are minor optimizations, because while they probably are efficient, I am not sure if it will make a difference beyond a few milliseconds - this depends how many inline keywords occur in a W3C spec in a practical scenario. 

There are 2 other modifications I was planning on doing, but would like some comments from others first since I do not have much experience with regex:

1. Do we really need the FAIL condition at the end? To me it seems like a bug if that condition ever arises, and so the focus should be on fixing that bug, and not have an extra condition.

2. On line 108, we are sorting the `aKeys` array in descending order of length. But since the regex is actually matches `<space>abbr<space>` do we really to sort it? Even if we have abbreviations like `abbr` and `abbre`, due to the space, regex should not match an instance of `abbre` with `abbr`. 