### PR TITLE
fix(assets/respec2): base.css removed underline from error links

### DIFF
--- a/assets/respec2.css
+++ b/assets/respec2.css
@@ -56,8 +56,9 @@ a.bibref {
   animation: pop 0.25s ease-in-out 0s 1;
 }
 
-.respec-offending-element {
-  text-decoration: red wavy underline !important;
+.respec-offending-element,
+a[href].respec-offending-element {
+  text-decoration: red wavy underline;
 }
 @supports not (text-decoration: red wavy underline) {
   .respec-offending-element:not(pre) {

--- a/assets/respec2.css
+++ b/assets/respec2.css
@@ -57,7 +57,7 @@ a.bibref {
 }
 
 .respec-offending-element {
-  text-decoration: red wavy underline;
+  text-decoration: red wavy underline !important;
 }
 @supports not (text-decoration: red wavy underline) {
   .respec-offending-element:not(pre) {


### PR DESCRIPTION
[base.css](https://www.w3.org/StyleSheets/TR/2016/base.css) was overriding broken links (`a.respec-offending-element`) and remove the squiggly underline. 
Not sure if adding `!important` is good idea or not.

![image](https://user-images.githubusercontent.com/8426945/61575484-fcfc3600-aae9-11e9-9cf0-c23389b3d2d6.png)
^^ squiggly underline not shown

<img src="https://user-images.githubusercontent.com/8426945/61575481-f1a90a80-aae9-11e9-9959-f8c6f3e809d4.png" width="350">
