### PR TITLE
fix(core/mdn-annotation): Improve user experience

### DIFF
--- a/assets/mdn-annotation.css
+++ b/assets/mdn-annotation.css
@@ -13,16 +13,10 @@
 
 .mdn button {
   cursor: pointer;
-  position: absolute;
-  left: 0;
-  top: -2px;
-  height: 1em;
   border: none;
   color: #000;
   background: transparent;
-  margin-left: -8px;
-  font-size: 10px;
-  line-height: 1em;
+  margin: -8px;
   outline: none;
 }
 
@@ -36,18 +30,11 @@
   vertical-align: top;
 }
 
-.mdn details {
-  display: inline;
-  margin-left: 2px;
+.mdn > div > div {
+  display: inline-block;
+  margin-left: 5px;
 }
 
-.mdn summary {
-  outline: none;
-}
-
-.mdn summary a {
-  margin-left: -4px;
-}
 
 .nosupportdata {
   font-style: italic;
@@ -213,7 +200,7 @@ h6 + .mdn {
   min-width: 0px;
 }
 
-.mdn.wrapped details {
+.mdn.wrapped > div > div {
   display: none;
 }
 

--- a/src/core/mdn-annotation.js
+++ b/src/core/mdn-annotation.js
@@ -43,23 +43,19 @@ function insertMDNBox(node) {
     // If the target ancestor already has a mdnBox inserted, we just use it
     return targetSibling;
   }
-  const mdnBox = hyperHTML`<aside class="mdn before wrapped">
-    <button onclick="toggleMDNStatus(this)" aria-label="Expand MDN details">⋰</button>
-  </aside>`;
+  const mdnBox = hyperHTML`<aside class="mdn before wrapped"></aside>`;
   parentNode.insertBefore(mdnBox, targetAncestor);
   return mdnBox;
 }
 
 function attachMDNDetail(container, mdnSpec) {
   const { slug, summary } = mdnSpec;
-  container.innerHTML += "<b>MDN </b>";
+  container.innerHTML += `<button onclick="toggleMDNStatus(this.parentNode)" aria-label="Expand MDN details"><b>MDN</b></button>`;
   const mdnSubPath = slug.slice(slug.indexOf("/") + 1);
-  const mdnDetail = document.createElement("details");
+  const mdnDetail = document.createElement("div");
   const href = `${MDN_URL_BASE}${slug}`;
   hyperHTML(mdnDetail)`
-    <summary>
       <a title="${summary}" href="${href}">${mdnSubPath}</a>
-    </summary>
   `;
   attachMDNBrowserSupport(mdnDetail, mdnSpec);
   container.appendChild(mdnDetail);


### PR DESCRIPTION
Closes #2313 

I have increased the hit area and also the removed the `<details>` section so now browser support table opens up without an additional click. Tested on Firefox and Chrome. Please try it out.

> We should also improve the markup. When we shipped, we copied what the HTML Spec was doing... but the markup is less than ideal.

Does this mean refactoring of the implementation? Like using `addEventListener("click",..)` instead of the current implementation where the event handler is in the HTML itself?  