### PR TITLE
fix(assets/var): prevent reflow on var:hover

### DIFF
--- a/assets/var.css
+++ b/assets/var.css
@@ -1,5 +1,5 @@
 var:hover {
-  border-bottom: 1px dotted;
+  text-decoration: underline;
   cursor: pointer;
 }
 


### PR DESCRIPTION
Using border bottom causes everything to reflow on hover, as it adds an extra pixel... using text-decoration prevents this. 