### PR TITLE
feat(assets/respec2): make inline warnings visually pop

### DIFF
--- a/assets/respec2.css
+++ b/assets/respec2.css
@@ -3,6 +3,19 @@
  * Robin Berjon - http://berjon.com/
  *****************************************************************/
 
+@keyframes pop {
+  0% {
+    transform: scale(1, 1);
+  }
+  25% {
+    transform: scale(1.25, 1.25);
+    opacity: 0.75;
+  }
+  100% {
+    transform: scale(1, 1);
+  }
+}
+
 /* Override code highlighter background */
 .hljs {
   background: transparent !important;
@@ -39,8 +52,21 @@ a.bibref {
   text-decoration: none;
 }
 
+.respec-offending-element:target {
+  animation: pop 0.25s ease-in-out 0s 1;
+}
+
+.respec-offending-element {
+  display: inline-block;
+  position: relative;
+  /* Red squiggly line */
+  background: url(data:image/gif;base64,R0lGODdhBAADAPEAANv///8AAP///wAAACwAAAAABAADAEACBZQjmIAFADs=)
+    bottom repeat-x;
+}
+
 #references :target {
   background: #eaf3ff;
+  animation: pop 0.4s ease-in-out 0s 1;
 }
 
 cite .bibref {

--- a/assets/respec2.css
+++ b/assets/respec2.css
@@ -63,6 +63,14 @@ a.bibref {
   background: url(data:image/gif;base64,R0lGODdhBAADAPEAANv///8AAP///wAAACwAAAAABAADAEACBZQjmIAFADs=)
     bottom repeat-x;
 }
+@supports (text-decoration-style: wavy) {
+  .respec-offending-element {
+    background: none;
+    text-decoration-line: underline;
+    text-decoration-style: wavy;
+    text-decoration-color: red;
+  }
+}
 
 #references :target {
   background: #eaf3ff;

--- a/assets/ui.css
+++ b/assets/ui.css
@@ -286,13 +286,6 @@
   border-radius: inherit;
 }
 
-.respec-offending-element {
-  display: inline-block;
-  position: relative;
-  background: url(data:image/gif;base64,R0lGODdhBAADAPEAANv///8AAP///wAAACwAAAAABAADAEACBZQjmIAFADs=)
-    bottom repeat-x;
-}
-
 @supports (text-decoration-style: wavy) {
   .respec-offending-element {
     background: none;

--- a/assets/ui.css
+++ b/assets/ui.css
@@ -286,15 +286,6 @@
   border-radius: inherit;
 }
 
-@supports (text-decoration-style: wavy) {
-  .respec-offending-element {
-    background: none;
-    text-decoration-line: underline;
-    text-decoration-style: wavy;
-    text-decoration-color: red;
-  }
-}
-
 .respec-button-copy-paste {
   position: absolute;
   display: block;


### PR DESCRIPTION
When clicking navigating to inline errors, or certain areas of interest, this makes the things "pop"... making them easier to find amongst other text.  