### PR TITLE
fix(core/markdown): syntax highlight in fenced blocks

### DIFF
--- a/src/core/markdown.js
+++ b/src/core/markdown.js
@@ -214,6 +214,7 @@ export function markdownToHtml(text) {
     sanitize: false,
     gfm: true,
     headerIds: false,
+    langPrefix: "",
     renderer: new Renderer(),
   });
   return result;

--- a/tests/spec/core/markdown-spec.js
+++ b/tests/spec/core/markdown-spec.js
@@ -241,7 +241,7 @@ describe("Core - Markdown", () => {
     expect(foo.contains(bar)).toBeFalsy();
   });
 
-  it("supports backticks for webidl", async () => {
+  it("supports backticks for syntax highlighting", async () => {
     const body = `
       ## test
 
@@ -267,15 +267,21 @@ describe("Core - Markdown", () => {
     const [webidlBlock, jsBlock, normalBlock] = doc.querySelectorAll("pre");
 
     expect(webidlBlock.classList).toContain("idl");
-    expect(webidlBlock.querySelector("code.hljs")).toBeFalsy();
+    expect(webidlBlock.querySelector("code.hljs")).toBeNull();
+    expect(webidlBlock.querySelector(".idlConstructor")).not.toBeNull();
     expect(webidlBlock.querySelector(".respec-button-copy-paste")).toBeTruthy();
 
     expect(jsBlock.firstElementChild.localName).toBe("code");
-    expect(jsBlock.querySelector("code.hljs").classList).toContain("js");
-    expect(jsBlock.querySelector(".respec-button-copy-paste")).toBeFalsy();
+    expect(
+      jsBlock.querySelector("code.hljs").classList.contains("js")
+    ).toBeTruthy();
+    expect(jsBlock.querySelector("code.hljs span")).not.toBeNull();
+    expect(jsBlock.querySelector(".respec-button-copy-paste")).toBeNull();
 
     expect(normalBlock.firstElementChild.localName).toBe("code");
-    expect(normalBlock.querySelector(".respec-button-copy-paste")).toBeFalsy();
+    expect(normalBlock.querySelector(".respec-button-copy-paste")).toBeNull();
+    expect(normalBlock.querySelector("code.hljs")).not.toBeNull();
+    expect(normalBlock.querySelector("code.hljs span")).toBeNull();
   });
 
   describe("nolinks options", () => {

--- a/tests/spec/core/markdown-spec.js
+++ b/tests/spec/core/markdown-spec.js
@@ -271,9 +271,7 @@ describe("Core - Markdown", () => {
     expect(webidlBlock.querySelector(".respec-button-copy-paste")).toBeTruthy();
 
     expect(jsBlock.firstElementChild.localName).toBe("code");
-    expect(jsBlock.querySelector("code.hljs").classList).toContain(
-      "language-js"
-    );
+    expect(jsBlock.querySelector("code.hljs").classList).toContain("js");
     expect(jsBlock.querySelector(".respec-button-copy-paste")).toBeFalsy();
 
     expect(normalBlock.firstElementChild.localName).toBe("code");


### PR DESCRIPTION
Fixes https://github.com/w3c/respec/issues/2607

`getLanguageHint` in `core/highlight.js` expects languages without any prefix.
Alternative way to solve this could be to remove `"language-"` prefixes from classList, but this is one simpler (don't add `language-` prefix)