### PR TITLE
fix(tools/respecDocWriter): filter browser warnings

### DIFF
--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -230,13 +230,13 @@ function makeConsoleMsgHandler(page) {
       const text = args.filter(msg => msg !== "undefined").join(" ");
       const type = message.type();
       if (
-        type === "error" &&
+        (type === "error" || type === "warning") &&
         msgText && // browser errors have text
-        !message.args().length // browser errors have no arguments
+        !message.args().length // browser errors/warnings have no arguments
       ) {
         // Since Puppeteer 1.4 reports _all_ errors, including CORS
-        // violations. Unfortunately, there is no way to distinguish these errors
-        // from other errors, so using this ugly hack.
+        // violations and slow preloads. Unfortunately, there is no way to distinguish
+        // these errors from other errors, so using this ugly hack.
         // https://github.com/GoogleChrome/puppeteer/issues/1939
         return;
       }


### PR DESCRIPTION
Prevents empty warning from browser warnings... same structure as errors: 

![Screen Shot 2019-06-27 at 10 58 37 am](https://user-images.githubusercontent.com/870154/60225506-885b2080-98ca-11e9-9aaf-4bf8650281ef.png)
