### PR TITLE
fix: remove all comment nodes when exporting

### DIFF
--- a/src/core/anchor-expander.js
+++ b/src/core/anchor-expander.js
@@ -1,5 +1,5 @@
 // expands empty anchors based on their context
-import { norm, renameElement, showInlineError } from "./utils.js";
+import { makeSafeCopy, norm, showInlineError } from "./utils.js";
 
 export const name = "core/anchor-expander";
 
@@ -60,8 +60,8 @@ function processBox(matchingElement, id, a) {
     showInlineError(a, msg, "Missing title.");
     return;
   }
-  const children = makeSafeCopy(selfLink);
-  a.append(...children);
+  const copy = makeSafeCopy(selfLink);
+  a.append(...copy.childNodes);
   a.classList.add("box-ref");
 }
 
@@ -74,7 +74,7 @@ function processFigure(matchingElement, id, a) {
     return;
   }
   // remove the figure's title
-  const children = [...makeSafeCopy(figcaption)].filter(
+  const children = [...makeSafeCopy(figcaption).childNodes].filter(
     node => !node.classList || !node.classList.contains("fig-title")
   );
   // drop an empty space at the end.
@@ -102,21 +102,12 @@ function processSection(matchingElement, id, a) {
 
 function processHeading(heading, a) {
   const hadSelfLink = heading.querySelector(".self-link");
-  const children = [...makeSafeCopy(heading)].filter(
+  const children = [...makeSafeCopy(heading).childNodes].filter(
     node => !node.classList || !node.classList.contains("self-link")
   );
   a.append(...children);
   if (hadSelfLink) a.prepend("§\u00A0");
   a.classList.add("sec-ref");
-}
-
-function makeSafeCopy(node) {
-  const clone = node.cloneNode(true);
-  clone.querySelectorAll("[id]").forEach(elem => elem.removeAttribute("id"));
-  clone.querySelectorAll("dfn").forEach(dfn => renameElement(dfn, "span"));
-  return [...clone.childNodes].filter(
-    node => node.nodeType !== Node.COMMENT_NODE
-  );
 }
 
 function localize(matchingElement, newElement) {

--- a/src/core/exporter.js
+++ b/src/core/exporter.js
@@ -6,10 +6,10 @@
  * That is, elements that have a "removeOnSave" css class.
  */
 
+import { removeCommentNodes, removeReSpec } from "./utils.js";
 import { expose } from "./expose-modules.js";
 import hyperHTML from "hyperhtml";
 import { pub } from "./pubsubhub.js";
-import { removeReSpec } from "./utils.js";
 
 const mimeTypes = new Map([["text/html", "html"], ["application/xml", "xml"]]);
 
@@ -53,7 +53,7 @@ function serialize(format, doc) {
 
 function cleanup(cloneDoc) {
   const { head, body, documentElement } = cloneDoc;
-  cleanupHyper(cloneDoc);
+  removeCommentNodes(cloneDoc);
 
   cloneDoc
     .querySelectorAll(".removeOnSave, #toc-nav")
@@ -87,32 +87,6 @@ function cleanup(cloneDoc) {
   insertions.appendChild(metaGenerator);
   head.prepend(insertions);
   pub("beforesave", documentElement);
-}
-
-function cleanupHyper({ documentElement: node }) {
-  // collect first, or walker will cease too early
-  /** @param {Comment} comment */
-  const filter = comment =>
-    comment.textContent.startsWith("-") && comment.textContent.endsWith("%");
-  const walker = document.createTreeWalker(
-    node,
-    NodeFilter.SHOW_COMMENT,
-    filter
-  );
-  for (const comment of [...walkTree(walker)]) {
-    comment.remove();
-  }
-}
-
-/**
- * @template {Node} T
- * @param {TreeWalker<T>} walker
- * @return {IterableIterator<T>}
- */
-function* walkTree(walker) {
-  while (walker.nextNode()) {
-    yield /** @type {T} */ (walker.currentNode);
-  }
 }
 
 expose("core/exporter", { rsDocToDataURL });

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -834,7 +834,7 @@ export function makeSafeCopy(node) {
 
 export function removeCommentNodes(node) {
   const walker = document.createTreeWalker(node, NodeFilter.SHOW_COMMENT);
-  for (const comment of [...walkTree(walker)]) {
+  for (const comment of walkTree(walker)) {
     comment.remove();
   }
 }

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -834,7 +834,7 @@ export function makeSafeCopy(node) {
 
 export function removeCommentNodes(node) {
   const walker = document.createTreeWalker(node, NodeFilter.SHOW_COMMENT);
-  for (const comment of walkTree(walker)) {
+  for (const comment of [...walkTree(walker)]) {
     comment.remove();
   }
 }

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -822,3 +822,30 @@ export class InsensitiveStringSet extends Set {
         );
   }
 }
+
+export function makeSafeCopy(node) {
+  const clone = node.cloneNode(true);
+  clone.querySelectorAll("[id]").forEach(elem => elem.removeAttribute("id"));
+  clone.querySelectorAll("dfn").forEach(dfn => renameElement(dfn, "span"));
+  if (clone.hasAttribute("id")) clone.removeAttribute("id");
+  removeCommentNodes(clone);
+  return clone;
+}
+
+export function removeCommentNodes(node) {
+  const walker = document.createTreeWalker(node, NodeFilter.SHOW_COMMENT);
+  for (const comment of [...walkTree(walker)]) {
+    comment.remove();
+  }
+}
+
+/**
+ * @template {Node} T
+ * @param {TreeWalker<T>} walker
+ * @return {IterableIterator<T>}
+ */
+function* walkTree(walker) {
+  while (walker.nextNode()) {
+    yield /** @type {T} */ (walker.currentNode);
+  }
+}

--- a/tests/spec/core/exporter-spec.js
+++ b/tests/spec/core/exporter-spec.js
@@ -28,9 +28,9 @@ describe("Core - exporter", () => {
     expect(doc.querySelectorAll(".removeOnSave").length).toBe(0);
   });
 
-  it("cleans up hyperHTML comments", async () => {
+  it("removes all comments", async () => {
     const ops = makeStandardOps();
-    ops.body = `<div><!---LEAVE%-->PASS<!-- STAY --></div>`;
+    ops.body = `<div><!-- remove -->PASS <span><!-- remove --></span></div>`;
     const doc = await getExportedDoc(ops);
 
     const walker = document.createTreeWalker(doc.body, NodeFilter.SHOW_COMMENT);
@@ -38,15 +38,7 @@ describe("Core - exporter", () => {
     while (walker.nextNode()) {
       comments.push(walker.currentNode);
     }
-
-    const hyperComments = comments.filter(
-      comment =>
-        comment.textContent.startsWith("-") && comment.textContent.endsWith("%")
-    );
-    expect(hyperComments.length).toBe(0);
-
-    expect(comments.length).toBe(1);
-    expect(comments[0].textContent.trim()).toBe("STAY");
+    expect(comments.length).toBe(0);
   });
 
   it("moves the W3C style sheet to be last thing in documents head", async () => {


### PR DESCRIPTION
All comments are removed when exporting. 

`makeSafeCopy()` now returns the copied node, not just the children. 

core/utils now exports `removeCommentNodes()`