### PR TITLE
feat(core/inlines): process code inside inline links

### DIFF
--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -27,6 +27,11 @@ import { renderInlineCitation } from "./render-biblio.js";
 export const name = "core/inlines";
 export const rfc2119Usage = {};
 
+// Inline `code`
+// TODO: Replace (?!`) at the end with (?:<!`) at the start when Firefox + Safari
+// add support.
+const inlineCodeRegExp = new RegExp("(?:`[^`]+`)(?!`)");
+
 /**
  * @param {string} matched
  * @return {HTMLElement}
@@ -121,12 +126,25 @@ function inlineLinkMatches(matched) {
     .split("/", 2)
     .map(s => s.trim());
   const [isFor, content] = parts.length === 2 ? parts : ["", parts[0]];
-  return hyperHTML`<a data-link-for="${isFor}" data-xref-for="${isFor}">${content}</a>`;
+  const processedContent = processInlineContent(content);
+  return hyperHTML`<a data-link-for="${isFor}" data-xref-for="${isFor}">${processedContent}</a>`;
 }
 
 function inlineCodeMatches(matched) {
   const clean = matched.slice(1, -1); // Chop ` and `
   return hyperHTML`<code>${clean}</code>`;
+}
+
+function processInlineContent(text) {
+  if (inlineCodeRegExp.test(text)) {
+    // We use a capture group to split, so we can process all the parts.
+    return text.split(/(`[^`]+`)(?!`)/).map(part => {
+      return part.startsWith("`")
+        ? inlineCodeMatches(part)
+        : processInlineContent(part);
+    });
+  }
+  return hyperHTML`${text}`;
 }
 
 export function run(conf) {
@@ -170,15 +188,13 @@ export function run(conf) {
       "(?:\\[\\[(?:!|\\\\|\\?)?[A-Za-z0-9\\.-]+\\]\\])",
       "(?:\\[\\[\\[(?:!|\\\\|\\?)?[A-Za-z0-9\\.-]+\\]\\]\\])",
       "(?:\\[=[^=]+=\\])", // Inline [= For/link =]
-      // TODO: Add (?:<!`) when Firefox and Safari add support
-      "(?:`[^`]+`)(?!`)", // Inline `code`
+      inlineCodeRegExp.source,
       ...(abbrRx ? [abbrRx] : []),
     ].join("|")})`
   );
   for (const txt of txts) {
     const subtxt = txt.data.split(rx);
     if (subtxt.length === 1) continue;
-
     const df = document.createDocumentFragment();
     let matched = true;
     for (const t of subtxt) {

--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -144,7 +144,7 @@ function processInlineContent(text) {
         : processInlineContent(part);
     });
   }
-  return hyperHTML`${text}`;
+  return document.createTextNode(text);
 }
 
 export function run(conf) {

--- a/tests/spec/core/inlines-spec.js
+++ b/tests/spec/core/inlines-spec.js
@@ -188,7 +188,31 @@ describe("Core - Inlines", () => {
     ]);
   });
 
-  it("proceses `backticks` as code", async () => {
+  it("proceseses backticks inside [= =] inline links", async () => {
+    const body = `
+      <section>
+        <p>
+          <dfn><code>link</code> element</dfn>
+          <dfn>some \`Coded\` thing</dfn>
+        </p>
+        <p id="inlines">
+          [= \`link\` element =] and [= some \`Coded\` thing =]
+        </p>
+      </section>
+    `;
+    const doc = await makeRSDoc(makeStandardOps(null, body));
+    const [linkElement, someCodedThing] = doc.querySelectorAll("#inlines a");
+
+    expect(linkElement.getAttribute("href")).toBe("#dfn-link-element");
+    const linkCodeElem = linkElement.querySelector("code");
+    expect(linkCodeElem.textContent).toBe("link");
+
+    expect(someCodedThing.getAttribute("href")).toBe("#dfn-some-coded-thing");
+    const codedThingCodeElem = someCodedThing.querySelector("code");
+    expect(codedThingCodeElem.textContent).toBe("Coded");
+  });
+
+  it("proceseses `backticks` as code", async () => {
     const body = `
       <section>
         <p id="simple">Return \`null\`.</p>


### PR DESCRIPTION
Can now handle, for example, [= `link` element =] 