### PR TITLE
feat(w3c/seo): Improve JSON-LD export of citations

### DIFF
--- a/src/w3c/seo.js
+++ b/src/w3c/seo.js
@@ -170,10 +170,24 @@ function addPerson({ name, url, mailto, company, companyURL }) {
  */
 function addRef(ref) {
   const { href: id, title: name, href: url } = ref;
-  return {
+  let jsonld = {
     id,
     type: "TechArticle",
     name,
     url,
   };
+  if (ref.authors) {
+    jsonld.creator = ref.authors.map(a => ({name: a}));
+  }
+  if (ref.rawDate) {
+    jsonld.publishedDate = ref.rawDate;
+  }
+  if (ref.isbn) {
+    jsonld.identifier = ref.isbn;
+  }
+  if (ref.publisher) {
+    jsonld.publisher = {name: ref.publisher};
+  }
+  return jsonld;
 }
+

--- a/src/w3c/seo.js
+++ b/src/w3c/seo.js
@@ -170,14 +170,14 @@ function addPerson({ name, url, mailto, company, companyURL }) {
  */
 function addRef(ref) {
   const { href: id, title: name, href: url } = ref;
-  let jsonld = {
+  const jsonld = {
     id,
     type: "TechArticle",
     name,
     url,
   };
   if (ref.authors) {
-    jsonld.creator = ref.authors.map(a => ({name: a}));
+    jsonld.creator = ref.authors.map(a => ({ name: a }));
   }
   if (ref.rawDate) {
     jsonld.publishedDate = ref.rawDate;
@@ -186,8 +186,7 @@ function addRef(ref) {
     jsonld.identifier = ref.isbn;
   }
   if (ref.publisher) {
-    jsonld.publisher = {name: ref.publisher};
+    jsonld.publisher = { name: ref.publisher };
   }
   return jsonld;
 }
-

--- a/tests/spec/w3c/seo-spec.js
+++ b/tests/spec/w3c/seo-spec.js
@@ -181,9 +181,7 @@ describe("W3C - SEO", () => {
       type: "TechArticle",
       name: "Test ref title",
       url: "http://test.com/1",
-      author: [
-        { name: "William Shakespeare" }
-      ],
+      author: [{ name: "William Shakespeare" }],
       publisher: { name: "Publishers Inc." },
     });
     expect(jsonld.citation).toContain({
@@ -191,10 +189,8 @@ describe("W3C - SEO", () => {
       type: "TechArticle",
       name: "Second test",
       url: "http://test.com/2",
-      author: [
-        { name: "Another author" }
-      ],
-      publisher: { name: "Testing 123" }
+      author: [{ name: "Another author" }],
+      publisher: { name: "Testing 123" },
     });
     expect(jsonld.citation).toContain({
       id: "http://test.com/3",

--- a/tests/spec/w3c/seo-spec.js
+++ b/tests/spec/w3c/seo-spec.js
@@ -106,6 +106,7 @@ describe("W3C - SEO", () => {
         title: "Third test",
         href: "http://test.com/3",
         publisher: "Publisher Here",
+        isbn: "9783319934167",
       },
     },
   };
@@ -180,18 +181,28 @@ describe("W3C - SEO", () => {
       type: "TechArticle",
       name: "Test ref title",
       url: "http://test.com/1",
+      author: [
+        { name: "William Shakespeare" }
+      ],
+      publisher: { name: "Publishers Inc." },
     });
     expect(jsonld.citation).toContain({
       id: "http://test.com/2",
       type: "TechArticle",
       name: "Second test",
       url: "http://test.com/2",
+      author: [
+        { name: "Another author" }
+      ],
+      publisher: { name: "Testing 123" }
     });
     expect(jsonld.citation).toContain({
       id: "http://test.com/3",
       type: "TechArticle",
       name: "Third test",
       url: "http://test.com/3",
+      publisher: { name: "Publisher Here" },
+      identifier: "9783319934167",
     });
   });
 

--- a/tests/spec/w3c/seo-spec.js
+++ b/tests/spec/w3c/seo-spec.js
@@ -181,7 +181,7 @@ describe("W3C - SEO", () => {
       type: "TechArticle",
       name: "Test ref title",
       url: "http://test.com/1",
-      author: [{ name: "William Shakespeare" }],
+      creator: [{ name: "William Shakespeare" }],
       publisher: { name: "Publishers Inc." },
     });
     expect(jsonld.citation).toContain({
@@ -189,7 +189,7 @@ describe("W3C - SEO", () => {
       type: "TechArticle",
       name: "Second test",
       url: "http://test.com/2",
-      author: [{ name: "Another author" }],
+      creator: [{ name: "Another author" }],
       publisher: { name: "Testing 123" },
     });
     expect(jsonld.citation).toContain({


### PR DESCRIPTION
This exports a few more fields from Specref's data model to the JSON-LD export of the bibliography.

Closes #2584.