### PR TITLE
Fix for race condition on page close (fixes #2477)

### DIFF
--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -105,9 +105,12 @@ async function fetchAndWrite(
       default:
         await writeTo(out, html);
     }
+    // Race condition: Wait before page close for all console messages to be logged
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    await page.close();
     return html;
   } finally {
-    browser.close();
+    await browser.close();
   }
 }
 


### PR DESCRIPTION
Fix for #2477 adds an additional 1 second wait to ensure that all console errors are logged before closing the page/browser.

Also switches to use `await` for `browser.close();` as per the Puppeteer [examples](https://pptr.dev/).