### PR TITLE
fix(w3c/headers): mismatched title warning

### DIFF
--- a/src/w3c/templates/headers.js
+++ b/src/w3c/templates/headers.js
@@ -27,7 +27,7 @@ function getSpecTitleElem(conf) {
     `;
     specTitleElem.prepend(...childNodes);
   }
-  conf.title = specTitleElem.textContent.trim();
+  conf.title = specTitleElem.textContent.replace(/\s{2,}/g, " ").trim();
   specTitleElem.classList.add("title", "p-name");
   if (document.querySelector("title") === null) {
     document.title = conf.title;

--- a/src/w3c/templates/headers.js
+++ b/src/w3c/templates/headers.js
@@ -1,5 +1,6 @@
 // @ts-check
 import html from "hyperhtml";
+import { norm } from "../../core/utils.js";
 import { pub } from "../../core/pubsubhub.js";
 import showLink from "./show-link.js";
 import showLogo from "./show-logo.js";
@@ -27,7 +28,7 @@ function getSpecTitleElem(conf) {
     `;
     specTitleElem.prepend(...childNodes);
   }
-  conf.title = specTitleElem.textContent.replace(/\s{2,}/g, " ").trim();
+  conf.title = norm(specTitleElem.textContent);
   specTitleElem.classList.add("title", "p-name");
   if (document.querySelector("title") === null) {
     document.title = conf.title;


### PR DESCRIPTION
This is a continuation to #2251 fixing a small bug with the implementation, when both `h1` and `document.title` are present and `isPreview`, `prUrl`, and `prNumber` are set, then ReSpec emits a warning `The document's title and the "<title>" element differ.` due to whitespace being present.

Sorry for not testing this initially. 

I don't think I can have a test for this until #1084 is fixed. 