### PR TITLE
Resolve Issue #2113

### DIFF
--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -384,7 +384,11 @@ export function run(conf) {
     pub("error", "At least one editor is required");
   const peopCheck = function(it) {
     if (!it.name) pub("error", "All authors and editors must have a name.");
-    if (it.orcid && !isOrcid(it.orcid)) pub("error", "All authors' and editors' ORCID must be in a valid format if provided.");
+    if (it.orcid && !isOrcid(it.orcid))
+      pub(
+        "error",
+        "All authors' and editors' ORCID must be in a valid format if provided."
+      );
   };
   if (conf.editors) {
     conf.editors.forEach(peopCheck);
@@ -669,19 +673,20 @@ function collectSotdContent(sotd, { isTagFinding = false }) {
 /**
  * @param {String} orcid
  * @return {boolean}
- **/
+ * */
 function isOrcid(orcid) {
   if (!/^https:\/\/orcid.org\/\d{4}-\d{4}-\d{4}-\d{3}(\d|X)$/.test(orcid)) {
     return false;
   }
   // calculate checksum as per https://support.orcid.org/hc/en-us/articles/360006897674-Structure-of-the-ORCID-Identifier
   const lastDigit = orcid[orcid.length - 1];
-  const remainder = orcid.split("")
-        .slice(0, -1)
-        .filter(c => /\d/.test(c))
-        .map(Number)
-        .reduce((acc, c) => (acc + c) * 2, 0);
-  const lastDigitInt = (12 - remainder % 11) % 11;
+  const remainder = orcid
+    .split("")
+    .slice(0, -1)
+    .filter(c => /\d/.test(c))
+    .map(Number)
+    .reduce((acc, c) => (acc + c) * 2, 0);
+  const lastDigitInt = (12 - (remainder % 11)) % 11;
   const lastDigitShould = lastDigitInt === 10 ? "X" : String(lastDigitInt);
   return lastDigit === lastDigitShould;
 }

--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -384,6 +384,7 @@ export function run(conf) {
     pub("error", "At least one editor is required");
   const peopCheck = function(it) {
     if (!it.name) pub("error", "All authors and editors must have a name.");
+    if (it.orcid && !isOrcid(it.orcid)) pub("error", "All authors' and editors' ORCID must be in a valid format if provided.");
   };
   if (conf.editors) {
     conf.editors.forEach(peopCheck);
@@ -663,6 +664,26 @@ function collectSotdContent(sotd, { isTagFinding = false }) {
     // Whatever sections are left, we throw at the end.
     additionalSections: sotdClone.childNodes,
   };
+}
+
+/**
+ * @param {String} orcid
+ * @return {boolean}
+ **/
+function isOrcid(orcid) {
+  if (!/^https:\/\/orcid.org\/\d{4}-\d{4}-\d{4}-\d{3}(\d|X)$/.test(orcid)) {
+    return false;
+  }
+  // calculate checksum as per https://support.orcid.org/hc/en-us/articles/360006897674-Structure-of-the-ORCID-Identifier
+  const lastDigit = orcid[orcid.length - 1];
+  const remainder = orcid.split("")
+        .slice(0, -1)
+        .filter(c => /\d/.test(c))
+        .map(Number)
+        .reduce((acc, c) => (acc + c) * 2, 0);
+  const lastDigitInt = (12 - remainder % 11) % 11;
+  const lastDigitShould = lastDigitInt === 10 ? "X" : String(lastDigitInt);
+  return lastDigit === lastDigitShould;
 }
 
 /**

--- a/src/w3c/templates/show-people.js
+++ b/src/w3c/templates/show-people.js
@@ -51,6 +51,15 @@ export default (conf, name, items = []) => {
         );
       }
     }
+    if (p.orcid) {
+      contents.push(
+        html`
+          <a class="p-name orcid" href="${p.orcid}">
+            <svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256"><style>.st1{fill:#fff}</style><path d="M256 128c0 70.7-57.3 128-128 128S0 198.7 0 128 57.3 0 128 0s128 57.3 128 128z" fill="#a6ce39"/><path class="st1" d="M86.3 186.2H70.9V79.1h15.4v107.1zM108.9 79.1h41.6c39.6 0 57 28.3 57 53.6 0 27.5-21.5 53.6-56.8 53.6h-41.8V79.1zm15.4 93.3h24.5c34.9 0 42.9-26.5 42.9-39.7C191.7 111.2 178 93 148 93h-23.7v79.4zM88.7 56.8c0 5.5-4.5 10.1-10.1 10.1s-10.1-4.6-10.1-10.1c0-5.6 4.5-10.1 10.1-10.1s10.1 4.6 10.1 10.1z"/></svg>
+          </a>
+        `
+      );
+    }
     if (p.note) contents.push(document.createTextNode(` (${p.note})`));
     if (p.extras) {
       const results = p.extras
@@ -78,7 +87,7 @@ export default (conf, name, items = []) => {
       `;
       span.appendChild(textContainer);
     }
-    textContainer.textContent = extra.name;
+    textContainer.innerHTML = extra.name;
     return span;
   }
-};
+}

--- a/src/w3c/templates/show-people.js
+++ b/src/w3c/templates/show-people.js
@@ -55,7 +55,26 @@ export default (conf, name, items = []) => {
       contents.push(
         html`
           <a class="p-name orcid" href="${p.orcid}">
-            <svg width="16" height="16" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256"><style>.st1{fill:#fff}</style><path d="M256 128c0 70.7-57.3 128-128 128S0 198.7 0 128 57.3 0 128 0s128 57.3 128 128z" fill="#a6ce39"/><path class="st1" d="M86.3 186.2H70.9V79.1h15.4v107.1zM108.9 79.1h41.6c39.6 0 57 28.3 57 53.6 0 27.5-21.5 53.6-56.8 53.6h-41.8V79.1zm15.4 93.3h24.5c34.9 0 42.9-26.5 42.9-39.7C191.7 111.2 178 93 148 93h-23.7v79.4zM88.7 56.8c0 5.5-4.5 10.1-10.1 10.1s-10.1-4.6-10.1-10.1c0-5.6 4.5-10.1 10.1-10.1s10.1 4.6 10.1 10.1z"/></svg>
+            <svg
+              width="16"
+              height="16"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 256 256"
+            >
+              <style>
+                .st1 {
+                  fill: #fff;
+                }
+              </style>
+              <path
+                d="M256 128c0 70.7-57.3 128-128 128S0 198.7 0 128 57.3 0 128 0s128 57.3 128 128z"
+                fill="#a6ce39"
+              />
+              <path
+                class="st1"
+                d="M86.3 186.2H70.9V79.1h15.4v107.1zM108.9 79.1h41.6c39.6 0 57 28.3 57 53.6 0 27.5-21.5 53.6-56.8 53.6h-41.8V79.1zm15.4 93.3h24.5c34.9 0 42.9-26.5 42.9-39.7C191.7 111.2 178 93 148 93h-23.7v79.4zM88.7 56.8c0 5.5-4.5 10.1-10.1 10.1s-10.1-4.6-10.1-10.1c0-5.6 4.5-10.1 10.1-10.1s10.1 4.6 10.1 10.1z"
+              />
+            </svg>
           </a>
         `
       );
@@ -90,4 +109,4 @@ export default (conf, name, items = []) => {
     textContainer.innerHTML = extra.name;
     return span;
   }
-}
+};

--- a/tests/spec/core/override-configuration-spec.js
+++ b/tests/spec/core/override-configuration-spec.js
@@ -29,7 +29,7 @@ describe("Core — Override Configuration", () => {
     url.searchParams.set(
       "additionalCopyrightHolders",
       // URL will perform encodeURIComponent automatically
-      "<span id=\"xss-attempt\">Internet Engineering Task Force</span>"
+      '<span id="xss-attempt">Internet Engineering Task Force</span>'
     );
     const doc = await makeRSDoc(makeStandardOps(), url);
     const copyrightText = doc.querySelector(".copyright").textContent;

--- a/tests/spec/core/override-configuration-spec.js
+++ b/tests/spec/core/override-configuration-spec.js
@@ -9,6 +9,7 @@ describe("Core — Override Configuration", () => {
     url.searchParams.set("previousPublishDate", "1994-03-01");
     url.searchParams.set(
       "additionalCopyrightHolders",
+      // URL will perform encodeURIComponent automatically
       "Internet Engineering Task Force"
     );
     const doc = await makeRSDoc(makeStandardOps(), url);
@@ -21,5 +22,18 @@ describe("Core — Override Configuration", () => {
     expect(previousMaturity).toEqual("REC");
     const copyrightText = doc.querySelector(".copyright").textContent;
     expect(copyrightText).toMatch(/Internet Engineering Task Force/);
+  });
+
+  it("doesn't allow HTML tags", async () => {
+    const url = new URL(simpleURL.href);
+    url.searchParams.set(
+      "additionalCopyrightHolders",
+      // URL will perform encodeURIComponent automatically
+      "<span id=\"xss-attempt\">Internet Engineering Task Force</span>"
+    );
+    const doc = await makeRSDoc(makeStandardOps(), url);
+    const copyrightText = doc.querySelector(".copyright").textContent;
+    // if the ID is in the textContent, the HTML must not have been parsed.
+    expect(copyrightText).toMatch(/xss-attempt/);
   });
 });

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -94,7 +94,9 @@ describe("W3C — Headers", () => {
       expect(dd.querySelectorAll("a[href='http://URI']").length).toBe(0);
       expect(dd.dataset.editorId).toBe("1234");
       expect(dd.textContent).toMatch("(NOTE)");
-      expect(dd.querySelectorAll("a[href='https://orcid.org/0000-0002-1694-233X]").length).toBe(1);
+      expect(
+        dd.querySelector("a[href='https://orcid.org/0000-0002-1694-233X']")
+      ).not.toBeNull();
     });
 
     it("takes multiple editors into account", async () => {
@@ -140,6 +142,11 @@ describe("W3C — Headers", () => {
                 class: "twitter",
               },
               {
+                name: '<strong id="fb-link">Pyotr Zverev</strong>',
+                href: "https://facebook.com/pyotr_zverev",
+                class: "",
+              },
+              {
                 href: "http://not-valid-missing-name",
                 class: "invalid",
               },
@@ -169,7 +176,9 @@ describe("W3C — Headers", () => {
       // Check CSS is correctly applied
       expect(orcidAnchor.parentNode.className).toBe("orcid");
       expect(twitterAnchor.parentNode.className).toBe("twitter");
-      // check that extra items with no name are ignored
+      // Check that HTML is not escaped
+      expect(doc.querySelector("#fb-link")).not.toBeNull();
+      // Check that extra items with no name are ignored
       expect(doc.querySelector("a[href='http://not-valid']")).toBe(null);
       expect(doc.querySelector("a[href='http://empty-name']")).toBe(null);
     });

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -73,6 +73,7 @@ describe("W3C — Headers", () => {
             mailto: "EMAIL",
             note: "NOTE",
             w3cid: "1234",
+            orcid: "https://orcid.org/0000-0002-1694-233X",
           },
         ],
       };
@@ -93,6 +94,7 @@ describe("W3C — Headers", () => {
       expect(dd.querySelectorAll("a[href='http://URI']").length).toBe(0);
       expect(dd.dataset.editorId).toBe("1234");
       expect(dd.textContent).toMatch("(NOTE)");
+      expect(dd.querySelectorAll("a[href='https://orcid.org/0000-0002-1694-233X]").length).toBe(1);
     });
 
     it("takes multiple editors into account", async () => {


### PR DESCRIPTION
This escapes all query string configuration overrides, allows arbitrary HTML in a person's `extra` field, and allows for an `orcid` field on a person to display an ORCID logo and link. Resolves #2113 .

Questions:
* The ORCID logo isn't totally styled right (it's a bit off-center). The styles affecting other parts of a person's display seem to come from base.css, which is outside of respec. So, I would like guidance on where the appropriate spot is to add styles is.
* I had trouble getting the tests to pass on my local machine -- I'm not sure whether I should be going to `127.0.0.1:5000/tests/SpecRunner.html` as the developer guide recommends, running `npm run test:karma` (which is closer to what Travis does but seems not to use the minified JS in builds/ rather than the stuff in js/), or something else entirely.