### PR TITLE
chore(pr): deploy PR builds to now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ now_deploy: &now_deploy
   - npm run build:geonovum
   - chmod +x ./tools/create-pr-meta.sh && ./tools/create-pr-meta.sh
   - npx now ./builds/ -A ../now.json --meta branch=$TRAVIS_BRANCH --token $NOW_TOKEN
-  - npx now alias respec-$TRAVIS_BRANCH --token $NOW_TOKEN
+  - npx now alias respec-$TRAVIS_BRANCH -A ../now.json --token $NOW_TOKEN
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,21 @@ karma_runner: &karma_runner
   - npm run build:geonovum
   - travis_retry karma start --single-run --reporters mocha karma.conf.js
 
+now_deploy: &now_deploy
+  - npm run build:w3c
+  - npm run build:geonovum
+  - chmod +x ./tools/create-pr-meta.sh && ./tools/create-pr-meta.sh
+  - npx now ./builds/ -A ../now.json --meta branch=$TRAVIS_BRANCH --token $NOW_TOKEN
+  - npx now alias respec-$TRAVIS_BRANCH --token $NOW_TOKEN
+
 jobs:
   include:
     - stage: Run eslint
       script:
         - npm run lint
+    - stage: Deploy PR build
+      if: NOT branch IN (master, develop)
+      script: *now_deploy
     - stage: Run headless
       script:
         - npm run build:w3c

--- a/now.json
+++ b/now.json
@@ -1,0 +1,6 @@
+{
+  "name": "respec",
+  "version": 2,
+  "public": true,
+  "builds": [{ "src": "*", "use": "@now/static" }]
+}

--- a/now.json
+++ b/now.json
@@ -1,6 +1,7 @@
 {
-  "name": "respec",
   "version": 2,
+  "name": "respec",
+  "scope": "respec",
   "public": true,
   "builds": [{ "src": "*", "use": "@now/static" }]
 }

--- a/tools/create-pr-meta.sh
+++ b/tools/create-pr-meta.sh
@@ -1,0 +1,19 @@
+# array of environment variables to write
+vars=(
+  TRAVIS_BRANCH
+  TRAVIS_BUILD_WEB_URL
+  TRAVIS_EVENT_TYPE
+  TRAVIS_JOB_WEB_URL
+  TRAVIS_PULL_REQUEST_SLUG
+  TRAVIS_PULL_REQUEST
+  TRAVIS_COMMIT
+  TRAVIS_COMMIT_MESSAGE
+)
+# body will contain newline separated strings like: "var": "var_value_from_env",
+body=$(
+  printf "%s\n" "${vars[@]}" | \
+  xargs -i sh -c 'echo "  \"{}\": \"${}\"",'
+)
+# create json output (prepend `{`, remove trailing comma and append `}`)
+# and write to file
+printf "{\n%s\n}" "${body%?}" > ./builds/meta.json


### PR DESCRIPTION
🎉 We now have PR builds with ZEIT now 🎉 

The latest branch build will be available at: `respec-[BRANCH].now.sh` 
<details>
<summary>e.g. https://respec-now-pr-builds.now.sh/</summary>
<img src="https://user-images.githubusercontent.com/8426945/61296852-9c72ad80-a7f8-11e9-8794-5891c157050b.png"/>
</details>

In each deployment, there is a `meta.json` file, which gives info about the build. 
<details>
<summary>e.g. https://respec-now-pr-builds.now.sh/meta.json</summary>
<img src="https://user-images.githubusercontent.com/8426945/61296753-66352e00-a7f8-11e9-8315-eb43eaa29bd8.png"/>
</details>

Commit specific builds and build logs can be seen via Travis logs, in the "Deploy pr build" job for "branch" (not PR)

---

Deleting old deployments: I think I'll run a job from my end to delete the deployments which are not aliased to a branch (old commit specific builds) and for the branches that have been merged (like once a month or so).

https://respec.respec.now.sh/ contains the latest build (regardless of the branch - it gets overridden on each deployment), so it's mostly useless.