### PR TITLE
docs(w3c/headers): w3c-software-doc is the default

### DIFF
--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -82,13 +82,12 @@
 //          - href: a URL for the value (e.g., "https://foo.com/issues"). Optional.
 //          - class: a string representing CSS classes. Optional.
 //  - license: can be one of the following
-//      - "w3c", currently the default (restrictive) license
 //      - "cc-by", which is experimentally available in some groups (but likely to be phased out).
 //          Note that this is a dual licensing regime.
 //      - "cc0", an extremely permissive license. It is only recommended if you are working on a document that is
 //          intended to be pushed to the WHATWG.
 //      - "w3c-software", a permissive and attributions license (but GPL-compatible).
-//      - "w3c-software-doc", the W3C Software and Document License
+//      - "w3c-software-doc", (default) the W3C Software and Document License
 //            https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
 import { ISODate, concatDate, joinAnd } from "../core/utils.js";
 import cgbgHeadersTmpl from "./templates/cgbg-headers.js";


### PR DESCRIPTION
closes #2575 