### PR TITLE
refactor(core/biblio): remove redundant request

### DIFF
--- a/src/core/biblio.js
+++ b/src/core/biblio.js
@@ -153,6 +153,5 @@ export async function run(conf) {
     Object.assign(biblio, data);
   }
   Object.assign(biblio, conf.localBiblio);
-  await updateFromNetwork(neededRefs);
   finish();
 }


### PR DESCRIPTION
Removing that line shouldn't make any change, as both `split.hasData` and `split.noData` are already processed.

Closes #2461 