### PR TITLE
fix(core/xref): preserve original term in error messages

### DIFF
--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -361,9 +361,9 @@ function addToReferences(elem, cite, normative, term, conf) {
 
 /** @param {Errors} errors */
 function showErrors({ ambiguous, notFound }) {
-  const getPrefilledFormURL = (query, specs = []) => {
+  const getPrefilledFormURL = (term, query, specs = []) => {
     const url = new URL(API_URL);
-    url.searchParams.set("term", query.term);
+    url.searchParams.set("term", term);
     if (query.for) url.searchParams.set("for", query.for);
     url.searchParams.set("types", query.types.join(","));
     if (specs.length) url.searchParams.set("cite", specs.join(","));
@@ -372,9 +372,9 @@ function showErrors({ ambiguous, notFound }) {
 
   for (const { query, elems } of notFound.values()) {
     const specs = [...new Set(flatten([], query.specs))].sort();
-    const formUrl = getPrefilledFormURL(query, specs);
-    const specsString = specs.map(spec => `\`${spec}\``).join(", ");
     const originalTerm = getTermFromElement(elems[0]);
+    const formUrl = getPrefilledFormURL(originalTerm, query, specs);
+    const specsString = specs.map(spec => `\`${spec}\``).join(", ");
     const msg =
       `Couldn't match "**${originalTerm}**" to anything in the document or in any other document cited in this specification: ${specsString}. ` +
       `See [how to cite to resolve the error](${formUrl})`;
@@ -383,9 +383,9 @@ function showErrors({ ambiguous, notFound }) {
 
   for (const { query, elems, results } of ambiguous.values()) {
     const specs = [...new Set(results.map(entry => entry.shortname))].sort();
-    const formUrl = getPrefilledFormURL(query, specs);
     const specsString = specs.map(s => `**${s}**`).join(", ");
     const originalTerm = getTermFromElement(elems[0]);
+    const formUrl = getPrefilledFormURL(originalTerm, query, specs);
     const msg =
       `The term "**${originalTerm}**" is defined in ${specsString} in multiple ways, so it's ambiguous. ` +
       `See [how to cite to resolve the error](${formUrl})`;

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -130,11 +130,7 @@ function normalizeConfig(xref) {
 function getRequestEntry(elem) {
   const isIDL = "xrefType" in elem.dataset;
 
-  let term = elem.dataset.lt
-    ? elem.dataset.lt.split("|", 1)[0]
-    : elem.textContent;
-  term = normalize(term);
-  if (term === "the-empty-string") term = "";
+  let term = getTermFromElement(elem);
   if (!isIDL) term = term.toLowerCase();
 
   /** @type {string[][]} */
@@ -191,6 +187,14 @@ function getRequestEntry(elem) {
     ...(specs.length && { specs }),
     ...(typeof forContext === "string" && { for: forContext }),
   };
+}
+
+/** @param {HTMLElement} elem */
+function getTermFromElement(elem) {
+  const { lt: linkingText } = elem.dataset;
+  let term = linkingText ? linkingText.split("|", 1)[0] : elem.textContent;
+  term = normalize(term);
+  return term === "the-empty-string" ? "" : term;
 }
 
 /**

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -374,8 +374,9 @@ function showErrors({ ambiguous, notFound }) {
     const specs = [...new Set(flatten([], query.specs))].sort();
     const formUrl = getPrefilledFormURL(query, specs);
     const specsString = specs.map(spec => `\`${spec}\``).join(", ");
+    const originalTerm = getTermFromElement(elems[0]);
     const msg =
-      `Couldn't match "**${query.term}**" to anything in the document or in any other document cited in this specification: ${specsString}. ` +
+      `Couldn't match "**${originalTerm}**" to anything in the document or in any other document cited in this specification: ${specsString}. ` +
       `See [how to cite to resolve the error](${formUrl})`;
     showInlineError(elems, msg, "Error: No matching dfn found.");
   }
@@ -384,8 +385,9 @@ function showErrors({ ambiguous, notFound }) {
     const specs = [...new Set(results.map(entry => entry.shortname))].sort();
     const formUrl = getPrefilledFormURL(query, specs);
     const specsString = specs.map(s => `**${s}**`).join(", ");
+    const originalTerm = getTermFromElement(elems[0]);
     const msg =
-      `The term "**${query.term}**" is defined in ${specsString} in multiple ways, so it's ambiguous. ` +
+      `The term "**${originalTerm}**" is defined in ${specsString} in multiple ways, so it's ambiguous. ` +
       `See [how to cite to resolve the error](${formUrl})`;
     showInlineError(elems, msg, "Error: Linking an ambiguous dfn.");
   }


### PR DESCRIPTION
Re-uses the term getting logic from `getRequestEntry`, but doesn't lowercase it (to preserve the original term).

Other way could be: keep original term in query always, and handle case-sensitivity check on back-end.

| before | after |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/8426945/64322910-10535a00-cfe1-11e9-9932-36c3b2f0c9b6.png) | ![after](https://user-images.githubusercontent.com/8426945/64322865-fc0f5d00-cfe0-11e9-91c0-e4ad6641f8e9.png) |
