### PR TITLE
fix(core/link-to-dfn): don't xref autofills (again)

### DIFF
--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -238,7 +238,7 @@ function findExplicitExternalLinks() {
   return [...links]
     .filter(el => {
       // ignore empties
-      if (el.textContent === "") return false;
+      if (el.textContent.trim() === "") return false;
       /** @type {HTMLElement} */
       const closest = el.closest("[data-cite]");
       return !closest || closest.dataset.cite !== "";

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -237,11 +237,11 @@ function findExplicitExternalLinks() {
   );
   return [...links]
     .filter(el => {
+      // ignore empties
+      if (el.textContent === "") return false;
       /** @type {HTMLElement} */
       const closest = el.closest("[data-cite]");
-      return (
-        !!el.textContent.trim() && (!closest || closest.dataset.cite !== "")
-      );
+      return !closest || closest.dataset.cite !== "";
     })
     .concat([...document.querySelectorAll("dfn.externalDFN")]);
 }


### PR DESCRIPTION
What's better here is:
 1. more clear... 
 1. avoid call to .closest() 