### PR TITLE
chore(package): pin puppeteer to 1.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "opencollective": "^1.0.3",
     "opencollective-postinstall": "^2.0.2",
     "prompt": "^1.0.0",
-    "puppeteer": "^1.16.0"
+    "puppeteer": "1.16.0"
   },
   "prettier": {
     "trailingComma": "es5"

--- a/tools/copydeps.js
+++ b/tools/copydeps.js
@@ -83,7 +83,11 @@ async function deleteFolder(path) {
   for (const file of await fs.readdir(path)) {
     const curPath = `${path}/${file}`;
     const stat = await fs.lstat(curPath);
-    stat.isDirectory() ? deleteFolder(curPath) : fs.unlink(curPath);
+    if (stat.isDirectory()) {
+      await deleteFolder(curPath);
+    } else {
+      await fs.unlink(curPath);
+    }
   }
   await fs.rmdir(path);
 }


### PR DESCRIPTION
As I said in https://github.com/w3c/respec/issues/2359#issuecomment-495554972 I think this is an intermittent Chrome Canary bug (on which puppeteer depends).