### PR TITLE
Use Remaining Requests from GitHub Response Headers

### DIFF
--- a/src/core/contrib.js
+++ b/src/core/contrib.js
@@ -32,7 +32,7 @@ async function toHTML(urls, editors, element, headers) {
     urls
       .map(url =>
         fetch(new Request(url, { headers })).then(r => {
-          if (checkLimitReached(r)) return;
+          if (checkLimitReached(r)) return null;
           return r.json();
         })
       )

--- a/src/core/github-api.js
+++ b/src/core/github-api.js
@@ -35,17 +35,6 @@ export function checkLimitReached(response) {
   // Not sure we can reach here.
 }
 
-export async function getRateLimit(conf) {
-  const headers = githubRequestHeaders(conf);
-  const request = new Request(`https://api.github.com/rate_limit`, {
-    mode: "cors",
-    referrerPolicy: "no-referrer",
-    headers,
-  });
-  const responseJSON = await fetch(request).then(r => r.json());
-  return responseJSON.rate.remaining;
-}
-
 export async function fetchAndStoreGithubIssues(conf) {
   const { githubAPI } = conf;
   const specIssues = document.querySelectorAll(".issue[data-number]");

--- a/src/core/github-api.js
+++ b/src/core/github-api.js
@@ -21,7 +21,6 @@ export function githubRequestHeaders(conf) {
 }
 
 export function checkLimitReached(response) {
-  if (response.ok) return false;
   const { headers, status } = response;
   if (status === 403 && headers.get("X-RateLimit-Remaining") === "0") {
     if (typeof checkLimitReached.warned === "undefined") {
@@ -32,7 +31,7 @@ export function checkLimitReached(response) {
     }
     return true;
   }
-  // Not sure we can reach here.
+  return false;
 }
 
 export async function fetchAndStoreGithubIssues(conf) {


### PR DESCRIPTION
I came up with this strategy to use the request headers instead of a new endpoint https://github.com/w3c/respec/pull/2197#discussion_r268945469

We don't need to merge that PR if this is good.