### PR TITLE
refactor(core/utils): transfer marked dependency to core/markdown

### DIFF
--- a/src/core/markdown.js
+++ b/src/core/markdown.js
@@ -1,3 +1,4 @@
+// @ts-check
 /**
  * Module core/markdown
  * Handles the optional markdown processing.
@@ -43,8 +44,30 @@
  * The whitespace of pre elements are left alone.
  */
 
-import { markdownToHtml } from "./utils.js";
+import marked from "marked";
+import { normalizePadding } from "./utils.js";
 export const name = "core/markdown";
+
+const gtEntity = /&gt;/gm;
+const ampEntity = /&amp;/gm;
+
+/**
+ * @param {string} text
+ */
+export function markdownToHtml(text) {
+  const normalizedLeftPad = normalizePadding(text);
+  // As markdown is pulled from HTML, > and & are already escaped and
+  // so blockquotes aren't picked up by the parser. This fixes it.
+  const potentialMarkdown = normalizedLeftPad
+    .replace(gtEntity, ">")
+    .replace(ampEntity, "&");
+  const result = marked(potentialMarkdown, {
+    sanitize: false,
+    gfm: true,
+    headerIds: false,
+  });
+  return result;
+}
 
 function processElements(selector) {
   return element => {

--- a/src/core/ui.js
+++ b/src/core/ui.js
@@ -11,7 +11,7 @@
 
 import css from "text!../../assets/ui.css";
 import hyperHTML from "hyperhtml";
-import { markdownToHtml } from "./utils.js";
+import { markdownToHtml } from "./markdown.js";
 import shortcut from "../shortcut.js";
 import { sub } from "./pubsubhub.js";
 export const name = "core/ui";

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -4,32 +4,12 @@
 // As the name implies, this contains a ragtag gang of methods that just don't fit
 // anywhere else.
 import { lang as docLang } from "./l10n.js";
-import marked from "marked";
 import { pub } from "./pubsubhub.js";
 export const name = "core/utils";
-
-marked.setOptions({
-  sanitize: false,
-  gfm: true,
-  headerIds: false,
-});
 
 const spaceOrTab = /^[ |\t]*/;
 const endsWithSpace = /\s+$/gm;
 const dashes = /-/g;
-const gtEntity = /&gt;/gm;
-const ampEntity = /&amp;/gm;
-
-export function markdownToHtml(text) {
-  const normalizedLeftPad = normalizePadding(text);
-  // As markdown is pulled from HTML, > and & are already escaped and
-  // so blockquotes aren't picked up by the parser. This fixes it.
-  const potentialMarkdown = normalizedLeftPad
-    .replace(gtEntity, ">")
-    .replace(ampEntity, "&");
-  const result = marked(potentialMarkdown);
-  return result;
-}
 
 export const ISODate = new Intl.DateTimeFormat(["en-ca-iso8601"], {
   timeZone: "UTC",


### PR DESCRIPTION
This is mainly to enable ES module system to load `core/utils` without requiring `marked`, and this anyway also looks more logical to me.