### PR TITLE
fix(core/inlines): Single letter variables don't get converted to var

### DIFF
--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -137,7 +137,7 @@ export function run(conf) {
       "\\b(?:NOT\\s+)?RECOMMENDED\\b",
       "\\bOPTIONAL\\b",
       "(?:{{3}\\s*.*\\s*}{3})", // inline IDL references,
-      "\\B\\|\\w[\\s\\w]*\\w(?:\\s*\\:\\s*\\w+)?\\|\\B", // inline variable regex
+      "\\B\\|\\w[\\w\\s]*(?:\\s*\\:[\\w\\s&;<>]+)?\\|\\B", // inline variable regex
       "(?:\\[\\[(?:!|\\\\|\\?)?[A-Za-z0-9\\.-]+\\]\\])",
       ...(abbrRx ? [abbrRx] : []),
     ].join("|")})`

--- a/tests/spec/core/inlines-spec.js
+++ b/tests/spec/core/inlines-spec.js
@@ -79,9 +79,12 @@ describe("Core - Inlines", () => {
         <p id="a1">TEXT |variable: Type| TEXT</p>
         <p id="a2">TEXT |variable with spaces:Type| TEXT</p>
         <p id="a3">TEXT |with spaces :  Type| TEXT</p>
+        <p id="a4">TEXT |with spaces :  Type with spaces| TEXT</p>
         <p id="b">TEXT |variable| TEXT</p>
         <p id="c">TEXT | ignored | TEXT</p>
         <p id="d">TEXT|ignore: Ignore|TEXT</p>
+        <p id="e">TEXT |p| TEXT </p>
+        <p id="f">TEXT |p: Type with spaces| TEXT </p>
       </section>
     `;
     const doc = await makeRSDoc(makeStandardOps(null, body));
@@ -97,11 +100,22 @@ describe("Core - Inlines", () => {
     expect(a3.textContent).toEqual("with spaces");
     expect(a3.dataset.type).toEqual("Type");
 
+    const a4 = doc.querySelector("#a4 var");
+    expect(a4.textContent).toEqual("with spaces");
+    expect(a4.dataset.type).toEqual("Type with spaces");
+
     const b = doc.querySelector("#b var");
     expect(b.textContent).toEqual("variable");
     expect(b.dataset.type).toBeUndefined();
 
     expect(doc.querySelector("#c var")).toBeFalsy();
     expect(doc.querySelector("#d var")).toBeFalsy();
+
+    const e = doc.querySelector("#e var");
+    expect(e.textContent).toEqual("p");
+    expect(e.dataset.type).toBeUndefined();
+    const f = doc.querySelector("#f var");
+    expect(f.textContent).toEqual("p");
+    expect(f.dataset.type).toEqual("Type with spaces");
   });
 });

--- a/tests/spec/core/inlines-spec.js
+++ b/tests/spec/core/inlines-spec.js
@@ -85,6 +85,8 @@ describe("Core - Inlines", () => {
         <p id="d">TEXT|ignore: Ignore|TEXT</p>
         <p id="e">TEXT |p| TEXT </p>
         <p id="f">TEXT |p: Type with spaces| TEXT </p>
+        <p id="g"> |p: Type with spaces| and |var1| and |var2:Type| </p>
+        <p id="h"> TEXT |var: Generic&lt;int&gt;| TEXT |var2: Generic&lt;unsigned short int&gt;| </p>
       </section>
     `;
     const doc = await makeRSDoc(makeStandardOps(null, body));
@@ -117,5 +119,19 @@ describe("Core - Inlines", () => {
     const f = doc.querySelector("#f var");
     expect(f.textContent).toEqual("p");
     expect(f.dataset.type).toEqual("Type with spaces");
+
+    const g = doc.querySelectorAll("#g var");
+    expect(g[0].textContent).toEqual("p");
+    expect(g[0].dataset.type).toEqual("Type with spaces");
+    expect(g[1].textContent).toEqual("var1");
+    expect(g[1].dataset.type).toBeUndefined();
+    expect(g[2].textContent).toEqual("var2");
+    expect(g[2].dataset.type).toEqual("Type");
+
+    const h = doc.querySelectorAll("#h var");
+    expect(h[0].textContent).toEqual("var");
+    expect(h[0].dataset.type).toEqual("Generic<int>");
+    expect(h[1].textContent).toEqual("var2");
+    expect(h[1].dataset.type).toEqual("Generic<unsigned short int>");
   });
 });


### PR DESCRIPTION
Fixes #2208 

The new RegEx is:
```js
/\B\|\w[\w\s]*(?:\s*\:[\w\s&;<>]+)?\|\B/
```

Thanks to @sidvishnoi for the RegEx. This matches single letter variables, and also types with spaces. I have tested it on some possible variable types, and it does not seem to create any new issues.

In the variable type, the RegEx matches word characters (A-Z, a-z, 0-9, _) and whitespace characterss and the characters `&;<>`. 

I want to confirm if no other character occurs in a variable type. @saschanaz Could you take a look at this?