### PR TITLE
fix(core/link-to-dfn): wrap as code for all linking formats

### DIFF
--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -211,7 +211,7 @@ function shouldWrapByCode(dfn, term) {
   } else if (dataset.title === term) {
     return true;
   } else if (dataset.lt) {
-    return dataset.lt.split("|").includes(term.toLowerCase());
+    return dataset.lt.split("|").includes(term);
   }
   return false;
 }

--- a/tests/spec/core/link-to-dfn-spec.js
+++ b/tests/spec/core/link-to-dfn-spec.js
@@ -29,7 +29,7 @@ describe("Core — Link to definitions", () => {
             Request clone();
           };
         </pre>
-        <p id="codeWrap">A <a>Request</a> object has the <dfn>clone</dfn> method.</p>
+        <p id="codeWrap">A <a>Request</a> object has a <dfn>clone</dfn> method.</p>
         <p id="codeWrapMethod"><a>clone</a>, <a>clone()</a>, <a>Request.clone</a>, and <a>Request.clone()</a> are all same.</p>
         <p id="noCodeWrap">An instance of <a lt="Request">the request interface</a>.</p>
       </section>`;

--- a/tests/spec/core/link-to-dfn-spec.js
+++ b/tests/spec/core/link-to-dfn-spec.js
@@ -43,6 +43,7 @@ describe("Core — Link to definitions", () => {
     expect(codeWrapMethods.length).toBe(4);
     const noCodeWrap = doc.body.querySelector("#noCodeWrap a");
     expect(noCodeWrap).toBeTruthy();
+    expect(noCodeWrap.getAttribute("href")).toBe("#dom-request");
     expect(noCodeWrap.querySelector("code")).toBeFalsy();
     expect(noCodeWrap.textContent).toBe("the request interface");
   });

--- a/tests/spec/core/link-to-dfn-spec.js
+++ b/tests/spec/core/link-to-dfn-spec.js
@@ -25,9 +25,12 @@ describe("Core — Link to definitions", () => {
       <section data-link-for="Request">
         <h2><dfn>Request</dfn> interface</h2>
         <pre class="idl">
-          interface Request {};
+          interface Request {
+            Request clone();
+          };
         </pre>
-        <p id="codeWrap">A <a>Request</a> object.</p>
+        <p id="codeWrap">A <a>Request</a> object has the <dfn>clone</dfn> method.</p>
+        <p id="codeWrapMethod"><a>clone</a>, <a>clone()</a>, <a>Request.clone</a>, and <a>Request.clone()</a> are all same.</p>
         <p id="noCodeWrap">An instance of <a lt="Request">the request interface</a>.</p>
       </section>`;
     const ops = makeStandardOps(null, bodyText);
@@ -36,6 +39,8 @@ describe("Core — Link to definitions", () => {
     expect(hasCode).toBeTruthy();
     expect(hasCode.firstElementChild.localName).toBe("code");
     expect(hasCode.textContent).toBe("Request");
+    const codeWrapMethods = doc.body.querySelectorAll("#codeWrapMethod a code");
+    expect(codeWrapMethods.length).toBe(4);
     const noCodeWrap = doc.body.querySelector("#noCodeWrap a");
     expect(noCodeWrap).toBeTruthy();
     expect(noCodeWrap.querySelector("code")).toBeFalsy();

--- a/tests/spec/core/link-to-dfn-spec.js
+++ b/tests/spec/core/link-to-dfn-spec.js
@@ -31,7 +31,7 @@ describe("Core — Link to definitions", () => {
         </pre>
         <p id="codeWrap">A <a>Request</a> object has a <dfn>clone</dfn> method.</p>
         <p id="codeWrapMethod"><a>clone</a>, <a>clone()</a>, <a>Request.clone</a>, and <a>Request.clone()</a> are all same.</p>
-        <p id="noCodeWrap">An instance of <a lt="Request">the request interface</a>.</p>
+        <p id="noCodeWrap">An instance of <a data-lt="Request">the request interface</a>.</p>
       </section>`;
     const ops = makeStandardOps(null, bodyText);
     const doc = await makeRSDoc(ops);


### PR DESCRIPTION
Closes #2500 