### PR TITLE
refactor: replace uses of `array.reduce()`

### DIFF
--- a/src/core/biblio-db.js
+++ b/src/core/biblio-db.js
@@ -8,6 +8,7 @@
  *
  */
 /* globals IDBKeyRange, DOMException */
+import { flatten } from "./utils.js";
 import { pub } from "./pubsubhub.js";
 export const name = "core/biblio-db";
 
@@ -219,21 +220,20 @@ export const biblioDB = {
         return true;
       })
       .map(id => Object.assign({ id }, data[id]))
-      .reduce((collector, obj) => {
+      .forEach(obj => {
         if (obj.aliasOf) {
-          collector.alias.add(obj);
+          aliasesAndRefs.alias.add(obj);
         } else {
-          collector.reference.add(obj);
+          aliasesAndRefs.reference.add(obj);
         }
-        return collector;
-      }, aliasesAndRefs);
+      });
     const promisesToAdd = Object.keys(aliasesAndRefs)
       .map(type => {
         return Array.from(aliasesAndRefs[type]).map(details =>
           this.add(type, details)
         );
       })
-      .reduce((collector, promises) => collector.concat(promises), []);
+      .reduce(flatten, []);
     await Promise.all(promisesToAdd);
   },
   /**

--- a/src/core/biblio.js
+++ b/src/core/biblio.js
@@ -138,14 +138,12 @@ export async function run(conf) {
     console.warn(err);
   }
   const split = { hasData: [], noData: [] };
-  idbRefs.reduce((collector, ref) => {
-    ref.data ? collector.hasData.push(ref) : collector.noData.push(ref);
-    return collector;
-  }, split);
-  split.hasData.reduce((collector, ref) => {
-    collector[ref.id] = ref.data;
-    return collector;
-  }, biblio);
+  idbRefs.forEach(ref => {
+    (ref.data ? split.hasData : split.noData).push(ref);
+  });
+  split.hasData.forEach(ref => {
+    biblio[ref.id] = ref.data;
+  });
   const externalRefs = split.noData.map(item => item.id);
   if (externalRefs.length) {
     // Going to the network for refs we don't have

--- a/src/core/linter-rules/no-http-props.js
+++ b/src/core/linter-rules/no-http-props.js
@@ -35,8 +35,7 @@ function lintingFunction(conf, doc) {
     // this check is expensive, so separate step
     .filter(key =>
       new URL(conf[key], doc.location.href).href.startsWith("http://")
-    )
-    .reduce((collector, key) => collector.concat(key), []);
+    );
   if (!offendingMembers.length) {
     return;
   }

--- a/src/core/linter.js
+++ b/src/core/linter.js
@@ -24,7 +24,7 @@ class Linter {
    * @param  {...import("./LinterRule").default} newRules
    */
   register(...newRules) {
-    newRules.reduce((rules, newRule) => rules.add(newRule), this.rules);
+    newRules.forEach(newRule => this.rules.add(newRule));
   }
   async lint(conf, doc = window.document) {
     const promisesToLint = [...privates.get(this).rules].map(rule =>

--- a/src/core/ui.js
+++ b/src/core/ui.js
@@ -28,10 +28,9 @@ function ariaDecorate(elem, ariaMap) {
   if (!elem) {
     return;
   }
-  Array.from(ariaMap).reduce((elem, [name, value]) => {
+  Array.from(ariaMap).forEach(([name, value]) => {
     elem.setAttribute(`aria-${name}`, value);
-    return elem;
-  }, elem);
+  });
 }
 
 const respecUI = hyperHTML`<div id='respec-ui' class='removeOnSave' hidden></div>`;

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -476,7 +476,7 @@ export async function fetchAndCache(input, maxAge = 86400000) {
 export function flatten(collector, item) {
   const items = !Array.isArray(item)
     ? [item]
-    : [...item.values()].reduce(flatten, []);
+    : item.slice().reduce(flatten, []);
   collector.push(...items);
   return collector;
 }

--- a/src/core/webidl-index.js
+++ b/src/core/webidl-index.js
@@ -54,13 +54,12 @@ export function run() {
       }
       return fragment;
     })
-    .reduce((collector, elem) => {
-      if (collector.lastChild) {
-        collector.appendChild(document.createTextNode("\n\n"));
+    .forEach(elem => {
+      if (pre.lastChild) {
+        pre.append("\n\n");
       }
-      collector.appendChild(elem);
-      return collector;
-    }, pre);
+      pre.appendChild(elem);
+    });
   // Remove duplicate IDs
   pre.querySelectorAll("*[id]").forEach(elem => elem.removeAttribute("id"));
   idlIndexSec.appendChild(pre);

--- a/src/geonovum/l10n.js
+++ b/src/geonovum/l10n.js
@@ -14,7 +14,6 @@ const additions = {
   },
 };
 
-Object.keys(additions).reduce((l10n, key) => {
+Object.keys(additions).forEach(key => {
   Object.assign(l10n[key], additions[key]);
-  return l10n;
-}, l10n);
+});

--- a/src/ui/about-respec.js
+++ b/src/ui/about-respec.js
@@ -35,10 +35,9 @@ function show() {
         return { name, duration: humanDuration };
       })
       .map(perfEntryToTR)
-      .reduce((collector, entry) => {
-        collector.push(entry);
-        return collector;
-      }, entries);
+      .forEach(entry => {
+        entries.push(entry);
+      });
   }
   render`
   <p>

--- a/src/ui/search-specref.js
+++ b/src/ui/search-specref.js
@@ -1,6 +1,7 @@
 // Module ui/search-specref
 // Search Specref database
 import { l10n, lang } from "../core/l10n.js";
+import { flatten } from "../core/utils.js";
 import hyperHTML from "hyperhtml";
 import { ui } from "../core/ui.js";
 import { wireReference } from "../core/biblio.js";
@@ -72,7 +73,7 @@ function resultProcessor({ includeVersions } = { includeVersions: false }) {
     if (!includeVersions) {
       Array.from(results.values())
         .filter(entry => typeof entry === "object" && "versions" in entry)
-        .reduce((collector, entry) => collector.concat(entry.versions), [])
+        .reduce(flatten, [])
         .forEach(version => {
           results.delete(version);
         });

--- a/src/w3c/l10n.js
+++ b/src/w3c/l10n.js
@@ -30,7 +30,6 @@ const additions = {
   },
 };
 
-Object.keys(additions).reduce((l10n, key) => {
+Object.keys(additions).forEach(key => {
   Object.assign(l10n[key], additions[key]);
-  return l10n;
-}, l10n);
+});


### PR DESCRIPTION
Sometimes `.reduce()` is used only to prevent closure, causing lower readability and longer code.