### PR TITLE
fix(core/pluralize): normalize to lowercase

### DIFF
--- a/src/core/pluralize.js
+++ b/src/core/pluralize.js
@@ -46,7 +46,7 @@ function getPluralizer() {
   /** @type {NodeListOf<HTMLAnchorElement>} */
   const reflessAnchors = document.querySelectorAll("a:not([href])");
   reflessAnchors.forEach(el => {
-    const normText = normalize(el.textContent);
+    const normText = normalize(el.textContent).toLowerCase();
     links.add(normText);
     if (el.dataset.lt) {
       links.add(el.dataset.lt);
@@ -58,7 +58,7 @@ function getPluralizer() {
   /** @type {NodeListOf<HTMLElement>} */
   const dfns = document.querySelectorAll("dfn:not([data-lt-noDefault])");
   dfns.forEach(dfn => {
-    const normText = normalize(dfn.textContent);
+    const normText = normalize(dfn.textContent).toLowerCase();
     dfnTexts.add(normText);
     if (dfn.dataset.lt) {
       dfn.dataset.lt.split("|").forEach(lt => dfnTexts.add(lt));
@@ -67,7 +67,7 @@ function getPluralizer() {
 
   // returns pluralized/singularized term if `text` needs pluralization/singularization, "" otherwise
   return function pluralizeDfn(/** @type {string} */ text) {
-    const normText = normalize(text);
+    const normText = normalize(text).toLowerCase();
     const plural = isSingular(normText)
       ? pluralOf(normText)
       : singularOf(normText);

--- a/tests/spec/core/pluralize-spec.js
+++ b/tests/spec/core/pluralize-spec.js
@@ -8,9 +8,9 @@ describe("Core - Pluralize", () => {
         <span id="fooLinks">
           <a>foo</a> or <a>foos</a>
         </span>
-        <dfn>bars</dfn> can be referenced as
+        <dfn>Bars</dfn> can be referenced as
         <span id="barLinks">
-          <a>bar</a> or <a>bars</a>
+          <a>Bar</a> or <a>bars</a> or <a>bar</a>
         </span>
       </section>`;
     const ops = makeStandardOps({ pluralize: true }, body);
@@ -31,7 +31,7 @@ describe("Core - Pluralize", () => {
     expect(dfnBars.dataset.lt).toBeFalsy();
     expect(dfnBars.dataset.plurals).toBe("bar");
     const linksBars = [...doc.querySelectorAll("#barLinks a")];
-    expect(linksBars.length).toBe(2);
+    expect(linksBars.length).toBe(3);
     expect(
       linksBars.every(el => el.getAttribute("href") === "#dfn-bars")
     ).toBeTruthy();
@@ -40,10 +40,13 @@ describe("Core - Pluralize", () => {
   it("adds pluralization when [data-lt] is defined", async () => {
     const body = `
       <section id="section">
-        <dfn data-lt="baz">bars</dfn> can be referenced
+        <dfn data-lt="Baz">Bars</dfn> can be referenced
         as <a>baz</a>
         or <a>bar</a>
+        or <a>Bar</a>
         or <a>bars</a>
+        or <a>Bars</a>
+        or <a>BaZs</a>
         or <a>bazs</a>
         but not as <a id="ignored-link" href="/PASS">bar</a>
       </section>`;
@@ -52,10 +55,10 @@ describe("Core - Pluralize", () => {
 
     const dfn = doc.querySelector("#section dfn");
     expect(dfn.id).toBe("dfn-baz"); // uses first data-lt as `id`
-    expect(dfn.dataset.lt).toBe("baz|bars");
+    expect(dfn.dataset.lt).toBe("Baz|Bars");
     expect(dfn.dataset.plurals.split("|").sort()).toEqual(["bar", "bazs"]);
     const validLinks = [...doc.querySelectorAll("#section a[href^='#']")];
-    expect(validLinks.length).toBe(4);
+    expect(validLinks.length).toBe(7);
     expect(
       validLinks.every(el => el.getAttribute("href") === "#dfn-baz")
     ).toBeTruthy();


### PR DESCRIPTION
Regression from https://github.com/w3c/respec/pull/2484, https://github.com/w3c/respec/pull/2489. Should fix https://github.com/w3c/respec/issues/2496#issuecomment-527560437
Makes sense as one won't be pluralizing IDL and concept-dfn can be lowercased.

[Fixes `json-ld-syntax`](https://respec-preview.netlify.com/?spec=https://w3c.github.io/json-ld-syntax/&version=https://deploy-preview-2505--respec-pr.netlify.com/respec-w3c-common.js). Will try to confirm if any exports break.