### PR TITLE
fix(core/webidl): link idl blocks contextually

### DIFF
--- a/examples/basic.html
+++ b/examples/basic.html
@@ -18,7 +18,7 @@
         }],
         github: "https://github.com/w3c/some-API/",
         testSuiteURI: "https://w3c-test.org/some-API/",
-        implementationReportURI: "https://w3c.github.io/test-results/some-API"
+        implementationReportURI: "https://w3c.github.io/test-results/some-API",
       };
     </script>
   </head>

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -19,6 +19,7 @@
         github: "https://github.com/w3c/some-API/",
         testSuiteURI: "https://w3c-test.org/some-API/",
         implementationReportURI: "https://w3c.github.io/test-results/some-API",
+        xref: "web-platform",
       };
     </script>
   </head>

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -18,8 +18,7 @@
         }],
         github: "https://github.com/w3c/some-API/",
         testSuiteURI: "https://w3c-test.org/some-API/",
-        implementationReportURI: "https://w3c.github.io/test-results/some-API",
-        xref: "web-platform",
+        implementationReportURI: "https://w3c.github.io/test-results/some-API"
       };
     </script>
   </head>

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -259,9 +259,7 @@ function renderWebIDL(idlElement) {
   }
   idlElement.classList.add("def", "idl");
   const closestCite = idlElement.closest("[data-cite]");
-  if (!closestCite) {
-    document.body.dataset.cite = "WebIDL";
-  } else {
+  if (closestCite) {
     const { dataset } = closestCite;
     if (dataset.cite) {
       const hasWebIDL = dataset.cite

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -273,19 +273,21 @@ function renderWebIDL(idlElement) {
   // cross reference
   const closestCite = idlElement.closest("[data-cite], body");
   const { dataset } = closestCite;
-  if ("cite" in dataset) {
-    const hasWebIDL = dataset.cite
-      .split(/\s+/)
-      .map(item => item.toLowerCase())
-      .includes("webidl");
-    if (hasWebIDL) return;
-  } else {
-    // this is body, so just add it
+  if (!dataset.cite) {
     dataset.cite = "WebIDL";
     return;
   }
-  const newCite = ["WebIDL"].concat(dataset.cite.split(/\s+/)).filter(i => i);
-  dataset.cite = newCite.join(" ");
+  const hasWebIDL = dataset.cite
+    .split(/\s+/)
+    .map(item => item.toLowerCase())
+    .includes("webidl");
+
+  if (hasWebIDL) return;
+
+  dataset.cite = ["WebIDL"]
+    .concat(dataset.cite.split(/\s+/))
+    .filter(i => i)
+    .join(" ");
 }
 
 export function run() {

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -258,24 +258,6 @@ function renderWebIDL(idlElement) {
     return;
   }
   idlElement.classList.add("def", "idl");
-  const closestCite = idlElement.closest("[data-cite]");
-  if (closestCite) {
-    const { dataset } = closestCite;
-    if (dataset.cite) {
-      const hasWebIDL = dataset.cite
-        .split(" ")
-        .map(item => item.toLowerCase())
-        .includes("webidl");
-      if (!hasWebIDL) {
-        const newDataCite = ["WebIDL"].concat(
-          dataset.cite.split(/\s+/).filter(i => i)
-        );
-        dataset.cite = newDataCite.join(" ");
-      }
-    } else {
-      dataset.cite = "WebIDL";
-    }
-  }
   const html = webidl2.write(parse, { templates });
   const render = hyperHTML.bind(idlElement);
   render`${html}`;
@@ -288,6 +270,22 @@ function renderWebIDL(idlElement) {
     }
     registerDefinition(elem, [title]);
   });
+  // cross reference
+  const closestCite = idlElement.closest("[data-cite]");
+  if (!closestCite) {
+    document.body.dataset.cite = "WebIDL";
+    return;
+  }
+  const { dataset } = closestCite;
+  const hasWebIDL = dataset.cite
+    .split(/s+/)
+    .map(item => item.toLowerCase())
+    .includes("webidl");
+  if (hasWebIDL) return;
+  dataset.cite = dataset.cite
+    .split(/s+/)
+    .push("WebIDL")
+    .join(" ");
 }
 
 export function run() {

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -273,16 +273,11 @@ function renderWebIDL(idlElement) {
   // cross reference
   const closestCite = idlElement.closest("[data-cite], body");
   const { dataset } = closestCite;
-  if (!dataset.cite) {
-    dataset.cite = "WebIDL";
-    return;
-  }
-  const cites = dataset.cite.split(/\s+/).filter(i => i);
-  const hasWebIDL = cites.map(item => item.toLowerCase()).includes("webidl");
-
-  if (hasWebIDL) return;
-
-  dataset.cite = cites.concat("WebIDL").join(" ");
+  if (!dataset.cite) dataset.cite = "WebIDL";
+  // includes webidl in some form
+  if (/\bwebidl\b/i.test(dataset.cite)) return;
+  const cites = dataset.cite.trim().split(/\s+/);
+  dataset.cite = ["WebIDL", ...cites].join(" ");
 }
 
 export function run() {

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -258,20 +258,25 @@ function renderWebIDL(idlElement) {
     return;
   }
   idlElement.classList.add("def", "idl");
-  const { dataset } = idlElement;
-  if (dataset.cite) {
-    const hasWebIDL = dataset.cite
-      .split(" ")
-      .map(item => item.toLowerCase())
-      .includes("webidl");
-    if (!hasWebIDL) {
-      const newDataCite = ["WebIDL"].concat(
-        dataset.cite.split(/\s+/).filter(i => i)
-      );
-      dataset.cite = newDataCite.join(" ");
-    }
+  const closestCite = idlElement.closest("[data-cite]");
+  if (!closestCite) {
+    document.body.dataset.cite = "WebIDL";
   } else {
-    dataset.cite = "WebIDL";
+    const { dataset } = closestCite;
+    if (dataset.cite) {
+      const hasWebIDL = dataset.cite
+        .split(" ")
+        .map(item => item.toLowerCase())
+        .includes("webidl");
+      if (!hasWebIDL) {
+        const newDataCite = ["WebIDL"].concat(
+          dataset.cite.split(/\s+/).filter(i => i)
+        );
+        dataset.cite = newDataCite.join(" ");
+      }
+    } else {
+      dataset.cite = "WebIDL";
+    }
   }
   const html = webidl2.write(parse, { templates });
   const render = hyperHTML.bind(idlElement);

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -271,21 +271,21 @@ function renderWebIDL(idlElement) {
     registerDefinition(elem, [title]);
   });
   // cross reference
-  const closestCite = idlElement.closest("[data-cite]");
-  if (!closestCite) {
-    document.body.dataset.cite = "WebIDL";
+  const closestCite = idlElement.closest("[data-cite], body");
+  const { dataset } = closestCite;
+  if ("cite" in dataset) {
+    const hasWebIDL = dataset.cite
+      .split(/s+/)
+      .map(item => item.toLowerCase())
+      .includes("webidl");
+    if (hasWebIDL) return;
+  } else {
+    // this is body, so just add it
+    dataset.cite = "WebIDL";
     return;
   }
-  const { dataset } = closestCite;
-  const hasWebIDL = dataset.cite
-    .split(/s+/)
-    .map(item => item.toLowerCase())
-    .includes("webidl");
-  if (hasWebIDL) return;
-  dataset.cite = dataset.cite
-    .split(/s+/)
-    .push("WebIDL")
-    .join(" ");
+  const newCite = ["WebIDL"].concat(dataset.cite.split(/s+/)).filter(i => i);
+  dataset.cite = newCite.join(" ");
 }
 
 export function run() {

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -275,7 +275,7 @@ function renderWebIDL(idlElement) {
   const { dataset } = closestCite;
   if ("cite" in dataset) {
     const hasWebIDL = dataset.cite
-      .split(/s+/)
+      .split(/\s+/)
       .map(item => item.toLowerCase())
       .includes("webidl");
     if (hasWebIDL) return;
@@ -284,7 +284,7 @@ function renderWebIDL(idlElement) {
     dataset.cite = "WebIDL";
     return;
   }
-  const newCite = ["WebIDL"].concat(dataset.cite.split(/s+/)).filter(i => i);
+  const newCite = ["WebIDL"].concat(dataset.cite.split(/\s+/)).filter(i => i);
   dataset.cite = newCite.join(" ");
 }
 

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -277,17 +277,12 @@ function renderWebIDL(idlElement) {
     dataset.cite = "WebIDL";
     return;
   }
-  const hasWebIDL = dataset.cite
-    .split(/\s+/)
-    .map(item => item.toLowerCase())
-    .includes("webidl");
+  const cites = dataset.cite.split(/\s+/).filter(i => i);
+  const hasWebIDL = cites.map(item => item.toLowerCase()).includes("webidl");
 
   if (hasWebIDL) return;
 
-  dataset.cite = ["WebIDL"]
-    .concat(dataset.cite.split(/\s+/))
-    .filter(i => i)
-    .join(" ");
+  dataset.cite = cites.concat("WebIDL").join(" ");
 }
 
 export function run() {

--- a/tests/data/xref/inline-idl-enum.json
+++ b/tests/data/xref/inline-idl-enum.json
@@ -1,7 +1,7 @@
 {
   "result": [
     [
-      "9a7f11d8f9a46fce8d14170914f73271d1cc8896",
+      "322b86ae2a57f3f9c9808ed6eef392ad921a66db",
       [
         {
           "shortname": "service-workers",
@@ -13,7 +13,7 @@
       ]
     ],
     [
-      "2dc7c88bffd81e1ddc880de8841fb9cdd3f612d5",
+      "ae23c059caeaa0072e8c6cd9ac6685d3b77bc22a",
       [
         {
           "shortname": "xhr",
@@ -42,12 +42,12 @@
       "term": "imports",
       "types": ["enum-value"],
       "for": "ServiceWorkerUpdateViaCache",
-      "id": "9a7f11d8f9a46fce8d14170914f73271d1cc8896"
+      "id": "322b86ae2a57f3f9c9808ed6eef392ad921a66db"
     },
     {
       "term": "blob",
       "types": ["enum-value"],
-      "id": "2dc7c88bffd81e1ddc880de8841fb9cdd3f612d5"
+      "id": "ae23c059caeaa0072e8c6cd9ac6685d3b77bc22a"
     },
     {
       "term": "block",

--- a/tests/data/xref/inline-locals.json
+++ b/tests/data/xref/inline-locals.json
@@ -1,7 +1,7 @@
 {
   "result": [
     [
-      "0eca50dead2a4aa568d80cde770d660417a20b78",
+      "318a08442ab399ac176948abb64c7fe6a4c3e8a6",
       [
         {
           "shortname": "webidl",
@@ -12,7 +12,7 @@
       ]
     ],
     [
-      "7c6f3cfd1cf92d00249d3a483265a7c58e42ecf1",
+      "4e91016cfc0939b42979e950ae4571b0e6576763",
       [
         {
           "shortname": "html",
@@ -23,7 +23,7 @@
       ]
     ],
     [
-      "5530bca3f739b4cec44acfa985117a332bff078e",
+      "929b4f5cad2be24d5025bc092ff848711bc04cca",
       [
         {
           "shortname": "dom",
@@ -39,18 +39,18 @@
     {
       "term": "DOMString",
       "types": ["_IDL_"],
-      "id": "0eca50dead2a4aa568d80cde770d660417a20b78"
+      "id": "318a08442ab399ac176948abb64c7fe6a4c3e8a6"
     },
     {
       "term": "Window",
       "types": ["_IDL_"],
-      "id": "7c6f3cfd1cf92d00249d3a483265a7c58e42ecf1"
+      "id": "4e91016cfc0939b42979e950ae4571b0e6576763"
     },
     {
       "term": "event",
       "types": ["attribute", "dict-member"],
       "for": "Window",
-      "id": "5530bca3f739b4cec44acfa985117a332bff078e"
+      "id": "929b4f5cad2be24d5025bc092ff848711bc04cca"
     }
   ]
 }

--- a/tests/data/xref/inline-locals.json
+++ b/tests/data/xref/inline-locals.json
@@ -1,7 +1,7 @@
 {
   "result": [
     [
-      "318a08442ab399ac176948abb64c7fe6a4c3e8a6",
+      "0eca50dead2a4aa568d80cde770d660417a20b78",
       [
         {
           "shortname": "webidl",
@@ -36,6 +36,11 @@
     ]
   ],
   "query": [
+    {
+      "term": "DOMString",
+      "types": ["_IDL_"],
+      "id": "0eca50dead2a4aa568d80cde770d660417a20b78"
+    },
     {
       "term": "Window",
       "types": ["_IDL_"],

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -1080,7 +1080,8 @@ callback CallBack = Z? (X x, optional Y y, /*trivia*/ optional Z z);
   it("auto-links based on definition context", async () => {
     const body = `
       <section>
-        <pre class="idl" id="link-test">
+        <h2>Test</h2>
+        <pre class="idl" id="link-test" data-cite="HTML DOM">
           interface Foo {
             DOMString fromWebIDL(); // defined in WebIDL
             attribute EventTarget fromDomSpec; // Defined in DOM

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -1077,6 +1077,40 @@ callback CallBack = Z? (X x, optional Y y, /*trivia*/ optional Z z);
     const enumValueType = doc.getElementById("dom-enumtype-enumvaluetype");
     expect(enumValueType.dataset.idl).toBe("enum-value");
   });
+  it("auto-links based on definition context", async () => {
+    const body = `
+      <section>
+        <pre class="idl" id="link-test">
+          interface Foo {
+            DOMString fromWebIDL(); // defined in WebIDL
+            attribute EventTarget fromDomSpec; // Defined in DOM
+            attribute EventHandler fromHTMLSpec; // Defined in HTML
+          };
+        </pre>
+      </section>
+    `;
+    const ops = makeStandardOps({ xref: "web-platform" }, body);
+    const doc = await makeRSDoc(ops);
+
+    // DOMString fromWebIDL();
+    const domString = doc.querySelector(
+      "#link-test a[href='https://heycam.github.io/webidl/#idl-DOMString']"
+    );
+    expect(domString).toBeTruthy();
+
+    // attribute EventTarget fromDomSpec; // Defined in DOM
+    const eventTarget = doc.querySelector(
+      "#link-test a[href='https://dom.spec.whatwg.org/#eventtarget']"
+    );
+    expect(eventTarget).toBeTruthy();
+
+    // attribute EventHandler fromHTMLSpec; // Defined in HTML
+    const eventHandler = doc.querySelector(
+      "#link-test a[href='https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler']"
+    );
+    expect(eventHandler).toBeTruthy();
+  });
+
   it("auto-links some IDL types", async () => {
     const body = `
       <section>

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -1,15 +1,29 @@
 "use strict";
 
 import { flushIframes, makeRSDoc, makeStandardOps } from "../SpecHelper.js";
+import { IDBKeyVal } from "../../../src/core/utils.js";
+import { openDB } from "../../../node_modules/idb/build/esm/index.js";
 
 describe("Core - WebIDL", () => {
   afterAll(flushIframes);
   /** @type {Document} */
   let doc;
+  let cache;
   beforeAll(async () => {
     const ops = makeStandardOps();
     ops.config.xref = true;
     doc = await makeRSDoc(ops, "spec/core/webidl.html");
+    const idb = await openDB("xref", 1, {
+      upgrade(db) {
+        db.createObjectStore("xrefs");
+      },
+    });
+    cache = new IDBKeyVal(idb, "xrefs");
+  });
+
+  beforeEach(async () => {
+    // clear idb cache before each
+    await cache.clear();
   });
 
   describe("records", () => {
@@ -1090,7 +1104,7 @@ callback CallBack = Z? (X x, optional Y y, /*trivia*/ optional Z z);
         </pre>
       </section>
     `;
-    const ops = makeStandardOps({ xref: "web-platform" }, body);
+    const ops = makeStandardOps({ xref: true }, body);
     const doc = await makeRSDoc(ops);
 
     // DOMString fromWebIDL();

--- a/tests/spec/core/xref-spec.js
+++ b/tests/spec/core/xref-spec.js
@@ -801,7 +801,7 @@ describe("Core — xref", () => {
         <section id="test">
           <h2>Ignore</h2>
           <p>Some other <dfn>languageCode</dfn> definitions.</p>
-          <p id="link-internal">{{ PaymentAddress.languageCode }} links to PaymentAddress definitionss.</p>
+          <p id="link-internal">{{ PaymentAddress.languageCode }} links to PaymentAddress definitions.</p>
           <p id="link-internal-dfn">{{ languageCode }} links to some other definitions.</p>
           <p id="link-external">{{ Window.event }} links to html spec.</p>
         </section>

--- a/tests/spec/core/xref-spec.js
+++ b/tests/spec/core/xref-spec.js
@@ -800,9 +800,9 @@ describe("Core — xref", () => {
         </section>
         <section id="test">
           <h2>Ignore</h2>
-          <p>Some other <dfn>languageCode</dfn> definiton.</p>
-          <p id="link-internal">{{ PaymentAddress.languageCode }} links to PaymentAddress definitons.</p>
-          <p id="link-internal-dfn">{{ languageCode }} links to some other definiton.</p>
+          <p>Some other <dfn>languageCode</dfn> definitions.</p>
+          <p id="link-internal">{{ PaymentAddress.languageCode }} links to PaymentAddress definitionss.</p>
+          <p id="link-internal-dfn">{{ languageCode }} links to some other definitions.</p>
           <p id="link-external">{{ Window.event }} links to html spec.</p>
         </section>
       `;


### PR DESCRIPTION
I'd made a mistake in the WebIDL code, where I was putting `data-cite` on the container pre. This was causing linking to fail.  