### PR TITLE
fix(w3c/conformance): use BCP 14 (RFC8174) for conformance

### DIFF
--- a/src/w3c/conformance.js
+++ b/src/w3c/conformance.js
@@ -32,9 +32,12 @@ function processConformance(conformance, conf) {
     ${terms.length
       ? html`
           <p>
-            The key word${plural ? "s" : ""} ${[keywords]}
+            The key word${plural ? "s" : ""} ${[keywords]} in this document
             ${plural ? "are" : "is"} to be interpreted as described in
-            ${renderInlineCitation("RFC2119")}.
+            <a href="https://tools.ietf.org/html/bcp14">BCP 14</a>
+            ${renderInlineCitation("RFC2119")}
+            ${renderInlineCitation("RFC8174")} when, and only when, they appear
+            in all capitals, as shown here.
           </p>
         `
       : null}

--- a/tests/spec/core/inlines-spec.js
+++ b/tests/spec/core/inlines-spec.js
@@ -41,7 +41,7 @@ describe("Core - Inlines", () => {
     expect(inform.map(el => el.textContent)).toEqual(["[infra]", "[webidl]"]);
 
     const links = [...doc.querySelectorAll("section cite a")];
-    expect(links.length).toBe(7);
+    expect(links.length).toBe(8);
     expect(links[0].textContent).toBe("RFC2119");
     expect(links[0].getAttribute("href")).toBe("#bib-rfc2119");
     expect(links[1].textContent).toBe("dom");

--- a/tests/spec/core/inlines-spec.js
+++ b/tests/spec/core/inlines-spec.js
@@ -44,10 +44,12 @@ describe("Core - Inlines", () => {
     expect(links.length).toBe(8);
     expect(links[0].textContent).toBe("RFC2119");
     expect(links[0].getAttribute("href")).toBe("#bib-rfc2119");
-    expect(links[1].textContent).toBe("dom");
-    expect(links[1].getAttribute("href")).toBe("#bib-dom");
-    expect(links[5].textContent).toBe("svg");
-    expect(links[5].getAttribute("href")).toBe("#bib-svg");
+    expect(links[1].textContent).toBe("RFC8174");
+    expect(links[1].getAttribute("href")).toBe("#bib-rfc8174");
+    expect(links[2].textContent).toBe("dom");
+    expect(links[2].getAttribute("href")).toBe("#bib-dom");
+    expect(links[6].textContent).toBe("svg");
+    expect(links[6].getAttribute("href")).toBe("#bib-svg");
 
     const illegalCite = doc.querySelector("#illegal cite");
     expect(illegalCite.classList.contains("respec-offending-element")).toBe(


### PR DESCRIPTION
Move to using the newer [rfc8174](https://tools.ietf.org/html/rfc8174) for conformance key worlds, which fixes ambiguity between "MUST" and "must". 