### PR TITLE
fix(tools/copydeps): gracely ignore when no folder

### DIFF
--- a/tools/copydeps.js
+++ b/tools/copydeps.js
@@ -77,7 +77,7 @@ async function deleteFolder(path) {
   try {
     await fs.stat(path);
   } catch (err) {
-    if (err.errno === -2) return; // doesn't exist
+    if (err.code === "ENOENT") return; // doesn't exist
     throw err;
   }
   for (const file of await fs.readdir(path)) {


### PR DESCRIPTION
`errno` is different in Windows, so it's more safe to use `code` instead.