### PR TITLE
fix(templates/show-people): add missing datatime attribute

### DIFF
--- a/src/w3c/templates/show-people.js
+++ b/src/w3c/templates/show-people.js
@@ -113,7 +113,7 @@ export default (items = []) => {
           "Invalid date"
         );
       }
-      timeElem.datetime = toShortIsoDate(retiredDate);
+      timeElem.dateTime = toShortIsoDate(retiredDate);
       contents.push(
         html`
           - ${l10n.until.concat(" ")}${[timeElem]}

--- a/src/w3c/templates/show-people.js
+++ b/src/w3c/templates/show-people.js
@@ -1,4 +1,4 @@
-import { humanDate, showInlineError } from "../../core/utils";
+import { humanDate, showInlineError, toShortIsoDate } from "../../core/utils";
 import { lang as defaultLang } from "../../core/l10n.js";
 import html from "hyperhtml";
 
@@ -102,20 +102,21 @@ export default (items = []) => {
     if (p.retiredDate) {
       const retiredDate = new Date(p.retiredDate);
       const isValidDate = retiredDate.toString() !== "Invalid Date";
-      const result = document.createElement("time");
-      result.textContent = isValidDate
+      const timeElem = document.createElement("time");
+      timeElem.textContent = isValidDate
         ? humanDate(retiredDate)
         : "Invalid Date"; // todo: Localise invalid date
       if (!isValidDate) {
         showInlineError(
-          result,
+          timeElem,
           "The date is invalid. The expected format is YYYY-MM-DD.",
           "Invalid date"
         );
       }
+      timeElem.datetime = toShortIsoDate(retiredDate);
       contents.push(
         html`
-          - ${l10n.until.concat(" ")}${[result]}
+          - ${l10n.until.concat(" ")}${[timeElem]}
         `
       );
     }

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -95,6 +95,8 @@ describe("W3C — Headers", () => {
         expect(dtFormerEditor[0].nextElementSibling.textContent).toContain(
           "marzo"
         );
+        const time = dtFormerEditor[0].nextElementSibling.querySelector("time");
+        expect(time.dateTime).toBe("2020-03-01");
       });
       it("relocates single editor with retiredDate member to single formerEditor", async () => {
         const ops = makeStandardOps();
@@ -144,7 +146,7 @@ describe("W3C — Headers", () => {
           editors: [
             {
               name: "FORMER EDITOR 1",
-              retiredDate: "2020-03-01",
+              retiredDate: "2020-03-02",
             },
             {
               name: "FORMER EDITOR 2",
@@ -159,6 +161,7 @@ describe("W3C — Headers", () => {
         expect(dtEditors.length).toBe(0);
         const dd = dtFormerEditors[0].nextElementSibling;
         expect(dd.textContent).toContain("FORMER EDITOR 1");
+        expect(dd.querySelector("time").dateTime).toBe("2020-03-02");
         expect(dd.nextElementSibling.textContent).toContain("FORMER EDITOR 2");
       });
       it("relocates multiple editors with retiredDate member to multple formerEditors", async () => {


### PR DESCRIPTION
The W3C validator is complaining about the missing `datetime`, because the text content is in the wrong format.   