### PR TITLE
fix(core/data-cite): prevent re-export of exisiting dfns

### DIFF
--- a/src/core/data-cite.js
+++ b/src/core/data-cite.js
@@ -15,8 +15,12 @@
  * https://github.com/w3c/respec/wiki/data--cite
  */
 import { biblio, resolveRef, updateFromNetwork } from "./biblio.js";
-import { refTypeFromContext, showInlineWarning, wrapInner } from "./utils.js";
-import hyperHTML from "hyperhtml";
+import {
+  refTypeFromContext,
+  showInlineError,
+  showInlineWarning,
+  wrapInner,
+} from "./utils.js";
 export const name = "core/data-cite";
 
 function requestLookup(conf) {
@@ -66,7 +70,8 @@ function requestLookup(conf) {
         break;
       }
       case "dfn": {
-        const anchor = hyperHTML`<a href="${href}">`;
+        const anchor = document.createElement("a");
+        anchor.href = href;
         if (!elem.textContent) {
           anchor.textContent = title;
           elem.append(anchor);
@@ -78,6 +83,15 @@ function requestLookup(conf) {
           cite.append(anchor);
           elem.append(cite);
         }
+        if ("export" in elem.dataset) {
+          showInlineError(
+            elem,
+            "Exporting an linked external definition is not allowed. Please remove the `data-export` attribute",
+            "Please remove the `data-export` attribute."
+          );
+          delete elem.dataset.export;
+        }
+        elem.dataset.noExport = "";
         break;
       }
     }

--- a/tests/spec/core/data-cite-spec.js
+++ b/tests/spec/core/data-cite-spec.js
@@ -380,6 +380,6 @@ describe("Core — data-cite attribute", () => {
     const dfn2 = doc.querySelector("#t2");
     expect(dfn2.classList).toContain("respec-offending-element");
     expect("export" in dfn2.dataset).toBe(false);
-    expect("no-export" in dfn2.dataset).toBe(true);
+    expect("noExport" in dfn2.dataset).toBe(true);
   });
 });

--- a/tests/spec/core/data-cite-spec.js
+++ b/tests/spec/core/data-cite-spec.js
@@ -361,4 +361,25 @@ describe("Core — data-cite attribute", () => {
     const cite = doc.querySelector("#t1 > cite");
     expect(cite).toBeNull();
   });
+  it("prevents re-exporting things defined in other specs", async () => {
+    const body = `
+      <section>
+        <p>
+          <dfn id="t1" data-cite="html#foo">no export</dfn>
+          <dfn id="t2" data-cite="html#bar" data-export>attempt to export</dfn>
+        </p>
+      </section>
+    `;
+    const ops = makeStandardOps(null, body);
+    const doc = await makeRSDoc(ops);
+
+    const dfn1 = doc.querySelector("#t1");
+    expect("export" in dfn1.dataset).toBe(false);
+    expect("noExport" in dfn1.dataset).toBe(true);
+
+    const dfn2 = doc.querySelector("#t2");
+    expect(dfn2.classList).toContain("respec-offending-element");
+    expect("export" in dfn2.dataset).toBe(false);
+    expect("no-export" in dfn2.dataset).toBe(true);
+  });
 });


### PR DESCRIPTION
Prevents specs stomping on each other's definitions by accident.   