### PR TITLE
fix(core/xref): normative refs always win

### DIFF
--- a/src/core/data-cite.js
+++ b/src/core/data-cite.js
@@ -129,10 +129,12 @@ export async function run(conf) {
       return key.toLowerCase() !== (conf.shortName || "").toLowerCase();
     })
     .forEach(({ isNormative, key }) => {
-      const refSink = isNormative
-        ? conf.normativeReferences
-        : conf.informativeReferences;
-      refSink.add(key);
+      if (!isNormative && !conf.normativeReferences.has(key)) {
+        conf.informativeReferences.add(key);
+        return;
+      }
+      conf.normativeReferences.add(key);
+      conf.informativeReferences.delete(key);
     });
 }
 

--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -14,7 +14,12 @@
 //  - respecRFC2119: a list of the number of times each RFC2119
 //    key word was used.  NOTE: While each member is a counter, at this time
 //    the counter is not used.
-import { getTextNodes, refTypeFromContext, showInlineWarning } from "./utils";
+import {
+  InsensitiveStringSet,
+  getTextNodes,
+  refTypeFromContext,
+  showInlineWarning,
+} from "./utils";
 import hyperHTML from "hyperhtml";
 import { idlStringToHtml } from "./inline-idl-parser";
 import { renderInlineCitation } from "./render-biblio";
@@ -104,8 +109,9 @@ export function run(conf) {
     // make the document informative
     document.body.classList.add("informative");
   }
-  if (!conf.normativeReferences) conf.normativeReferences = new Set();
-  if (!conf.informativeReferences) conf.informativeReferences = new Set();
+  conf.normativeReferences = new InsensitiveStringSet();
+  conf.informativeReferences = new InsensitiveStringSet();
+
   if (!conf.respecRFC2119) conf.respecRFC2119 = rfc2119Usage;
 
   // PRE-PROCESSING

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -914,3 +914,53 @@ export function msgIdGenerator(namespace, counter = 0) {
     return gen.next().value;
   };
 }
+
+export class InsensitiveStringSet extends Set {
+  /**
+   * @param {Array<String>} [keys] Optional, initial keys
+   */
+  constructor(keys = []) {
+    super();
+    for (const key of keys) {
+      this.add(key);
+    }
+  }
+  /**
+   * @param {string} key
+   */
+  add(key) {
+    if (!this.has(key) && !this.getCanonicalKey(key)) {
+      return super.add(key);
+    }
+    return this;
+  }
+  /**
+   * @param {string} key
+   */
+  has(key) {
+    return (
+      super.has(key) ||
+      [...this.keys()].some(
+        existingKey => existingKey.toLowerCase() === key.toLowerCase()
+      )
+    );
+  }
+  /**
+   * @param {string} key
+   */
+  delete(key) {
+    return super.has(key)
+      ? super.delete(key)
+      : super.delete(this.getCanonicalKey(key));
+  }
+  /**
+   * @param {string} key
+   */
+  getCanonicalKey(key) {
+    return super.has(key)
+      ? key
+      : [...this.keys()].find(
+          existingKey => existingKey.toLowerCase() === key.toLowerCase()
+        );
+  }
+}

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -270,6 +270,7 @@ function addDataCiteToTerms(results, xrefMap, conf) {
       }
       if (normative) {
         conf.normativeReferences.add(cite);
+        conf.informativeReferences.delete(cite);
       } else {
         const msg =
           `Adding an informative reference to "${term}" from "${cite}" ` +

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -269,15 +269,20 @@ function addDataCiteToTerms(results, xrefMap, conf) {
         continue;
       }
       if (normative) {
-        conf.normativeReferences.add(cite);
-        conf.informativeReferences.delete(cite);
-      } else {
-        const msg =
-          `Adding an informative reference to "${term}" from "${cite}" ` +
-          "in a normative section";
-        const title = "Error: Informative reference in normative section";
-        showInlineWarning(entry.elem, msg, title);
+        // If it was originally informative, we move the existing
+        // key to be normative.
+        const existingKey = conf.informativeReferences.has(cite)
+          ? conf.informativeReferences.getCanonicalKey(cite)
+          : cite;
+        conf.normativeReferences.add(existingKey);
+        conf.informativeReferences.delete(existingKey);
+        continue;
       }
+      const msg =
+        `Adding an informative reference to "${term}" from "${cite}" ` +
+        "in a normative section";
+      const title = "Error: Informative reference in normative section";
+      showInlineWarning(entry.elem, msg, title);
     }
   }
   showErrors(errorCollectors);

--- a/tests/spec/core/xref-spec.js
+++ b/tests/spec/core/xref-spec.js
@@ -439,6 +439,7 @@ describe("Core — xref", () => {
     const body = `
       <section class="informative" id="test">
         <section>
+          <p>Cite the <a data-cite="URL"></a> non-normative.</p>
           <p>informative reference: <a id="valid1">fake inform 1</a> is in spec "local-1"</p>
           <p>informative reference: <a id="valid1n">list</a> is in infra</p>
         </section>

--- a/tests/spec/core/xref-spec.js
+++ b/tests/spec/core/xref-spec.js
@@ -439,13 +439,13 @@ describe("Core — xref", () => {
     const body = `
       <section class="informative" id="test">
         <section>
-          <p>Cite the <a data-cite="URL"></a> non-normative.</p>
+          <p>Cite the <a data-cite="URL"></a> non-normative</p>
           <p>informative reference: <a id="valid1">fake inform 1</a> is in spec "local-1"</p>
           <p>informative reference: <a id="valid1n">list</a> is in infra</p>
         </section>
         <section class="normative">
           <p>Informative document: <a id="invalid">bearing angle</a> in normative section</p>
-          <p>Normative reference: <a id="valid5n">URL parser</a> from URL</p>
+          <p>Normative reference: <a id="valid5n">URL parser</a> from "url" (lower case)</p>
           <section>
             <div class="example">
               <p><a id="valid2">fake inform 2</a></p>
@@ -505,7 +505,7 @@ describe("Core — xref", () => {
 
     const normRefs = [...doc.querySelectorAll("#normative-references dt")];
     expect(normRefs.length).toEqual(1); // excludes `css-values` of `#invalid`
-    expect(normRefs.map(r => r.textContent)).toEqual(["[url]"]);
+    expect(normRefs.map(r => r.textContent)).toEqual(["[URL]"]);
 
     const informRefs = [...doc.querySelectorAll("#informative-references dt")];
     expect(informRefs.map(r => r.textContent).join()).toBe(


### PR DESCRIPTION
Found that this wasn't completely fixed. The citation order was getting out of whack. 