### PR TITLE
refactor(core/dfn-finder): move addAlternativeNames to decorateDfn

### DIFF
--- a/src/core/dfn-finder.js
+++ b/src/core/dfn-finder.js
@@ -1,7 +1,6 @@
 // @ts-check
 import { definitionMap, registerDefinition } from "./dfn-map.js";
-import { pub } from "./pubsubhub.js";
-import { wrapInner } from "./utils.js";
+import { showInlineError, wrapInner } from "./utils.js";
 
 const topLevelEntities = new Set([
   "callback interface",
@@ -37,27 +36,11 @@ export function findDfn(defn, name, { parent = "" } = {}) {
  */
 function tryFindDfn(defn, parent, name) {
   switch (defn.type) {
-    case "attribute":
-      return findAttributeDfn(defn, parent, name);
     case "operation":
       return findOperationDfn(defn, parent, name);
     default:
       return findNormalDfn(defn, parent, name);
   }
-}
-
-/**
- * @param {*} defn
- * @param {string} parent
- * @param {string} name
- */
-function findAttributeDfn(defn, parent, name) {
-  const dfn = findNormalDfn(defn, parent, name);
-  if (!dfn) {
-    return;
-  }
-  addAlternativeNames(dfn, getAlternativeNames("attribute", parent, name));
-  return dfn;
 }
 
 function getAlternativeNames(type, parent, name) {
@@ -85,14 +68,7 @@ function findOperationDfn(defn, parent, name) {
     return findNormalDfn(defn, parent, name);
   }
   const asMethodName = `${name}()`;
-  const dfn =
-    findNormalDfn(defn, parent, asMethodName) ||
-    findNormalDfn(defn, parent, name);
-  if (!dfn) {
-    return;
-  }
-  addAlternativeNames(dfn, getAlternativeNames("operation", parent, name));
-  return dfn;
+  return findNormalDfn(defn, parent, asMethodName, name);
 }
 
 /**
@@ -109,36 +85,38 @@ function addAlternativeNames(dfn, names) {
 /**
  * @param {*} defn
  * @param {string} parent
- * @param {string} name
+ * @param {...string} names
  */
-function findNormalDfn(defn, parent, name) {
-  let resolvedName =
-    defn.type === "enum-value" && name === "" ? "the-empty-string" : name;
-  let dfnForArray = definitionMap[resolvedName];
-  let dfns = getDfns(dfnForArray, parent, name, defn.type);
-  // If we haven't found any definitions with explicit [for]
-  // and [title], look for a dotted definition, "parent.name".
-  if (dfns.length === 0 && parent !== "") {
-    resolvedName = `${parent}.${resolvedName}`;
-    dfnForArray = definitionMap[resolvedName];
-    if (dfnForArray !== undefined && dfnForArray.length === 1) {
-      dfns = dfnForArray;
-      // Found it: register with its local name
-      delete definitionMap[resolvedName];
-      registerDefinition(dfns[0], [resolvedName]);
+function findNormalDfn(defn, parent, ...names) {
+  for (const name of names) {
+    let resolvedName =
+      defn.type === "enum-value" && name === "" ? "the-empty-string" : name;
+    let dfnForArray = definitionMap[resolvedName];
+    let dfns = getDfns(dfnForArray, parent, name, defn.type);
+    // If we haven't found any definitions with explicit [for]
+    // and [title], look for a dotted definition, "parent.name".
+    if (dfns.length === 0 && parent !== "") {
+      resolvedName = `${parent}.${resolvedName}`;
+      dfnForArray = definitionMap[resolvedName];
+      if (dfnForArray !== undefined && dfnForArray.length === 1) {
+        dfns = dfnForArray;
+        // Found it: register with its local name
+        delete definitionMap[resolvedName];
+        registerDefinition(dfns[0], [resolvedName]);
+      }
     }
-  }
-  if (dfns.length > 1) {
-    const msg = `Multiple \`<dfn>\`s for \`${name}\` ${
-      parent ? `in \`${parent}\`` : ""
-    }`;
-    pub("error", msg);
-  }
-  if (dfns.length) {
-    if (name !== resolvedName) {
-      dfns[0].dataset.lt = resolvedName;
+    if (dfns.length > 1) {
+      const msg = `Multiple \`<dfn>\`s for \`${name}\` ${
+        parent ? `in \`${parent}\`` : ""
+      }`;
+      showInlineError(dfns, msg, "Duplicate definition.");
     }
-    return dfns[0];
+    if (dfns.length) {
+      if (name !== resolvedName) {
+        dfns[0].dataset.lt = resolvedName;
+      }
+      return dfns[0];
+    }
   }
 }
 
@@ -176,6 +154,15 @@ export function decorateDfn(dfn, defn, parent, name) {
   if (!dfn.querySelector("code") && !dfn.closest("code") && dfn.children) {
     wrapInner(dfn, dfn.ownerDocument.createElement("code"));
   }
+
+  // Add data-lt values and register them
+  switch (defn.type) {
+    case "attribute":
+    case "operation":
+      addAlternativeNames(dfn, getAlternativeNames(defn.type, parent, name));
+      break;
+  }
+
   return dfn;
 }
 

--- a/src/core/dfn-finder.js
+++ b/src/core/dfn-finder.js
@@ -26,15 +26,6 @@ const topLevelEntities = new Set([
  * @param {string} name
  */
 export function findDfn(defn, name, { parent = "" } = {}) {
-  return tryFindDfn(defn, parent, name);
-}
-
-/**
- * @param {*} defn
- * @param {string} parent
- * @param {string} name
- */
-function tryFindDfn(defn, parent, name) {
   switch (defn.type) {
     case "operation":
       return findOperationDfn(defn, parent, name);
@@ -43,6 +34,11 @@ function tryFindDfn(defn, parent, name) {
   }
 }
 
+/**
+ * @param {string} type
+ * @param {string} parent
+ * @param {string} name
+ */
 function getAlternativeNames(type, parent, name) {
   const asQualifiedName = `${parent}.${name}`;
   switch (type) {

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -39,11 +39,10 @@ export async function run(conf) {
   const badLinks = [];
 
   const localLinkSelector =
-    "a[data-cite=''], a:not([href]):not([data-cite]):not(.logo)";
+    "a[data-cite=''], a:not([href]):not([data-cite]):not(.logo):not(.externalDFN)";
   document.querySelectorAll(localLinkSelector).forEach((
     /** @type {HTMLAnchorElement} */ anchor
   ) => {
-    if (anchor.classList.contains("externalDFN")) return;
     const linkTargets = getLinkTargets(anchor);
     const foundDfn = linkTargets.some(target => {
       return findLinkTarget(target, anchor, titleToDfns, possibleExternalLinks);
@@ -86,8 +85,8 @@ function mapTitleToDfns() {
     if (duplicates.length > 0) {
       showInlineError(
         duplicates,
-        `Duplicate definitions of '${title}'`,
-        l10n[lang].duplicate
+        l10n[lang].duplicateMsg(title),
+        l10n[lang].duplicateTitle
       );
     }
   });

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -141,6 +141,7 @@ function defineIdlName(escaped, data, parent) {
   }
   if (!data.partial) {
     const dfn = hyperHTML`<dfn data-export data-dfn-type="${linkType}">${escaped}</dfn>`;
+    registerDefinition(dfn, [name]);
     decorateDfn(dfn, data, parentName, name);
     return dfn;
   }

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -955,7 +955,7 @@ callback CallBack = Z? (X x, optional Y y, /*trivia*/ optional Z z);
     expect(notDefinedAttr[0].textContent).toBe("notDefined");
     expect(
       section.querySelector(
-        "p[data-link-for] a[href='#idl-def-documented-notdefined']"
+        "p[data-link-for] a[href='#dom-documented-notdefined']"
       ).textContent
     ).toBe("notDefined");
 

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -1322,6 +1322,7 @@ callback CallBack = Z? (X x, optional Y y, /*trivia*/ optional Z z);
           };
         </pre>
         <dfn>Roselia</dfn> and <dfn>PastelPalettes</dfn> are names of bands.
+        <span id="links"><a>Roselia</a> <a>PastelPalettes</a> {{Roselia/hikawa}}</span>.
       </section>
     `;
     const ops = makeStandardOps(null, body);
@@ -1331,6 +1332,10 @@ callback CallBack = Z? (X x, optional Y y, /*trivia*/ optional Z z);
     expect(member2.dataset.dfnFor).toBe("PastelPalettes");
     expect(member1.classList).not.toContain("respec-offending-element");
     expect(member2.classList).not.toContain("respec-offending-element");
+    const [anchor1, anchor2, anchor3] = doc.querySelectorAll("#links a");
+    expect(anchor1.getAttribute("href")).toBe("#dom-roselia");
+    expect(anchor2.getAttribute("href")).toBe("#dom-pastelpalettes");
+    expect(anchor3.getAttribute("href")).toBe("#dom-roselia-hikawa");
   });
   it("marks a failing IDL block", async () => {
     const body = `


### PR DESCRIPTION
The second wave of refactors in #2489.