### PR TITLE
(w3c/l10n): Added string for es (Spanish)

### DIFF
--- a/src/w3c/l10n.js
+++ b/src/w3c/l10n.js
@@ -24,6 +24,10 @@ const additions = {
     status_at_publication:
       "This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current W3C publications and the latest revision of this technical report can be found in the <a href='https://www.w3.org/TR/'>W3C technical reports index</a> at https://www.w3.org/TR/.",
   },
+  es: {
+    status_at_publication:
+      "This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current W3C publications and the latest revision of this technical report can be found in the <a href='https://www.w3.org/TR/'>W3C technical reports index</a> at https://www.w3.org/TR/.",
+  },
 };
 
 Object.keys(additions).reduce((l10n, key) => {

--- a/src/w3c/l10n.js
+++ b/src/w3c/l10n.js
@@ -26,7 +26,7 @@ const additions = {
   },
   es: {
     status_at_publication:
-      "This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current W3C publications and the latest revision of this technical report can be found in the <a href='https://www.w3.org/TR/'>W3C technical reports index</a> at https://www.w3.org/TR/.",
+      "Esta sección describe el estado del presente documento al momento de su publicación. El presente documento puede ser remplazado por otros. Una lista de las publicaciones actuales del W3C y la última revisión del presente informe técnico puede hallarse en http://www.w3.org/TR/ <a href='https://www.w3.org/TR/'>el índice de informes técnicos</a> del W3C.",
   },
 };
 


### PR DESCRIPTION
Added the `status_at_publication` string for Spanish language.
@marcoscaceres This also fixes the TypeError in tests, and yes, I see it was important to fix this error even though the test passed, because I discovered that without this, the "Status of This Document" section is not generated in Spanish documents.

While writing a test for (core/structure), I noticed a TypeError in the browser console, for the localization test. I found that all tests with Spanish language result in the same error while none of the other languages have a problem. The `status_at_publication`string was required by the SOTD template. 