### PR TITLE
fix(core/webidl): do not overwrite data-dfn-for

### DIFF
--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -140,8 +140,7 @@ function defineIdlName(escaped, data, parent) {
      data-lt="default toJSON operation">${escaped}</a>`;
   }
   if (!data.partial) {
-    const dfn = hyperHTML`<dfn data-export data-dfn-type="${linkType}" data-dfn-for="${parent &&
-      parent.name}">${escaped}</dfn>`;
+    const dfn = hyperHTML`<dfn data-export data-dfn-type="${linkType}">${escaped}</dfn>`;
     decorateDfn(dfn, data, parentName, name);
     return dfn;
   }

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -302,6 +302,9 @@ function renderWebIDL(idlElement, index) {
   const render = hyperHTML.bind(idlElement);
   render`${html}`;
   idlElement.querySelectorAll("[data-idl]").forEach(elem => {
+    if (elem.dataset.dfnFor) {
+      return;
+    }
     const title = elem.dataset.title;
     // Select the nearest ancestor element that can contain members.
     const parent = elem.parentElement.closest("[data-idl][data-title]");

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -1310,6 +1310,28 @@ callback CallBack = Z? (X x, optional Y y, /*trivia*/ optional Z z);
     const [, tea] = doc.querySelectorAll(".respec-offending-element");
     expect(tea.textContent).toBe("TeaTime");
   });
+  it("self-defining IDL with same member names", async () => {
+    const body = `
+      <section>
+        <pre class="idl">
+          dictionary Roselia {
+            DOMString hikawa = "sayo";
+          };
+          dictionary PastelPalettes {
+            DOMString hikawa = "hina";
+          };
+        </pre>
+        <dfn>Roselia</dfn> and <dfn>PastelPalettes</dfn> are names of bands.
+      </section>
+    `;
+    const ops = makeStandardOps(null, body);
+    const doc = await makeRSDoc(ops);
+    const [member1, member2] = doc.querySelectorAll("pre dfn");
+    expect(member1.dataset.dfnFor).toBe("Roselia");
+    expect(member2.dataset.dfnFor).toBe("PastelPalettes");
+    expect(member1.classList).not.toContain("respec-offending-element");
+    expect(member2.classList).not.toContain("respec-offending-element");
+  });
   it("marks a failing IDL block", async () => {
     const body = `
       <section>


### PR DESCRIPTION
IDL self-definition defines `data-dfn-for` but it's immediately overwritten by incorrect value (the name of itself instead of the parent's name). This PR fixes it.

(Found from https://w3c.github.io/editing/execCommand.html#methods-to-query-and-execute-commands-0)