### PR TITLE
refactor(core/webidl-clipboard): remove wrapper div

### DIFF
--- a/assets/ui.css
+++ b/assets/ui.css
@@ -288,29 +288,18 @@
 
 .respec-button-copy-paste {
   position: absolute;
-  display: block;
-  padding: 0px 8px;
   height: 28px;
   width: 40px;
-  color: #333;
-  white-space: nowrap;
-  vertical-align: middle;
   cursor: pointer;
-  background-color: #eee;
   background-image: linear-gradient(#fcfcfc, #eee);
   border: 1px solid rgb(144, 184, 222);
+  border-left: 0;
   border-radius: 0px 0px 3px 0;
   -webkit-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
   user-select: none;
   -webkit-appearance: none;
-  margin: 0px 127px;
-  border-left: 0;
-}
-
-p + .respec-button-copy-paste {
-  margin: 1px 127px;
+  top: 0;
+  left: 127px;
 }
 
 #specref-ui {

--- a/assets/webidl.css
+++ b/assets/webidl.css
@@ -2,6 +2,7 @@
 
 pre.idl {
   padding: 1em;
+  position: relative;
 }
 
 @media print {

--- a/src/core/webidl-clipboard.js
+++ b/src/core/webidl-clipboard.js
@@ -18,12 +18,10 @@ copyButton.classList.add("respec-button-copy-paste", "removeOnSave");
 export async function run() {
   for (const pre of document.querySelectorAll("pre.idl")) {
     const button = copyButton.cloneNode(true);
-    const wrapper = document.createElement("div");
     button.addEventListener("click", () => {
       clipboardWriteText(pre.textContent);
     });
-    pre.replaceWith(wrapper);
-    wrapper.append(button, pre);
+    pre.prepend(button);
   }
 }
 


### PR DESCRIPTION
This simplifies the tree for crawlers e.g. TSJS-lib-generator.

Also removing redundant CSS properties.