### PR TITLE
fix(assets/respec2): offending elements don't display properly in Firefox

### DIFF
--- a/assets/respec2.css
+++ b/assets/respec2.css
@@ -56,6 +56,10 @@ a.bibref {
   animation: pop 0.25s ease-in-out 0s 1;
 }
 
+.respec-offending-element a[href] {
+  margin: 0;
+}
+
 .respec-offending-element {
   display: inline-block;
   position: relative;

--- a/assets/respec2.css
+++ b/assets/respec2.css
@@ -56,6 +56,7 @@ a.bibref {
   animation: pop 0.25s ease-in-out 0s 1;
 }
 
+/* TODO: Remove once https://github.com/w3c/tr-design/pull/176 is merged.*/
 .respec-offending-element a[href] {
   margin: 0;
 }

--- a/assets/respec2.css
+++ b/assets/respec2.css
@@ -56,7 +56,7 @@ a.bibref {
   animation: pop 0.25s ease-in-out 0s 1;
 }
 
-/* TODO: Remove once https://github.com/w3c/tr-design/pull/176 is merged.*/
+/* TODO: Remove once https://github.com/w3c/tr-design/pull/176 is merged. */
 .respec-offending-element a[href] {
   margin: 0;
 }


### PR DESCRIPTION
Fixes #2224 

To be reverted once https://github.com/w3c/tr-design/pull/176 is merged.
Fixes the issue for Firefox, and does not cause problems with Chrome. 