### PR TITLE
Add <cite> when data-cite="spec" is used

### DIFF
--- a/src/core/data-cite.js
+++ b/src/core/data-cite.js
@@ -52,6 +52,10 @@ function requestLookup(conf) {
     if (frag) {
       href = new URL(frag, href).href;
     }
+    if (frag == null && path == null) {
+      const cite = hyperHTML`<cite>`;
+      wrapInner(cite, elem);
+    }
     switch (elem.localName) {
       case "a": {
         if (elem.textContent === "") {
@@ -62,6 +66,8 @@ function requestLookup(conf) {
       }
       case "dfn": {
         const anchor = hyperHTML`<a href="${href}">`;
+        const cite = hyperHTML`<cite>`;
+        wrapInner(cite, anchor);
         if (!elem.textContent) {
           anchor.textContent = title;
           elem.append(anchor);

--- a/src/core/data-cite.js
+++ b/src/core/data-cite.js
@@ -53,7 +53,7 @@ function requestLookup(conf) {
       href = new URL(frag, href).href;
     }
     if (frag == null && path == null) {
-      const cite = hyperHTML`<cite>`;
+      const cite = document.createElement("cite");
       wrapInner(cite, elem);
     }
     switch (elem.localName) {
@@ -66,7 +66,7 @@ function requestLookup(conf) {
       }
       case "dfn": {
         const anchor = hyperHTML`<a href="${href}">`;
-        const cite = hyperHTML`<cite>`;
+        const cite = document.createElement("cite");
         wrapInner(cite, anchor);
         if (!elem.textContent) {
           anchor.textContent = title;

--- a/src/core/data-cite.js
+++ b/src/core/data-cite.js
@@ -52,7 +52,7 @@ function requestLookup(conf) {
     if (frag) {
       href = new URL(frag, href).href;
     }
-    if (frag == null && path == null) {
+    if (!frag && !path) {
       const cite = document.createElement("cite");
       wrapInner(cite, elem);
     }


### PR DESCRIPTION
Fixes #2021 

`<cite><a href="https://foo.com/whatever-spec">Some spec</a></cite>`

This type of link is created when there is no fragment or path.