### PR TITLE
fix(assets/mdn-annotation.css): link to svgs to fix 404 opera and samsung icons

### DIFF
--- a/assets/mdn-annotation.css
+++ b/assets/mdn-annotation.css
@@ -117,7 +117,7 @@
 
 .mdnsupport > .opera::before,
 .mdnsupport > .opera_android::before {
-  background-image: url(https://resources.whatwg.org/browser-logos/opera.png);
+  background-image: url(https://resources.whatwg.org/browser-logos/opera.svg);
 }
 
 .mdnsupport > .safari::before {
@@ -129,7 +129,7 @@
 }
 
 .mdnsupport > .samsunginternet_android::before {
-  background-image: url(https://resources.whatwg.org/browser-logos/samsung.png);
+  background-image: url(https://resources.whatwg.org/browser-logos/samsung.svg);
 }
 
 .mdnsupport > .webview_android::before {


### PR DESCRIPTION
* Closes [issue 2540](https://github.com/w3c/respec/issues/2540)
* I took the icon links from the [same folder as other icons](https://resources.whatwg.org/browser-logos/)
* Thank you @marcoscaceres for pointing me towards this repo!