### PR TITLE
feat(core/xref): Handle singular and plural cases

### DIFF
--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -89,10 +89,9 @@ export async function run(conf, elems) {
   }, Object.create(null));
 
   Object.keys(results).forEach(key => {
-      if (isSingular(key)) xrefMap.delete(pluralOf(key));
-      else xrefMap.delete(singularOf(key));
-    }
-  )
+    if (isSingular(key)) xrefMap.delete(pluralOf(key));
+    else xrefMap.delete(singularOf(key));
+  });
   addDataCiteToTerms(results, xrefMap, conf);
 }
 
@@ -201,10 +200,22 @@ function createXrefMap(elems) {
     const types = [isIDL ? elem.dataset.xrefType || "_IDL_" : "_CONCEPT_"];
     const { linkFor: forContext } = elem.dataset;
 
-    const xrefsForSingularTerm = map.has(singularterm) ? map.get(singularterm) : [];
+    const xrefsForSingularTerm = map.has(singularterm)
+      ? map.get(singularterm)
+      : [];
     const xrefsForPluralTerm = map.has(pluralterm) ? map.get(pluralterm) : [];
-    xrefsForSingularTerm.push({ elem, specs: uniqueSpecs, for: forContext, types });
-    xrefsForPluralTerm.push({ elem, specs: uniqueSpecs, for: forContext, types });
+    xrefsForSingularTerm.push({
+      elem,
+      specs: uniqueSpecs,
+      for: forContext,
+      types,
+    });
+    xrefsForPluralTerm.push({
+      elem,
+      specs: uniqueSpecs,
+      for: forContext,
+      types,
+    });
     map.set(singularterm, xrefsForSingularTerm);
     return map.set(pluralterm, xrefsForPluralTerm);
   }, new Map());


### PR DESCRIPTION
Fixes #2179 
<strike>Not fit for review currently.</strike>

To do:
1. Think of a better approach to process both singular and plural terms.
2. Change error handling to show an error only when both singular and plural forms could not be matched. [Currently, singular and plural forms are separate in xrefMap].
3. Add tests.