### PR TITLE
fix(core/inline-idl-parser): better support IDL primitives

### DIFF
--- a/src/core/inline-idl-parser.js
+++ b/src/core/inline-idl-parser.js
@@ -3,7 +3,7 @@
 
 import hyperHTML from "hyperhtml";
 import { showInlineError } from "./utils";
-const idlPrimitiveRegex = /^[a-z]+(\s+[a-z]+)+$/; // {{unrestricted double}}
+const idlPrimitiveRegex = /^[a-z]+(\s+[a-z]+)+$/; // {{unrestricted double}} {{ double }}
 const exceptionRegex = /\B"([^"]*)"\B/; // {{ "SomeException" }}
 const methodRegex = /(\w+)\((.*)\)$/;
 const slotRegex = /^\[\[(\w+)\]\]$/;

--- a/src/core/inline-idl-parser.js
+++ b/src/core/inline-idl-parser.js
@@ -3,7 +3,7 @@
 
 import hyperHTML from "hyperhtml";
 import { showInlineError } from "./utils";
-const idlPrimitiveRegex = /^[a-z]+(\s+[a-z]+)+$/; // {{unrestricted double}} {{boolean}}
+const idlPrimitiveRegex = /^[a-z]+(\s+[a-z]+)+$/; // {{unrestricted double}}
 const exceptionRegex = /\B"([^"]*)"\B/; // {{ "SomeException" }}
 const methodRegex = /(\w+)\((.*)\)$/;
 const slotRegex = /^\[\[(\w+)\]\]$/;

--- a/tests/spec/core/xref-spec.js
+++ b/tests/spec/core/xref-spec.js
@@ -799,6 +799,37 @@ describe("Core — xref", () => {
       );
     });
 
+    it("links idl primitives that have spaces", async () => {
+      const body = `
+      <section id="test">
+        {{
+          unsigned
+          long
+          long
+        }}
+        {{  unrestricted   float
+        }}
+        {{double}}
+      </section>
+      `;
+      const config = { xref: true, localBiblio };
+      const ops = makeStandardOps(config, body);
+      const doc = await makeRSDoc(ops);
+
+      const [uLongLong, unrestrictedFloat, double] = doc.querySelectorAll(
+        "#test a"
+      );
+
+      expect(uLongLong.textContent).toBe("unsigned long long");
+      expect(uLongLong.hash).toBe("#idl-unsigned-long-long");
+
+      expect(unrestrictedFloat.textContent).toBe("unrestricted float");
+      expect(unrestrictedFloat.hash).toBe("#idl-unrestricted-float");
+
+      expect(double.textContent).toBe("double");
+      expect(double.hash).toBe("#idl-double");
+    });
+
     it("links local definitions first", async () => {
       const body = `
         <section data-dfn-for="PaymentAddress" data-link-for="PaymentAddress">


### PR DESCRIPTION
We didn't support {{ unrestricted double }} {{ long long }} and friends 