### PR TITLE
fix(core/figures): generate tof even when no figcaption

### DIFF
--- a/src/core/figures.js
+++ b/src/core/figures.js
@@ -68,11 +68,10 @@ function collectFigures() {
 
     if (caption) {
       decorateFigure(fig, caption, i);
+      tof.push(getTableOfFiguresListItem(fig.id, caption));
     } else {
       showInlineWarning(fig, "Found a `<figure>` without a `<figcaption>`");
     }
-
-    tof.push(getTableOfFiguresListItem(fig.id, caption));
   });
   return tof;
 }

--- a/tests/spec/core/anchor-expander-spec.js
+++ b/tests/spec/core/anchor-expander-spec.js
@@ -74,8 +74,8 @@ describe("Core - anchor-expander", () => {
     </section>`;
     const ops = makeStandardOps({}, body);
     const doc = await makeRSDoc(ops);
-    expect(document.querySelector("#expansion dfn")).toBeNull();
-    expect(document.querySelector("#expansion *[id]")).toBeNull();
+    expect(doc.querySelector("#expansion dfn")).toBeNull();
+    expect(doc.querySelector("#expansion *[id]")).toBeNull();
 
     const [firstSpan, secondSpan] = doc.querySelectorAll("#expansion a > span");
     expect(firstSpan.title).toBe("pass");

--- a/tests/spec/core/figures-spec.js
+++ b/tests/spec/core/figures-spec.js
@@ -92,6 +92,24 @@ describe("Core - Figures", () => {
     expect(anchorFig.classList).toContain("respec-offending-element");
   });
 
+  it("excludes figures with no <figcaption>", async () => {
+    const ops = {
+      config: makeBasicConfig(),
+      htmlAttrs: {
+        lang: "ja",
+      },
+      body: `${makeDefaultBody()}
+      <figure><img src='img' alt=''></figure>
+      <figure><img src='img' alt=''><figcaption>Geralt of Rivia</figcaption</figure>
+      <section id=tof></section>`,
+    };
+    const doc = await makeRSDoc(ops);
+    const tof = doc.getElementById("tof");
+    const tofItems = tof.querySelectorAll("ul li");
+    expect(tof.querySelector("figcaption")).toBeNull();
+    expect(tofItems.length).toBe(1);
+  });
+
   describe("normalize images", () => {
     const imgDataURL =
       "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAADCAIAAADUVFKvAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4gQKACEWdS72PwAAABl0RVh0Q29tbWVudABDcmVhdGVkIHdpdGggR0lNUFeBDhcAAAAMSURBVAjXY2AgDQAAADAAAceqhY4AAAAASUVORK5CYII=";


### PR DESCRIPTION
Currently the whole module fails when there is no valid figcaption, because `getTableOfFiguresListItem` expects a caption element.