### PR TITLE
fix(w3c/headers): do not emit undefined wg link

### DIFF
--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -537,7 +537,9 @@ export function run(conf) {
     conf.wgPatentHTML = joinAnd(pats);
   } else {
     conf.multipleWGs = false;
-    conf.wgHTML = `the <a href='${conf.wgURI}'>${conf.wg}</a>`;
+    if (conf.wg) {
+      conf.wgHTML = `the <a href='${conf.wgURI}'>${conf.wg}</a>`;
+    }
   }
   if (conf.specStatus === "PR" && !conf.crEnd) {
     pub(

--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -18,14 +18,7 @@ export default (conf, opts) => {
                 ${!conf.sotdAfterWGinfo ? opts.additionalContent : ""}
                 ${!conf.overrideStatus
                   ? html`
-                      <p>
-                        This document was published by ${[conf.wgHTML]} as
-                        ${conf.anOrA} ${conf.longStatus}.
-                        ${conf.notYetRec
-                          ? "This document is intended to become a W3C Recommendation."
-                          : ""}
-                      </p>
-                      ${linkToCommunity(conf, opts)}
+                      ${linkToWorkingGroup(conf)} ${linkToCommunity(conf, opts)}
                       ${conf.isCR || conf.isPER || conf.isPR
                         ? html`
                             <p>
@@ -326,6 +319,21 @@ function noteForTeamSubmission(conf, opts) {
     <p>
       Please consult the complete
       <a href="https://www.w3.org/TeamSubmission/">list of Team Submissions</a>.
+    </p>
+  `;
+}
+
+function linkToWorkingGroup(conf) {
+  if (!conf.wg) {
+    return;
+  }
+  return html`
+    <p>
+      This document was published by ${[conf.wgHTML]} as ${conf.anOrA}
+      ${conf.longStatus}.
+      ${conf.notYetRec
+        ? "This document is intended to become a W3C Recommendation."
+        : ""}
     </p>
   `;
 }

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -956,6 +956,13 @@ describe("W3C — Headers", () => {
       expect(contains(sotd, "a", "disclosures").length).toBe(2);
       expect(contains(sotd, "a", "WGLIST").length).toBe(1);
     });
+
+    it("does not emit working group link without conf.wg", async () => {
+      const ops = makeStandardOps();
+      const doc = await makeRSDoc(ops);
+      const sotd = doc.getElementById("sotd");
+      expect(sotd.textContent).not.toContain("This document was published by");
+    });
   });
 
   describe("perEnd", () => {


### PR DESCRIPTION
It should either emit correct link or nothing, not `the <a href='undefined'>undefined</a>`.