### PR TITLE
Shifted localization tests into specification test suites

### DIFF
--- a/tests/spec/core/examples-spec.js
+++ b/tests/spec/core/examples-spec.js
@@ -147,20 +147,20 @@ describe("Core — Examples", () => {
     const mybutton = doc.getElementById("mybutton");
     expect(mybutton.onclick).toBeTruthy();
   });
+  it("localizes examples", async () => {
+    const ops = {
+      config: makeBasicConfig(),
+      htmlAttrs: {
+        lang: "nl",
+      },
+      body: `<section>
+          <pre class="example"> This is an example </pre>
+        </section>`,
+    };
+    const doc = await makeRSDoc(ops);
+    const { textContent } = doc.querySelector(".example");
+    expect(doc.documentElement.lang).toBe("nl");
+    expect(textContent).toContain("Voorbeeld");
+  });
 });
 
-it("localizes examples", async () => {
-  const ops = {
-    config: makeBasicConfig(),
-    htmlAttrs: {
-      lang: "nl",
-    },
-    body: `<section>
-        <pre class="example"> This is an example </pre>
-      </section>`,
-  };
-  const doc = await makeRSDoc(ops);
-  const { textContent } = doc.querySelector(".example");
-  expect(doc.documentElement.lang).toBe("nl");
-  expect(textContent).toContain("Voorbeeld");
-});

--- a/tests/spec/core/examples-spec.js
+++ b/tests/spec/core/examples-spec.js
@@ -163,4 +163,3 @@ describe("Core — Examples", () => {
     expect(textContent).toContain("Voorbeeld");
   });
 });
-

--- a/tests/spec/core/figures-spec.js
+++ b/tests/spec/core/figures-spec.js
@@ -171,4 +171,3 @@ describe("Core - Figures", () => {
     expect(textContent).toContain("Lijst met figuren");
   });
 });
-

--- a/tests/spec/core/figures-spec.js
+++ b/tests/spec/core/figures-spec.js
@@ -151,24 +151,24 @@ describe("Core - Figures", () => {
       expect(image.hasAttribute("width")).toBeFalsy();
     });
   });
+  it("localizes table of figures", async () => {
+    const ops = {
+      config: makeBasicConfig(),
+      htmlAttrs: {
+        lang: "nl",
+      },
+      body: `
+      <section id="tof" class="informative appendix"></section>
+      <section>
+        <figure id='figure'> <img src='img' alt=''>
+          <figcaption>Example Figure</figcaption>
+        </figure>
+      </section>`,
+    };
+    const doc = await makeRSDoc(ops);
+    const { textContent } = doc.querySelector("#tof h2");
+    expect(doc.documentElement.lang).toBe("nl");
+    expect(textContent).toContain("Lijst met figuren");
+  });
 });
 
-it("localizes table of figures", async () => {
-  const ops = {
-    config: makeBasicConfig(),
-    htmlAttrs: {
-      lang: "nl",
-    },
-    body: `
-    <section id="tof" class="informative appendix"></section>
-    <section>
-      <figure id='figure'> <img src='img' alt=''>
-        <figcaption>Example Figure</figcaption>
-      </figure>
-    </section>`,
-  };
-  const doc = await makeRSDoc(ops);
-  const { textContent } = doc.querySelector("#tof h2");
-  expect(doc.documentElement.lang).toBe("nl");
-  expect(textContent).toContain("Lijst met figuren");
-});

--- a/tests/spec/core/issues-notes-spec.js
+++ b/tests/spec/core/issues-notes-spec.js
@@ -359,24 +359,24 @@ describe("Core — Issues and Notes", () => {
       `${config.github}/issues/1540`
     );
   });
+  it("localizes issues summary", async () => {
+    const ops = {
+      config: makeBasicConfig(),
+      htmlAttrs: {
+        lang: "es",
+      },
+      body: `
+      <section>
+        <h2>Test Issues</h2>
+        <p class="issue" data-number=123></p>
+      </section>
+      <section id="issue-summary"></section>
+      `,
+    };
+    const doc = await makeRSDoc(ops);
+    const { textContent } = doc.querySelector("#issue-summary h2");
+    expect(doc.documentElement.lang).toBe("es");
+    expect(textContent).toContain("Resumen de la cuestión");
+  });
 });
 
-it("localizes issues summary", async () => {
-  const ops = {
-    config: makeBasicConfig(),
-    htmlAttrs: {
-      lang: "es",
-    },
-    body: `
-    <section>
-      <h2>Test Issues</h2>
-      <p class="issue" data-number=123></p>
-    </section>
-    <section id="issue-summary"></section>
-    `,
-  };
-  const doc = await makeRSDoc(ops);
-  const { textContent } = doc.querySelector("#issue-summary h2");
-  expect(doc.documentElement.lang).toBe("es");
-  expect(textContent).toContain("Resumen de la cuestión");
-});

--- a/tests/spec/core/issues-notes-spec.js
+++ b/tests/spec/core/issues-notes-spec.js
@@ -379,4 +379,3 @@ describe("Core — Issues and Notes", () => {
     expect(textContent).toContain("Resumen de la cuestión");
   });
 });
-


### PR DESCRIPTION
The localization tests recently added were outside the `describe()` block, so I have shifted them inside. I think I have shifted all of them. 