### PR TITLE
 feat(core/inlines): allow [[[#...]]] to expand ids in doc

### DIFF
--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -51,7 +51,9 @@ function inlineRFC2119Matches(matched) {
 function inlineRefMatches(matched) {
   // slices "[[[" at the beginning and "]]]" at the end
   const ref = matched.slice(3, -3).trim();
-  const nodeElement = hyperHTML`<a data-cite="${ref}"></a>`;
+  const nodeElement = ref.startsWith("#")
+    ? hyperHTML`<a href="${ref}"></a>`
+    : hyperHTML`<a data-cite="${ref}"></a>`;
   return nodeElement;
 }
 
@@ -191,7 +193,7 @@ export function run(conf) {
       "(?:{{[^}]+}})", // inline IDL references,
       "\\B\\|\\w[\\w\\s]*(?:\\s*\\:[\\w\\s&;<>]+)?\\|\\B", // inline variable regex
       "(?:\\[\\[(?:!|\\\\|\\?)?[A-Za-z0-9\\.-]+\\]\\])",
-      "(?:\\[\\[\\[(?:!|\\\\|\\?)?[A-Za-z0-9\\.-]+\\]\\]\\])",
+      "(?:\\[\\[\\[(?:!|\\\\|\\?)?[#A-Za-z0-9\\.-]+\\]\\]\\])",
       "(?:\\[=[^=]+=\\])", // Inline [= For/link =]
       inlineCodeRegExp.source,
       ...(abbrRx ? [abbrRx] : []),

--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -52,19 +52,19 @@ function inlineRFC2119Matches(matched) {
 function inlineRefMatches(matched) {
   // slices "[[[" at the beginning and "]]]" at the end
   const ref = matched.slice(3, -3).trim();
-  if (ref.startsWith("#")) {
-    if (document.querySelector(ref)) {
-      return hyperHTML`<a href="${ref}"></a>`;
-    }
-    const badReference = hyperHTML`<span>${matched}</span>`;
-    showInlineError(
-      badReference, // cite element
-      `Wasn't able to expand ${matched} as it didn't match any id in the document.`,
-      `Please make sure there is element with id ${ref} in the document.`
-    );
-    return badReference;
+  if (!ref.startsWith("#")) {
+    return hyperHTML`<a data-cite="${ref}"></a>`;
   }
-  return hyperHTML`<a data-cite="${ref}"></a>`;
+  if (document.querySelector(ref)) {
+    return hyperHTML`<a href="${ref}"></a>`;
+  }
+  const badReference = hyperHTML`<span>${matched}</span>`;
+  showInlineError(
+    badReference, // cite element
+    `Wasn't able to expand ${matched} as it didn't match any id in the document.`,
+    `Please make sure there is element with id ${ref} in the document.`
+  );
+  return badReference;
 }
 
 /**

--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -205,7 +205,7 @@ export function run(conf) {
       "(?:{{[^}]+}})", // inline IDL references,
       "\\B\\|\\w[\\w\\s]*(?:\\s*\\:[\\w\\s&;<>]+)?\\|\\B", // inline variable regex
       "(?:\\[\\[(?:!|\\\\|\\?)?[A-Za-z0-9\\.-]+\\]\\])",
-      "(?:\\[\\[\\[(?:!|\\\\|\\?)?[#A-Za-z0-9\\.-]+\\]\\]\\])",
+      "(?:\\[\\[\\[(?:!|\\\\|\\?)?#?[A-Za-z0-9\\.-]+\\]\\]\\])",
       "(?:\\[=[^=]+=\\])", // Inline [= For/link =]
       inlineCodeRegExp.source,
       ...(abbrRx ? [abbrRx] : []),

--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -53,18 +53,16 @@ function inlineRefMatches(matched) {
   // slices "[[[" at the beginning and "]]]" at the end
   const ref = matched.slice(3, -3).trim();
   if (ref.startsWith("#")) {
-    if (!document.querySelector(ref)) {
-      const badReference = hyperHTML`
-        <span>${matched}</span>
-      `;
-      showInlineError(
-        badReference, // cite element
-        `Wasn't able to expand ${matched} as it didn't match any id in the document.`,
-        `Please make sure there is element with id ${ref} in the document.`
-      );
-      return badReference;
+    if (document.querySelector(ref)) {
+      return hyperHTML`<a href="${ref}"></a>`;
     }
-    return hyperHTML`<a href="${ref}"></a>`;
+    const badReference = hyperHTML`<span>${matched}</span>`;
+    showInlineError(
+      badReference, // cite element
+      `Wasn't able to expand ${matched} as it didn't match any id in the document.`,
+      `Please make sure there is element with id ${ref} in the document.`
+    );
+    return badReference;
   }
   return hyperHTML`<a data-cite="${ref}"></a>`;
 }

--- a/tests/spec/core/inlines-spec.js
+++ b/tests/spec/core/inlines-spec.js
@@ -192,6 +192,33 @@ describe("Core - Inlines", () => {
     ]);
   });
 
+  it("allows [[[#...]]] to be a general expander for ids in document", async () => {
+    const body = `
+      <section id="section">
+        <h2>section heading</h2>
+        <figure id="figure">
+          <figcaption>figure caption</figcaption>
+        </figure>
+        <aside class="example" id="example-aside" title="aside"></aside>
+        <pre class="example" id="example-pre" title="pre">
+        </pre>
+      </section>
+      <p id="output">
+        [[[#section]]]
+        [[[#figure]]]
+        [[[#example-aside]]]
+        [[[#example-pre]]]
+      </p>`;
+    const doc = await makeRSDoc(makeStandardOps(null, body));
+    const [section, figure, exampleAside, examplePre] = doc.querySelectorAll(
+      "#output a"
+    );
+    expect(section.textContent).toBe("§ 1. section heading");
+    expect(figure.textContent).toBe("Figure 1");
+    expect(exampleAside.textContent).toBe("Example 1: aside");
+    expect(examplePre.textContent).toBe("Example 2: pre");
+  });
+
   it("proceseses backticks inside [= =] inline links", async () => {
     const body = `
       <section>

--- a/tests/spec/core/inlines-spec.js
+++ b/tests/spec/core/inlines-spec.js
@@ -208,15 +208,20 @@ describe("Core - Inlines", () => {
         [[[#figure]]]
         [[[#example-aside]]]
         [[[#example-pre]]]
+        [[[#does-not-exist]]]
       </p>`;
     const doc = await makeRSDoc(makeStandardOps(null, body));
-    const [section, figure, exampleAside, examplePre] = doc.querySelectorAll(
-      "#output a"
-    );
+    const anchors = doc.querySelectorAll("#output a");
+
+    expect(anchors.length).toBe(4);
+    const [section, figure, exampleAside, examplePre] = anchors;
     expect(section.textContent).toBe("§ 1. section heading");
     expect(figure.textContent).toBe("Figure 1");
     expect(exampleAside.textContent).toBe("Example 1: aside");
     expect(examplePre.textContent).toBe("Example 2: pre");
+
+    const badOne = doc.querySelector("#output span.respec-offending-element");
+    expect(badOne.textContent).toBe("[[[#does-not-exist]]]");
   });
 
   it("proceseses backticks inside [= =] inline links", async () => {


### PR DESCRIPTION
closes #2131 

Allow for `[[[#example-1]]]` and `[[[#figure-whatever]]]` and so on... 

The actual expansion is handled by individual modules. 