### PR TITLE
chore(release): deploy PR builds to now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,21 @@ karma_runner: &karma_runner
   - npm run build:geonovum
   - travis_retry karma start --single-run --reporters mocha karma.conf.js
 
+now_deploy: &now_deploy
+  - npm run build:w3c
+  - npm run build:geonovum
+  - chmod +x ./tools/create-pr-meta.sh && ./tools/create-pr-meta.sh
+  - npx now ./builds/ -A ../now.json --meta branch=$TRAVIS_BRANCH --token $NOW_TOKEN
+  - npx now alias respec-$TRAVIS_BRANCH -A ../now.json --token $NOW_TOKEN
+
 jobs:
   include:
     - stage: Run eslint
       script:
         - npm run lint
+    - stage: Deploy PR build
+      if: NOT branch IN (gh-pages, develop)
+      script: *now_deploy
     - stage: Run headless
       script:
         - npm run build:w3c

--- a/now.json
+++ b/now.json
@@ -1,0 +1,7 @@
+{
+  "version": 2,
+  "name": "respec",
+  "scope": "respec",
+  "public": true,
+  "builds": [{ "src": "*", "use": "@now/static" }]
+}

--- a/tools/create-pr-meta.sh
+++ b/tools/create-pr-meta.sh
@@ -1,0 +1,19 @@
+# array of environment variables to write
+vars=(
+  TRAVIS_BRANCH
+  TRAVIS_BUILD_WEB_URL
+  TRAVIS_EVENT_TYPE
+  TRAVIS_JOB_WEB_URL
+  TRAVIS_PULL_REQUEST_SLUG
+  TRAVIS_PULL_REQUEST
+  TRAVIS_COMMIT
+  TRAVIS_COMMIT_MESSAGE
+)
+# body will contain newline separated strings like: "var": "var_value_from_env",
+body=$(
+  printf "%s\n" "${vars[@]}" | \
+  xargs -i sh -c 'echo "  \"{}\": \"${}\"",'
+)
+# create json output (prepend `{`, remove trailing comma and append `}`)
+# and write to file
+printf "{\n%s\n}" "${body%?}" > ./builds/meta.json


### PR DESCRIPTION
🎉 We now have PR builds with ZEIT now 🎉 

The latest branch build will be available at: `respec-[BRANCH].now.sh` 
<details>
<summary>e.g. https://respec-deploy-pr-builds.now.sh/</summary>
<a href="https://respec-deploy-pr-builds.now.sh/"><img src="https://user-images.githubusercontent.com/8426945/61300988-aa2c3100-a800-11e9-9896-d4bcda826f54.png"></a>
</details>

In each deployment, there is a `meta.json` file, which gives info about the build. 
<details>
<summary>e.g. https://respec-deploy-pr-builds.now.sh/meta.json</summary>
<a href="https://respec-deploy-pr-builds.now.sh/meta.json"><img src="https://user-images.githubusercontent.com/8426945/61301029-c0d28800-a800-11e9-833d-86724333df2d.png"></a>
</details>

Commit specific deployments and deployment logs can be seen via Travis logs, in the "Deploy pr build" job for "branch" (not PR)

---

**How it will be useful?**
I created a tool https://github.com/sidvishnoi/respec-preview which lets you view ReSpec documents using a specific ReSpec version.

---

Deleting old deployments: I think I'll run a job from my end to delete the deployments which are not aliased to a branch (old commit specific builds) and for the branches that have been merged (like once a month or so).

https://respec.respec.now.sh/ contains the latest build (regardless of the branch - it gets overridden on each deployment), so it's mostly useless.