### PR TITLE
refactor(core): remove redundant `new Request()`

### DIFF
--- a/src/core/contrib.js
+++ b/src/core/contrib.js
@@ -30,7 +30,7 @@ async function toHTML(urls, editors, element, headers) {
   const args = await Promise.all(
     urls
       .map(url =>
-        fetch(new Request(url, { headers })).then(r => {
+        fetch(url, { headers }).then(r => {
           if (checkLimitReached(r)) return null;
           return r.json();
         })
@@ -60,7 +60,7 @@ export async function run(conf) {
   }
 
   const headers = githubRequestHeaders(conf);
-  const response = await fetch(new Request(githubAPI, { headers }));
+  const response = await fetch(githubAPI, { headers });
   checkLimitReached(response);
   if (!response.ok) {
     const msg =

--- a/src/core/mdn-annotation.js
+++ b/src/core/mdn-annotation.js
@@ -32,8 +32,7 @@ const MDN_BROWSERS = {
 
 function fetchAndCacheJson(url, maxAge) {
   if (!url) return {};
-  const request = new Request(url);
-  return fetchAndCache(request, maxAge).then(r => r.json());
+  return fetchAndCache(url, maxAge).then(r => r.json());
 }
 
 function insertMDNBox(node) {

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -418,7 +418,7 @@ export function runTransforms(content, flist) {
  *  else: request from network, cache and return fresh response.
  *    If network fails, return a stale cached version if exists (else throw)
  */
-export async function fetchAndCache(input, maxAge) {
+export async function fetchAndCache(input, maxAge = 86400000) {
   const request = new Request(input);
   const url = new URL(request.url);
 

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -411,17 +411,15 @@ export function runTransforms(content, flist) {
 
 /**
  * Cached request handler
- * @param {Request} request
- * @param {Object} maxAge cache expiration duration in ms. defaults to 24 hours (86400000 ms)
+ * @param {RequestInfo} input
+ * @param {number} maxAge cache expiration duration in ms. defaults to 24 hours (86400000 ms)
  * @return {Promise<Response>}
  *  if a cached response is available and it's not stale, return it
  *  else: request from network, cache and return fresh response.
  *    If network fails, return a stale cached version if exists (else throw)
  */
-export async function fetchAndCache(request, maxAge = 86400000) {
-  if (typeof request === "string" || request instanceof URL) {
-    request = new Request(request);
-  }
+export async function fetchAndCache(input, maxAge) {
+  const request = new Request(input);
   const url = new URL(request.url);
 
   // use data from cache data if valid and render


### PR DESCRIPTION
`fetch()` can directly receive a url and headers, so no need to explicitly create a request first.