### PR TITLE
 fix(core/webidl): autolink IDL partial definitions

### DIFF
--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -160,16 +160,15 @@ function findLinkTarget(target, ant, titleToDfns, possibleExternalLinks) {
   } else {
     if (ant.dataset.idl === "partial") {
       possibleExternalLinks.push(ant);
-      return true;
+    } else {
+      ant.href = `#${dfn.id}`;
+      ant.classList.add("internalDFN");
     }
-    ant.href = `#${dfn.id}`;
-    ant.classList.add("internalDFN");
   }
   // add a bikeshed style indication of the type of link
   if (!ant.hasAttribute("data-link-type")) {
     ant.dataset.linkType = "dfn";
   }
-
   if (isCode(dfn)) {
     wrapAsCode(ant, dfn);
   }

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -158,6 +158,10 @@ function findLinkTarget(target, ant, titleToDfns, possibleExternalLinks) {
     ant.dataset.lt = lt[0] || dfn.textContent;
     possibleExternalLinks.push(ant);
   } else {
+    if (ant.dataset.idl === "partial") {
+      possibleExternalLinks.push(ant);
+      return true;
+    }
     ant.href = `#${dfn.id}`;
     ant.classList.add("internalDFN");
   }

--- a/src/core/render-biblio.js
+++ b/src/core/render-biblio.js
@@ -271,6 +271,7 @@ function decorateInlineReference(refs, aliases) {
       elems.forEach(a => {
         a.setAttribute("href", refUrl);
         a.setAttribute("title", refcontent.title);
+        a.dataset.linkType = "biblio";
       });
     });
 }

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -148,7 +148,7 @@ function createIdlAnchor(escaped, data, parent) {
     return unlinkedAnchor;
   }
 
-  const showWarnings = name && data.type !== "typedef";
+   const showWarnings = name && data.type !== "typedef" && !(data.partial && !dfn);
   if (showWarnings) {
     const styledName = data.type === "operation" ? `${name}()` : name;
     const ofParent = parentName ? ` \`${parentName}\`'s` : "";

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -120,6 +120,7 @@ function createIdlAnchor(escaped, data, parent) {
       dfn.dataset.dfnType = getDfnType(data.type);
     }
     return hyperHTML`<a
+      data-link-type="idl"
       data-link-for="${parentName.toLowerCase()}"
       data-lt="${dfn.dataset.lt || null}">${escaped}</a>`;
   }
@@ -131,10 +132,17 @@ function createIdlAnchor(escaped, data, parent) {
   if (isDefaultJSON) {
     return hyperHTML`<a data-lt="default toJSON operation">${escaped}</a>`;
   }
+  const unlinkedAnchor = hyperHTML`<a
+    data-link-type="idl"
+    data-idl="${data.partial ? "partial" : null}"
+    data-title="${escaped}"
+    data-xref-type="${getDfnType(data.type)}">${escaped}</a>`;
 
-  const unlinkedAnchor = hyperHTML`<a data-xref-type="${
-    data.type
-  }">${escaped}</a>`;
+  // Partial interfaces must always link somewhere else.
+  if (data.partial && !dfn) {
+    return unlinkedAnchor;
+  }
+
   const showWarnings = name && data.type !== "typedef";
   if (showWarnings) {
     const styledName = data.type === "operation" ? `${name}()` : name;
@@ -157,6 +165,8 @@ function getDfnType(idlType) {
       return "method";
     case "field":
       return "dict-member";
+    case "interface mixin":
+      return "interface";
     default:
       return idlType;
   }

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -135,7 +135,7 @@ function createIdlAnchor(escaped, data, parent) {
   const unlinkedAnchor = hyperHTML`<a
     data-link-type="idl"
     data-idl="${data.partial ? "partial" : null}"
-    data-title="${escaped}"
+    data-title="${data.name}"
     data-xref-type="${getDfnType(data.type)}">${escaped}</a>`;
 
   // Partial interfaces must always link somewhere else.
@@ -165,6 +165,7 @@ function getDfnType(idlType) {
       return "method";
     case "field":
       return "dict-member";
+    case "callback interface":
     case "interface mixin":
       return "interface";
     default:

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -148,7 +148,8 @@ function createIdlAnchor(escaped, data, parent) {
     return unlinkedAnchor;
   }
 
-   const showWarnings = name && data.type !== "typedef" && !(data.partial && !dfn);
+  const showWarnings =
+    name && data.type !== "typedef" && !(data.partial && !dfn);
   if (showWarnings) {
     const styledName = data.type === "operation" ? `${name}()` : name;
     const ofParent = parentName ? ` \`${parentName}\`'s` : "";

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -143,11 +143,6 @@ function createIdlAnchor(escaped, data, parent) {
     data-xref-type="${linkType}"
     >${escaped}</a>`;
 
-  // Partial interfaces must always link somewhere else.
-  if (data.partial && !dfn) {
-    return unlinkedAnchor;
-  }
-
   const showWarnings =
     name && data.type !== "typedef" && !(data.partial && !dfn);
   if (showWarnings) {

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -114,15 +114,17 @@ function createIdlAnchor(escaped, data, parent) {
   const dfn = findDfn(data, name, {
     parent: parentName,
   });
+  const linkType = getDfnType(data.type);
   if (dfn) {
     if (!data.partial) {
       dfn.dataset.export = "";
-      dfn.dataset.dfnType = getDfnType(data.type);
+      dfn.dataset.dfnType = linkType;
     }
     return hyperHTML`<a
-      data-link-type="idl"
       data-link-for="${parentName.toLowerCase()}"
-      data-lt="${dfn.dataset.lt || null}">${escaped}</a>`;
+      data-link-type="${linkType}"
+      data-lt="${dfn.dataset.lt || null}"
+      >${escaped}</a>`;
   }
 
   const isDefaultJSON =
@@ -130,13 +132,16 @@ function createIdlAnchor(escaped, data, parent) {
     data.name === "toJSON" &&
     data.extAttrs.some(({ name }) => name === "Default");
   if (isDefaultJSON) {
-    return hyperHTML`<a data-lt="default toJSON operation">${escaped}</a>`;
+    return hyperHTML`<a
+     data-link-type="dfn"
+     data-lt="default toJSON operation">${escaped}</a>`;
   }
   const unlinkedAnchor = hyperHTML`<a
-    data-link-type="idl"
     data-idl="${data.partial ? "partial" : null}"
+    data-link-type="${linkType}"
     data-title="${data.name}"
-    data-xref-type="${getDfnType(data.type)}">${escaped}</a>`;
+    data-xref-type="${linkType}"
+    >${escaped}</a>`;
 
   // Partial interfaces must always link somewhere else.
   if (data.partial && !dfn) {

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -1249,7 +1249,7 @@ callback CallBack = Z? (X x, optional Y y, /*trivia*/ optional Z z);
       docOrShadowMixin,
       requestPartialInterface,
       eventInitDict,
-      ,
+      , // skip testing boolean link, tested elsewhere.
       itWorksMember,
     ] = doc.querySelectorAll(".idl a");
 

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -1248,8 +1248,8 @@ callback CallBack = Z? (X x, optional Y y, /*trivia*/ optional Z z);
       bananaPartial,
       docOrShadowMixin,
       requestPartialInterface,
-      eventInitDict,
-      , // skip testing boolean link, tested elsewhere.
+      eventInitDict, // skip testing boolean link (next line), tested elsewhere.
+      ,
       itWorksMember,
     ] = doc.querySelectorAll(".idl a");
 

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -1218,4 +1218,79 @@ callback CallBack = Z? (X x, optional Y y, /*trivia*/ optional Z z);
     const banana = p.querySelector("dfn");
     expect(banana.dataset.export).not.toBeDefined();
   });
+  it("autolinks partial definitions", async () => {
+    const body = `
+      <section data-dfn-for="EventInit">
+        <p>
+          <dfn>Banana</dfn>
+          <dfn>itWorks</dfn>
+        </p>
+        <pre class="idl">
+          // Local ref
+          interface Banana {};
+          // Local ref
+          partial interface Banana {};
+          // DOM spec
+          partial interface mixin DocumentOrShadowRoot {};
+          // Fetch spec
+          partial interface Request {};
+          // DOM spec
+          partial dictionary EventInit {
+            boolean itWorks;
+          };
+        </pre>
+      </section>
+    `;
+    const ops = makeStandardOps({ xref: "web-platform" }, body);
+    const doc = await makeRSDoc(ops);
+    const [
+      banana,
+      bananaPartial,
+      docOrShadowMixin,
+      requestPartialInterface,
+      eventInitDict,
+      ,
+      itWorksMember,
+    ] = doc.querySelectorAll(".idl a");
+
+    expect(banana.textContent).toBe("Banana");
+    expect(banana.getAttribute("href")).toBe("#dom-banana");
+    expect(banana.dataset.linkType).toBe("interface");
+    expect(banana.classList).toContain("internalDFN");
+
+    expect(bananaPartial.textContent).toBe("Banana");
+    expect(bananaPartial.getAttribute("href")).toBe("#dom-banana");
+    expect(bananaPartial.dataset.linkType).toBe("interface");
+    expect(banana.classList).toContain("internalDFN");
+
+    expect(docOrShadowMixin.textContent).toBe("DocumentOrShadowRoot");
+    expect(docOrShadowMixin.dataset.xrefType).toBe("interface");
+    expect(docOrShadowMixin.dataset.linkType).toBe("interface");
+    expect(docOrShadowMixin.dataset.idl).toBe("partial");
+    expect(docOrShadowMixin.dataset.title).toBe("DocumentOrShadowRoot");
+    expect(docOrShadowMixin.href).toBe(
+      "https://dom.spec.whatwg.org/#documentorshadowroot"
+    );
+
+    expect(requestPartialInterface.textContent).toBe("Request");
+    expect(requestPartialInterface.dataset.xrefType).toBe("interface");
+    expect(requestPartialInterface.dataset.linkType).toBe("interface");
+    expect(requestPartialInterface.dataset.idl).toBe("partial");
+    expect(requestPartialInterface.dataset.title).toBe("Request");
+    expect(requestPartialInterface.href).toBe(
+      "https://fetch.spec.whatwg.org/#request"
+    );
+
+    expect(eventInitDict.textContent).toBe("EventInit");
+    expect(eventInitDict.dataset.xrefType).toBe("dictionary");
+    expect(eventInitDict.dataset.linkType).toBe("dictionary");
+    expect(eventInitDict.dataset.idl).toBe("partial");
+    expect(eventInitDict.dataset.title).toBe("EventInit");
+    expect(eventInitDict.href).toBe(
+      "https://dom.spec.whatwg.org/#dictdef-eventinit"
+    );
+
+    expect(itWorksMember.classList).toContain("internalDFN");
+    expect(itWorksMember.getAttribute("href")).toBe("#dom-eventinit-itworks");
+  });
 });


### PR DESCRIPTION
xrefs things like:

```
partial interface Element {};
partial mixin Whatever {};
partial dictionary SomeDictionary {};
```

To the right specs. 