### PR TITLE
refactor: use `html` as the template string function

### DIFF
--- a/src/core/best-practices.js
+++ b/src/core/best-practices.js
@@ -5,7 +5,7 @@
 // Best practices are marked up with span.practicelab.
 import { addId, getIntlData, makeSafeCopy } from "./utils.js";
 import { lang as defaultLang } from "../core/l10n.js";
-import { hyperHTML } from "./import-maps.js";
+import { html } from "./import-maps.js";
 import { pub } from "./pubsubhub.js";
 
 export const name = "core/best-practices";
@@ -31,14 +31,13 @@ export function run() {
   const summaryItems = bpSummary ? document.createElement("ul") : null;
   [...bps].forEach((bp, num) => {
     const id = addId(bp, "bp");
-    const localizedBpName = hyperHTML`
-      <a class="marker self-link" href="${`#${id}`}"><bdi lang="${lang}">${
-      l10n.best_practice
-    }${num + 1}</bdi></a>`;
+    const localizedBpName = html` <a class="marker self-link" href="${`#${id}`}"
+      ><bdi lang="${lang}">${l10n.best_practice}${num + 1}</bdi></a
+    >`;
 
     // Make the summary items, if we have a summary
     if (summaryItems) {
-      const li = hyperHTML`
+      const li = html`
         <li>
           ${localizedBpName}: ${makeSafeCopy(bp)}
         </li>
@@ -55,12 +54,12 @@ export function run() {
 
     // Make the advisement box
     container.classList.add("advisement");
-    const title = hyperHTML`${localizedBpName.cloneNode(true)}: ${bp}`;
+    const title = html`${localizedBpName.cloneNode(true)}: ${bp}`;
     container.prepend(...title.childNodes);
   });
   if (bps.length) {
     if (bpSummary) {
-      bpSummary.appendChild(hyperHTML`<h2>Best Practices Summary</h2>`);
+      bpSummary.appendChild(html`<h2>Best Practices Summary</h2>`);
       bpSummary.appendChild(summaryItems);
     }
   } else if (bpSummary) {

--- a/src/core/caniuse.js
+++ b/src/core/caniuse.js
@@ -7,7 +7,7 @@
 import { pub, sub } from "./pubsubhub.js";
 import { createResourceHint } from "./utils.js";
 import { fetchAsset } from "./text-loader.js";
-import { hyperHTML } from "./import-maps.js";
+import { html } from "./import-maps.js";
 
 export const name = "core/caniuse";
 
@@ -63,37 +63,39 @@ export async function run(conf) {
   const featureURL = new URL(options.feature, "https://caniuse.com/").href;
 
   const caniuseCss = await caniuseCssPromise;
-  document.head.appendChild(hyperHTML`
-    <style class="removeOnSave">${caniuseCss}</style>`);
+  document.head.appendChild(html` <style class="removeOnSave">
+    ${caniuseCss}
+  </style>`);
 
   const headDlElem = document.querySelector(".head dl");
   const contentPromise = (async () => {
     try {
       const apiUrl = options.apiURL || API_URL;
       const stats = await fetchStats(apiUrl, options);
-      return hyperHTML`${{ html: stats }}`;
+      return html`${{ html: stats }}`;
     } catch (err) {
       console.error(err);
       const msg =
         `Couldn't find feature "${options.feature}" on caniuse.com? ` +
         "Please check the feature key on [caniuse.com](https://caniuse.com)";
       pub("error", msg);
-      return hyperHTML`<a href="${featureURL}">caniuse.com</a>`;
+      return html`<a href="${featureURL}">caniuse.com</a>`;
     }
   })();
-  const definitionPair = hyperHTML`
-    <dt class="caniuse-title">Browser support:</dt>
-    <dd class="caniuse-stats">${{
-      any: contentPromise,
-      placeholder: "Fetching data from caniuse.com...",
-    }}</dd>`;
+  const definitionPair = html` <dt class="caniuse-title">Browser support:</dt>
+    <dd class="caniuse-stats">
+      ${{
+        any: contentPromise,
+        placeholder: "Fetching data from caniuse.com...",
+      }}
+    </dd>`;
   headDlElem.append(...definitionPair.childNodes);
   await contentPromise;
 
   // remove from export
   pub("amend-user-config", { caniuse: options.feature });
   sub("beforesave", outputDoc => {
-    hyperHTML.bind(outputDoc.querySelector(".caniuse-stats"))`
+    html.bind(outputDoc.querySelector(".caniuse-stats"))`
       <a href="${featureURL}">caniuse.com</a>`;
   });
 }

--- a/src/core/contrib.js
+++ b/src/core/contrib.js
@@ -5,7 +5,7 @@
 // #gh-contributors: people whose PR have been merged.
 // Spec editors get filtered out automatically.
 import { fetchAndCache, joinAnd } from "./utils.js";
-import { hyperHTML } from "./import-maps.js";
+import { html } from "./import-maps.js";
 import { pub } from "./pubsubhub.js";
 export const name = "core/contrib";
 
@@ -80,7 +80,7 @@ function toHTML(contributors, element) {
   });
 
   if (element.tagName === "UL") {
-    hyperHTML(element)`${sortedContributors.map(
+    html(element)`${sortedContributors.map(
       ({ name, login }) =>
         `<li><a href="https://github.com/${login}">${name || login}</a></li>`
     )}`;

--- a/src/core/custom-elements/rs-changelog.js
+++ b/src/core/custom-elements/rs-changelog.js
@@ -8,7 +8,7 @@
  * @typedef {{message: string, hash: string}} Commit
  */
 import { github } from "../github.js";
-import { hyperHTML } from "../import-maps.js";
+import { html } from "../import-maps.js";
 import { showInlineError } from "../utils.js";
 
 export const name = "rs-changelog";
@@ -29,7 +29,7 @@ export const element = class ChangelogElement extends HTMLElement {
 
   connectedCallback() {
     const { from, to, filter } = this.props;
-    hyperHTML.bind(this)`
+    html.bind(this)`
       <ul>
       ${{
         any: fetchCommits(from, to, filter)
@@ -82,7 +82,7 @@ async function toHTML(commits) {
     const [message, prNumber = null] = commit.message.split(/\(#(\d+)\)/, 2);
     const commitURL = `${repoURL}commit/${commit.hash}`;
     const prURL = prNumber ? `${repoURL}pull/${prNumber}` : null;
-    const pr = prNumber && hyperHTML` (<a href="${prURL}">#${prNumber}</a>)`;
-    return hyperHTML`<li><a href="${commitURL}">${message.trim()}</a>${pr}</li>`;
+    const pr = prNumber && html` (<a href="${prURL}">#${prNumber}</a>)`;
+    return html`<li><a href="${commitURL}">${message.trim()}</a>${pr}</li>`;
   });
 }

--- a/src/core/data-tests.js
+++ b/src/core/data-tests.js
@@ -10,7 +10,7 @@
  * Docs: https://github.com/w3c/respec/wiki/data-tests
  */
 import { getIntlData, showInlineWarning } from "./utils.js";
-import { hyperHTML } from "./import-maps.js";
+import { html } from "./import-maps.js";
 import { pub } from "./pubsubhub.js";
 const localizationStrings = {
   en: {
@@ -76,11 +76,12 @@ function toListItem(href) {
     emojiList.push(manualPerformEmoji);
   }
 
-  const testList = hyperHTML`
+  const testList = html`
     <li>
       <a href="${href}">
         ${testFileName}
-      </a> ${emojiList}
+      </a>
+      ${emojiList}
     </li>
   `;
   return testList;
@@ -148,12 +149,14 @@ function handleDuplicates(testURLs, elem) {
  */
 function toHTML(testURLs) {
   const uniqueList = [...new Set(testURLs)];
-  const details = hyperHTML`
+  const details = html`
     <details class="respec-tests-details removeOnSave">
       <summary>
         tests: ${uniqueList.length}
       </summary>
-      <ul>${uniqueList.map(toListItem)}</ul>
+      <ul>
+        ${uniqueList.map(toListItem)}
+      </ul>
     </details>
   `;
   return details;

--- a/src/core/dfn-index.js
+++ b/src/core/dfn-index.js
@@ -8,7 +8,7 @@ import { addId, getIntlData } from "./utils.js";
 import { citeDetailsConverter } from "./data-cite.js";
 import { fetchAsset } from "./text-loader.js";
 import { getTermFromElement } from "./xref.js";
-import { hyperHTML as html } from "./import-maps.js";
+import { html } from "./import-maps.js";
 import { renderInlineCitation } from "./render-biblio.js";
 import { sub } from "./pubsubhub.js";
 

--- a/src/core/dfn-panel.js
+++ b/src/core/dfn-panel.js
@@ -2,7 +2,7 @@
 // self link to the selected dfn. Based on Bikeshed's dfn panels at
 // https://github.com/tabatkins/bikeshed/blob/ef44162c2e/bikeshed/dfnpanels.py
 import { fetchAsset } from "./text-loader.js";
-import { hyperHTML } from "./import-maps.js";
+import { html } from "./import-maps.js";
 import { norm } from "./utils.js";
 
 export const name = "core/dfn-panel";
@@ -10,7 +10,9 @@ export const name = "core/dfn-panel";
 export async function run() {
   const css = await loadStyle();
   document.head.insertBefore(
-    hyperHTML`<style>${css}</style>`,
+    html`<style>
+      ${css}
+    </style>`,
     document.querySelector("link")
   );
 
@@ -68,7 +70,7 @@ function createPanel(dfn) {
   const links = document.querySelectorAll(`a[href="${href}"]`);
 
   /** @type {HTMLElement} */
-  const panel = hyperHTML`
+  const panel = html`
     <aside class="dfn-panel" id="dfn-panel">
       <b><a class="self-link" href="${href}">Permalink</a></b>
       <b>Referenced in:</b>
@@ -85,7 +87,9 @@ function createPanel(dfn) {
  */
 function referencesToHTML(id, links) {
   if (!links.length) {
-    return hyperHTML`<ul><li>Not referenced in this document.</li></ul>`;
+    return html`<ul>
+      <li>Not referenced in this document.</li>
+    </ul>`;
   }
 
   /** @type {Map<string, string[]>} */
@@ -116,12 +120,16 @@ function referencesToHTML(id, links) {
    * @returns {HTMLLIElement}
    */
   const listItemToHTML = entry =>
-    hyperHTML`<li>${toLinkProps(entry).map(
-      link => hyperHTML`<a href="#${link.id}">${link.title}</a>${" "}`
-    )}</li>`;
+    html`<li>
+      ${toLinkProps(entry).map(
+        link => html`<a href="#${link.id}">${link.title}</a>${" "}`
+      )}
+    </li>`;
 
   const listItems = [...titleToIDs].map(listItemToHTML);
-  return hyperHTML`<ul>${listItems}</ul>`;
+  return html`<ul>
+    ${listItems}
+  </ul>`;
 }
 
 /** @param {HTMLAnchorElement} link */

--- a/src/core/dfn-panel.js
+++ b/src/core/dfn-panel.js
@@ -2,7 +2,7 @@
 // self link to the selected dfn. Based on Bikeshed's dfn panels at
 // https://github.com/tabatkins/bikeshed/blob/ef44162c2e/bikeshed/dfnpanels.py
 import { fetchAsset } from "./text-loader.js";
-import { html } from "./import-maps.js";
+import { html as hyperHTML } from "./import-maps.js";
 import { norm } from "./utils.js";
 
 export const name = "core/dfn-panel";
@@ -10,9 +10,7 @@ export const name = "core/dfn-panel";
 export async function run() {
   const css = await loadStyle();
   document.head.insertBefore(
-    html`<style>
-      ${css}
-    </style>`,
+    hyperHTML`<style>${css}</style>`,
     document.querySelector("link")
   );
 
@@ -70,7 +68,7 @@ function createPanel(dfn) {
   const links = document.querySelectorAll(`a[href="${href}"]`);
 
   /** @type {HTMLElement} */
-  const panel = html`
+  const panel = hyperHTML`
     <aside class="dfn-panel" id="dfn-panel">
       <b><a class="self-link" href="${href}">Permalink</a></b>
       <b>Referenced in:</b>
@@ -87,9 +85,7 @@ function createPanel(dfn) {
  */
 function referencesToHTML(id, links) {
   if (!links.length) {
-    return html`<ul>
-      <li>Not referenced in this document.</li>
-    </ul>`;
+    return hyperHTML`<ul><li>Not referenced in this document.</li></ul>`;
   }
 
   /** @type {Map<string, string[]>} */
@@ -120,16 +116,12 @@ function referencesToHTML(id, links) {
    * @returns {HTMLLIElement}
    */
   const listItemToHTML = entry =>
-    html`<li>
-      ${toLinkProps(entry).map(
-        link => html`<a href="#${link.id}">${link.title}</a>${" "}`
-      )}
-    </li>`;
+    hyperHTML`<li>${toLinkProps(entry).map(
+      link => hyperHTML`<a href="#${link.id}">${link.title}</a>${" "}`
+    )}</li>`;
 
   const listItems = [...titleToIDs].map(listItemToHTML);
-  return html`<ul>
-    ${listItems}
-  </ul>`;
+  return hyperHTML`<ul>${listItems}</ul>`;
 }
 
 /** @param {HTMLAnchorElement} link */

--- a/src/core/examples.js
+++ b/src/core/examples.js
@@ -8,7 +8,7 @@
 
 import { addId, getIntlData } from "./utils.js";
 import { fetchAsset } from "./text-loader.js";
-import { hyperHTML as html } from "./import-maps.js";
+import { html } from "./import-maps.js";
 import { pub } from "./pubsubhub.js";
 
 export const name = "core/examples";

--- a/src/core/exporter.js
+++ b/src/core/exporter.js
@@ -8,7 +8,7 @@
 
 import { removeCommentNodes, removeReSpec } from "./utils.js";
 import { expose } from "./expose-modules.js";
-import { hyperHTML } from "./import-maps.js";
+import { html } from "./import-maps.js";
 import { pub } from "./pubsubhub.js";
 
 const mimeTypes = new Map([
@@ -77,14 +77,14 @@ function cleanup(cloneDoc) {
     "meta[charset], meta[content*='charset=']"
   );
   if (!metaCharset) {
-    metaCharset = hyperHTML`<meta charset="utf-8">`;
+    metaCharset = html`<meta charset="utf-8" />`;
   }
   insertions.appendChild(metaCharset);
 
   // Add meta generator
   const respecVersion = `ReSpec ${window.respecVersion || "Developer Channel"}`;
-  const metaGenerator = hyperHTML`
-    <meta name="generator" content="${respecVersion}">
+  const metaGenerator = html`
+    <meta name="generator" content="${respecVersion}" />
   `;
 
   insertions.appendChild(metaGenerator);

--- a/src/core/figures.js
+++ b/src/core/figures.js
@@ -11,7 +11,7 @@ import {
   showInlineWarning,
   wrapInner,
 } from "./utils.js";
-import { hyperHTML } from "./import-maps.js";
+import { html } from "./import-maps.js";
 
 export const name = "core/figures";
 
@@ -58,8 +58,10 @@ export function run() {
   if (tof.length && tofElement) {
     decorateTableOfFigures(tofElement);
     tofElement.append(
-      hyperHTML`<h2>${l10n.list_of_figures}</h2>`,
-      hyperHTML`<ul class='tof'>${tof}</ul>`
+      html`<h2>${l10n.list_of_figures}</h2>`,
+      html`<ul class="tof">
+        ${tof}
+      </ul>`
     );
   }
 }
@@ -92,8 +94,8 @@ function decorateFigure(figure, caption, i) {
   const title = caption.textContent;
   addId(figure, "fig", title);
   // set proper caption title
-  wrapInner(caption, hyperHTML`<span class='fig-title'>`);
-  caption.prepend(l10n.fig, hyperHTML`<bdi class='figno'>${i + 1}</bdi>`, " ");
+  wrapInner(caption, html`<span class="fig-title"></span>`);
+  caption.prepend(l10n.fig, html`<bdi class="figno">${i + 1}</bdi>`, " ");
 }
 
 /**
@@ -106,8 +108,8 @@ function getTableOfFiguresListItem(figureId, caption) {
   tofCaption.querySelectorAll("a").forEach(anchor => {
     renameElement(anchor, "span").removeAttribute("href");
   });
-  return hyperHTML`<li class='tofline'>
-    <a class='tocxref' href='${`#${figureId}`}'>${tofCaption.childNodes}</a>
+  return html`<li class="tofline">
+    <a class="tocxref" href="${`#${figureId}`}">${tofCaption.childNodes}</a>
   </li>`;
 }
 

--- a/src/core/highlight.js
+++ b/src/core/highlight.js
@@ -5,7 +5,7 @@
  * Performs syntax highlighting to all pre and code elements.
  */
 import { fetchAsset } from "./text-loader.js";
-import { hyperHTML as html } from "./import-maps.js";
+import { html } from "./import-maps.js";
 import { msgIdGenerator } from "./utils.js";
 import { workerPromise } from "./worker.js";
 export const name = "core/highlight";

--- a/src/core/id-headers.js
+++ b/src/core/id-headers.js
@@ -5,7 +5,7 @@
 
 export const name = "core/id-headers";
 import { addId } from "./utils.js";
-import { hyperHTML } from "./import-maps.js";
+import { html } from "./import-maps.js";
 
 export function run(conf) {
   /** @type {NodeListOf<HTMLElement>} */
@@ -20,7 +20,7 @@ export function run(conf) {
       id = h.parentElement.id || h.id;
     }
     if (!conf.addSectionLinks) continue;
-    h.appendChild(hyperHTML`
+    h.appendChild(html`
       <a href="${`#${id}`}" class="self-link" aria-label="§"></a>
     `);
   }

--- a/src/core/import-maps.js
+++ b/src/core/import-maps.js
@@ -3,9 +3,9 @@
 
 import * as _idb from "../../node_modules/idb/build/esm/index.js";
 import * as _webidl2 from "../../node_modules/webidl2/index.js";
-import _hyperHTML from "../../node_modules/hyperhtml/esm.js";
 import _marked from "../../node_modules/marked/lib/marked.esm.js";
 import _pluralize from "../../js/deps/builds/pluralize.js";
+import hyperHTML from "../../node_modules/hyperhtml/esm.js";
 
 /** @type {import("idb")} */
 // @ts-ignore
@@ -13,7 +13,7 @@ export const idb = _idb;
 export const webidl2 = _webidl2;
 /** @type {import("hyperhtml").default} */
 // @ts-ignore
-export const hyperHTML = _hyperHTML;
+export const html = hyperHTML;
 /** @type {import("marked")} */
 // @ts-ignore
 export const marked = _marked;

--- a/src/core/informative.js
+++ b/src/core/informative.js
@@ -2,7 +2,7 @@
 // Module core/informative
 // Mark specific sections as informative, based on CSS
 import { getIntlData } from "../core/utils.js";
-import { hyperHTML } from "./import-maps.js";
+import { html } from "./import-maps.js";
 
 export const name = "core/informative";
 
@@ -31,6 +31,6 @@ export function run() {
     .map(informative => informative.querySelector("h2, h3, h4, h5, h6"))
     .filter(heading => heading)
     .forEach(heading => {
-      heading.after(hyperHTML`<p><em>${l10n.informative}</em></p>`);
+      heading.after(html`<p><em>${l10n.informative}</em></p>`);
     });
 }

--- a/src/core/inline-idl-parser.js
+++ b/src/core/inline-idl-parser.js
@@ -3,7 +3,7 @@
 //  and renders its components as HTML
 
 import { htmlJoinComma, showInlineError } from "./utils.js";
-import { hyperHTML } from "./import-maps.js";
+import { html } from "./import-maps.js";
 const idlPrimitiveRegex = /^[a-z]+(\s+[a-z]+)+$/; // {{unrestricted double}} {{ double }}
 const exceptionRegex = /\B"([^"]*)"\B/; // {{ "SomeException" }}
 const methodRegex = /(\w+)\((.*)\)$/;
@@ -141,7 +141,7 @@ function renderBase(details) {
   // Check if base is a local variable in a section
   const { identifier, renderParent } = details;
   if (renderParent) {
-    return hyperHTML`<a data-xref-type="_IDL_"><code>${identifier}</code></a>`;
+    return html`<a data-xref-type="_IDL_"><code>${identifier}</code></a>`;
   }
 }
 
@@ -153,12 +153,14 @@ function renderInternalSlot(details) {
   const { identifier, parent, renderParent } = details;
   const { identifier: linkFor } = parent || {};
   const lt = `[[${identifier}]]`;
-  const html = hyperHTML`${parent && renderParent ? "." : ""}<a
-    data-xref-type="attribute"
-    data-link-for=${linkFor}
-    data-xref-for=${linkFor}
-    data-lt="${lt}"><code>[[${identifier}]]</code></a>`;
-  return html;
+  const element = html`${parent && renderParent ? "." : ""}<a
+      data-xref-type="attribute"
+      data-link-for=${linkFor}
+      data-xref-for=${linkFor}
+      data-lt="${lt}"
+      ><code>[[${identifier}]]</code></a
+    >`;
+  return element;
 }
 
 /**
@@ -168,12 +170,13 @@ function renderInternalSlot(details) {
 function renderAttribute(details) {
   const { parent, identifier, renderParent } = details;
   const { identifier: linkFor } = parent || {};
-  const html = hyperHTML`${renderParent ? "." : ""}<a
+  const element = html`${renderParent ? "." : ""}<a
       data-xref-type="attribute|dict-member"
       data-link-for="${linkFor}"
       data-xref-for="${linkFor}"
-    ><code>${identifier}</code></a>`;
-  return html;
+      ><code>${identifier}</code></a
+    >`;
+  return element;
 }
 
 /**
@@ -183,15 +186,16 @@ function renderAttribute(details) {
 function renderMethod(details) {
   const { args, identifier, type, parent, renderParent } = details;
   const { identifier: linkFor } = parent || {};
-  const argsText = htmlJoinComma(args, arg => hyperHTML`<var>${arg}</var>`);
+  const argsText = htmlJoinComma(args, arg => html`<var>${arg}</var>`);
   const searchText = `${identifier}(${args.join(", ")})`;
-  const html = hyperHTML`${parent && renderParent ? "." : ""}<a
-    data-xref-type="${type}"
-    data-link-for="${linkFor}"
-    data-xref-for="${linkFor}"
-    data-lt="${searchText}"
-    ><code>${identifier}</code></a><code>(${argsText})</code>`;
-  return html;
+  const element = html`${parent && renderParent ? "." : ""}<a
+      data-xref-type="${type}"
+      data-link-for="${linkFor}"
+      data-xref-for="${linkFor}"
+      data-lt="${searchText}"
+      ><code>${identifier}</code></a
+    ><code>(${argsText})</code>`;
+  return element;
 }
 
 /**
@@ -203,13 +207,14 @@ function renderMethod(details) {
 function renderEnum(details) {
   const { identifier, enumValue, parent } = details;
   const forContext = parent ? parent.identifier : identifier;
-  const html = hyperHTML`"<a
-    data-xref-type="enum-value"
-    data-link-for="${forContext}"
-    data-xref-for="${forContext}"
-    data-lt="${!enumValue ? "the-empty-string" : null}"
-    ><code>${enumValue}</code></a>"`;
-  return html;
+  const element = html`"<a
+      data-xref-type="enum-value"
+      data-link-for="${forContext}"
+      data-xref-for="${forContext}"
+      data-lt="${!enumValue ? "the-empty-string" : null}"
+      ><code>${enumValue}</code></a
+    >"`;
+  return element;
 }
 
 /**
@@ -219,11 +224,10 @@ function renderEnum(details) {
  */
 function renderException(details) {
   const { identifier } = details;
-  const html = hyperHTML`"<a
-    data-cite="WebIDL"
-    data-xref-type="exception"
-    ><code>${identifier}</code></a>"`;
-  return html;
+  const element = html`"<a data-cite="WebIDL" data-xref-type="exception"
+      ><code>${identifier}</code></a
+    >"`;
+  return element;
 }
 
 /**
@@ -233,11 +237,10 @@ function renderException(details) {
  */
 function renderIdlPrimitiveType(details) {
   const { identifier } = details;
-  const html = hyperHTML`<a
-    data-cite="WebIDL"
-    data-xref-type="interface"
-    ><code>${identifier}</code></a>`;
-  return html;
+  const element = html`<a data-cite="WebIDL" data-xref-type="interface"
+    ><code>${identifier}</code></a
+  >`;
+  return element;
 }
 
 /**
@@ -250,11 +253,11 @@ export function idlStringToHtml(str) {
   try {
     results = parseInlineIDL(str);
   } catch (error) {
-    const el = hyperHTML`<span>{{ ${str} }}</span>`;
+    const el = html`<span>{{ ${str} }}</span>`;
     showInlineError(el, error.message, "Error: Invalid inline IDL string");
     return el;
   }
-  const render = hyperHTML(document.createDocumentFragment());
+  const render = html(document.createDocumentFragment());
   const output = [];
   for (const details of results) {
     switch (details.type) {

--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -15,7 +15,7 @@ import {
   showInlineError,
   showInlineWarning,
 } from "./utils.js";
-import { hyperHTML } from "./import-maps.js";
+import { html } from "./import-maps.js";
 import { idlStringToHtml } from "./inline-idl-parser.js";
 import { renderInlineCitation } from "./render-biblio.js";
 
@@ -81,11 +81,12 @@ function inlineElementMatches(matched) {
   const [xrefType, xrefFor, textContent] = attribute
     ? ["element-attr", element, attribute]
     : ["element", null, element];
-  const html = hyperHTML`<code><a
-    data-xref-type="${xrefType}"
-    data-xref-for="${xrefFor}"
-    >${textContent}</a></code>`;
-  return html;
+  const code = html`<code
+    ><a data-xref-type="${xrefType}" data-xref-for="${xrefFor}"
+      >${textContent}</a
+    ></code
+  >`;
+  return code;
 }
 
 /**
@@ -94,7 +95,7 @@ function inlineElementMatches(matched) {
  */
 function inlineRFC2119Matches(matched) {
   const value = norm(matched);
-  const nodeElement = hyperHTML`<em class="rfc2119" title="${value}">${value}</em>`;
+  const nodeElement = html`<em class="rfc2119" title="${value}">${value}</em>`;
   // remember which ones were used
   rfc2119Usage[value] = true;
   return nodeElement;
@@ -108,12 +109,12 @@ function inlineRefMatches(matched) {
   // slices "[[[" at the beginning and "]]]" at the end
   const ref = matched.slice(3, -3).trim();
   if (!ref.startsWith("#")) {
-    return hyperHTML`<a data-cite="${ref}"></a>`;
+    return html`<a data-cite="${ref}"></a>`;
   }
   if (document.querySelector(ref)) {
-    return hyperHTML`<a href="${ref}"></a>`;
+    return html`<a href="${ref}"></a>`;
   }
-  const badReference = hyperHTML`<span>${matched}</span>`;
+  const badReference = html`<span>${matched}</span>`;
   showInlineError(
     badReference, // cite element
     `Wasn't able to expand ${matched} as it didn't match any id in the document.`,
@@ -172,7 +173,7 @@ function inlineBibrefMatches(matched, txt, conf) {
 function inlineAbbrMatches(matched, txt, abbrMap) {
   return txt.parentElement.tagName === "ABBR"
     ? matched
-    : hyperHTML`<abbr title="${abbrMap.get(matched)}">${matched}</abbr>`;
+    : html`<abbr title="${abbrMap.get(matched)}">${matched}</abbr>`;
 }
 
 /**
@@ -184,7 +185,7 @@ function inlineVariableMatches(matched) {
   // remove "|" at the beginning and at the end, then split at an optional `:`
   const matches = matched.slice(1, -1).split(":", 2);
   const [varName, type] = matches.map(s => s.trim());
-  return hyperHTML`<var data-type="${type}">${varName}</var>`;
+  return html`<var data-type="${type}">${varName}</var>`;
 }
 
 /**
@@ -203,12 +204,17 @@ function inlineAnchorMatches(matched) {
     : [null, content];
   const processedContent = processInlineContent(text);
   const forContext = isFor ? norm(isFor) : null;
-  return hyperHTML`<a data-link-for="${forContext}" data-xref-for="${forContext}" data-lt="${linkingText}">${processedContent}</a>`;
+  return html`<a
+    data-link-for="${forContext}"
+    data-xref-for="${forContext}"
+    data-lt="${linkingText}"
+    >${processedContent}</a
+  >`;
 }
 
 function inlineCodeMatches(matched) {
   const clean = matched.slice(1, -1); // Chop ` and `
-  return hyperHTML`<code>${clean}</code>`;
+  return html`<code>${clean}</code>`;
 }
 
 function processInlineContent(text) {

--- a/src/core/issues-notes.js
+++ b/src/core/issues-notes.js
@@ -13,7 +13,7 @@
 // manually numbered, a link to the issue is created using issueBase and the issue number
 import { addId, getIntlData, joinAnd, parents } from "./utils.js";
 import { fetchAsset } from "./text-loader.js";
-import { hyperHTML } from "./import-maps.js";
+import { html } from "./import-maps.js";
 import { pub } from "./pubsubhub.js";
 
 export const name = "core/issues-notes";
@@ -116,10 +116,14 @@ function handleIssues(ins, ghIssues, conf) {
     if (!isInline) {
       const cssClass = isFeatureAtRisk ? `${type} atrisk` : type;
       const ariaRole = type === "note" ? "note" : null;
-      const div = hyperHTML`<div class="${cssClass}" role="${ariaRole}"></div>`;
+      const div = html`<div class="${cssClass}" role="${ariaRole}"></div>`;
       const title = document.createElement("span");
-      const titleParent = hyperHTML`
-        <div role='heading' class='${`${type}-title marker`}'>${title}</div>`;
+      const titleParent = html` <div
+        role="heading"
+        class="${`${type}-title marker`}"
+      >
+        ${title}
+      </div>`;
       addId(titleParent, "h", type);
       let text = displayType;
       if (inno.id) {
@@ -244,9 +248,9 @@ function getIssueType(inno) {
 function linkToIssueTracker(dataNum, conf, { isFeatureAtRisk = false } = {}) {
   // Set issueBase to cause issue to be linked to the external issue tracker
   if (!isFeatureAtRisk && conf.issueBase) {
-    return hyperHTML`<a href='${conf.issueBase + dataNum}'/>`;
+    return html`<a href="${conf.issueBase + dataNum}" />`;
   } else if (isFeatureAtRisk && conf.atRiskBase) {
-    return hyperHTML`<a href='${conf.atRiskBase + dataNum}'/>`;
+    return html`<a href="${conf.atRiskBase + dataNum}" />`;
   }
 }
 
@@ -257,11 +261,9 @@ function linkToIssueTracker(dataNum, conf, { isFeatureAtRisk = false } = {}) {
 function createIssueSummaryEntry(l10nIssue, report, id) {
   const issueNumberText = `${l10nIssue} ${report.number}`;
   const title = report.title
-    ? hyperHTML`<span style="text-transform: none">: ${report.title}</span>`
+    ? html`<span style="text-transform: none">: ${report.title}</span>`
     : "";
-  return hyperHTML`
-    <li><a href="${`#${id}`}">${issueNumberText}</a>${title}</li>
-  `;
+  return html` <li><a href="${`#${id}`}">${issueNumberText}</a>${title}</li> `;
 }
 
 /**
@@ -275,7 +277,7 @@ function makeIssueSectionSummary(issueList) {
 
   issueList.hasChildNodes()
     ? issueSummaryElement.append(issueList)
-    : issueSummaryElement.append(hyperHTML`<p>${l10n.no_issues_in_spec}</p>`);
+    : issueSummaryElement.append(html`<p>${l10n.no_issues_in_spec}</p>`);
   if (
     !heading ||
     (heading && heading !== issueSummaryElement.firstElementChild)
@@ -301,11 +303,11 @@ function createLabelsGroup(labels, title, repoURL) {
   }
   if (labelNames.length) {
     const ariaLabel = `This issue is labelled as ${joinedNames}.`;
-    return hyperHTML`<span
-      class="issue-label"
-      aria-label="${ariaLabel}">: ${title}${labelsGroup}</span>`;
+    return html`<span class="issue-label" aria-label="${ariaLabel}"
+      >: ${title}${labelsGroup}</span
+    >`;
   }
-  return hyperHTML`<span class="issue-label">: ${title}${labelsGroup}</span>`;
+  return html`<span class="issue-label">: ${title}${labelsGroup}</span>`;
 }
 
 /** @param {string} bgColorHex background color as a hex value without '#' */
@@ -323,10 +325,12 @@ function createLabel(label, repoURL) {
   issuesURL.searchParams.set("q", `is:issue is:open label:"${label.name}"`);
   const color = textColorFromBgColor(bgColor);
   const style = `background-color: #${bgColor}; color: ${color}`;
-  return hyperHTML`<a
+  return html`<a
     class="respec-gh-label"
     style="${style}"
-    href="${issuesURL.href}">${name}</a>`;
+    href="${issuesURL.href}"
+    >${name}</a
+  >`;
 }
 
 /**
@@ -373,7 +377,9 @@ export async function run(conf) {
   const css = await cssPromise;
   const { head: headElem } = document;
   headElem.insertBefore(
-    hyperHTML`<style>${css}</style>`,
+    html`<style>
+      ${css}
+    </style>`,
     headElem.querySelector("link")
   );
   handleIssues(issuesAndNotes, ghIssues, conf);

--- a/src/core/issues-notes.js
+++ b/src/core/issues-notes.js
@@ -13,7 +13,7 @@
 // manually numbered, a link to the issue is created using issueBase and the issue number
 import { addId, getIntlData, joinAnd, parents } from "./utils.js";
 import { fetchAsset } from "./text-loader.js";
-import { html } from "./import-maps.js";
+import { html as hyperHTML } from "./import-maps.js";
 import { pub } from "./pubsubhub.js";
 
 export const name = "core/issues-notes";
@@ -116,14 +116,10 @@ function handleIssues(ins, ghIssues, conf) {
     if (!isInline) {
       const cssClass = isFeatureAtRisk ? `${type} atrisk` : type;
       const ariaRole = type === "note" ? "note" : null;
-      const div = html`<div class="${cssClass}" role="${ariaRole}"></div>`;
+      const div = hyperHTML`<div class="${cssClass}" role="${ariaRole}"></div>`;
       const title = document.createElement("span");
-      const titleParent = html` <div
-        role="heading"
-        class="${`${type}-title marker`}"
-      >
-        ${title}
-      </div>`;
+      const titleParent = hyperHTML`
+        <div role='heading' class='${`${type}-title marker`}'>${title}</div>`;
       addId(titleParent, "h", type);
       let text = displayType;
       if (inno.id) {
@@ -248,9 +244,9 @@ function getIssueType(inno) {
 function linkToIssueTracker(dataNum, conf, { isFeatureAtRisk = false } = {}) {
   // Set issueBase to cause issue to be linked to the external issue tracker
   if (!isFeatureAtRisk && conf.issueBase) {
-    return html`<a href="${conf.issueBase + dataNum}" />`;
+    return hyperHTML`<a href='${conf.issueBase + dataNum}'/>`;
   } else if (isFeatureAtRisk && conf.atRiskBase) {
-    return html`<a href="${conf.atRiskBase + dataNum}" />`;
+    return hyperHTML`<a href='${conf.atRiskBase + dataNum}'/>`;
   }
 }
 
@@ -261,9 +257,11 @@ function linkToIssueTracker(dataNum, conf, { isFeatureAtRisk = false } = {}) {
 function createIssueSummaryEntry(l10nIssue, report, id) {
   const issueNumberText = `${l10nIssue} ${report.number}`;
   const title = report.title
-    ? html`<span style="text-transform: none">: ${report.title}</span>`
+    ? hyperHTML`<span style="text-transform: none">: ${report.title}</span>`
     : "";
-  return html` <li><a href="${`#${id}`}">${issueNumberText}</a>${title}</li> `;
+  return hyperHTML`
+    <li><a href="${`#${id}`}">${issueNumberText}</a>${title}</li>
+  `;
 }
 
 /**
@@ -277,7 +275,7 @@ function makeIssueSectionSummary(issueList) {
 
   issueList.hasChildNodes()
     ? issueSummaryElement.append(issueList)
-    : issueSummaryElement.append(html`<p>${l10n.no_issues_in_spec}</p>`);
+    : issueSummaryElement.append(hyperHTML`<p>${l10n.no_issues_in_spec}</p>`);
   if (
     !heading ||
     (heading && heading !== issueSummaryElement.firstElementChild)
@@ -303,11 +301,11 @@ function createLabelsGroup(labels, title, repoURL) {
   }
   if (labelNames.length) {
     const ariaLabel = `This issue is labelled as ${joinedNames}.`;
-    return html`<span class="issue-label" aria-label="${ariaLabel}"
-      >: ${title}${labelsGroup}</span
-    >`;
+    return hyperHTML`<span
+      class="issue-label"
+      aria-label="${ariaLabel}">: ${title}${labelsGroup}</span>`;
   }
-  return html`<span class="issue-label">: ${title}${labelsGroup}</span>`;
+  return hyperHTML`<span class="issue-label">: ${title}${labelsGroup}</span>`;
 }
 
 /** @param {string} bgColorHex background color as a hex value without '#' */
@@ -325,12 +323,10 @@ function createLabel(label, repoURL) {
   issuesURL.searchParams.set("q", `is:issue is:open label:"${label.name}"`);
   const color = textColorFromBgColor(bgColor);
   const style = `background-color: #${bgColor}; color: ${color}`;
-  return html`<a
+  return hyperHTML`<a
     class="respec-gh-label"
     style="${style}"
-    href="${issuesURL.href}"
-    >${name}</a
-  >`;
+    href="${issuesURL.href}">${name}</a>`;
 }
 
 /**
@@ -377,9 +373,7 @@ export async function run(conf) {
   const css = await cssPromise;
   const { head: headElem } = document;
   headElem.insertBefore(
-    html`<style>
-      ${css}
-    </style>`,
+    hyperHTML`<style>${css}</style>`,
     headElem.querySelector("link")
   );
   handleIssues(issuesAndNotes, ghIssues, conf);

--- a/src/core/mdn-annotation.js
+++ b/src/core/mdn-annotation.js
@@ -1,7 +1,7 @@
 // @ts-check
 import { fetchAndCache } from "./utils.js";
 import { fetchAsset } from "./text-loader.js";
-import { hyperHTML } from "./import-maps.js";
+import { html } from "./import-maps.js";
 
 export const name = "core/mdn-annotation";
 
@@ -53,7 +53,7 @@ function insertMDNBox(node) {
     // If the target ancestor already has a mdnBox inserted, we just use it
     return targetSibling;
   }
-  const mdnBox = hyperHTML`<aside class="mdn before wrapped"></aside>`;
+  const mdnBox = html`<aside class="mdn before wrapped"></aside>`;
   parentNode.insertBefore(mdnBox, targetAncestor);
   return mdnBox;
 }
@@ -63,7 +63,7 @@ function attachMDNDetail(container, mdnSpec) {
   container.innerHTML += `<button onclick="toggleMDNStatus(this.parentNode)" aria-label="Expand MDN details"><b>MDN</b></button>`;
   const mdnSubPath = slug.slice(slug.indexOf("/") + 1);
   const href = `${MDN_URL_BASE}${slug}`;
-  const mdnDetail = hyperHTML`
+  const mdnDetail = html`
     <div>
       <a title="${summary}" href="${href}">${mdnSubPath}</a>
     </div>
@@ -77,7 +77,7 @@ function attachMDNBrowserSupport(container, mdnSpec) {
     container.innerHTML += `<p class="nosupportdata">No support data.</p>`;
     return;
   }
-  const supportTable = hyperHTML`<p class="mdnsupport">
+  const supportTable = html`<p class="mdnsupport">
     ${buildBrowserSupportTable(mdnSpec.support)}
   </p>`;
   container.appendChild(supportTable);
@@ -87,11 +87,10 @@ function buildBrowserSupportTable(support) {
   function createRow(browserId, yesNoUnknown, version) {
     const displayStatus = yesNoUnknown === "Unknown" ? "?" : yesNoUnknown;
     const classList = `${browserId} ${yesNoUnknown.toLowerCase()}`;
-    return hyperHTML`
-      <span class="${classList}">
-        <span class="browser-name">${MDN_BROWSERS[browserId]}</span>
-        <span class="version">${version ? version : displayStatus}</span>
-      </span>`;
+    return html` <span class="${classList}">
+      <span class="browser-name">${MDN_BROWSERS[browserId]}</span>
+      <span class="version">${version ? version : displayStatus}</span>
+    </span>`;
   }
 
   function createRowFromBrowserData(browserId, versionData) {
@@ -149,11 +148,15 @@ export async function run(conf) {
     maxAge
   );
   const mdnCss = await mdnCssPromise;
-  document.head.appendChild(hyperHTML`<style>${mdnCss}</style>`);
-  document.head.appendChild(hyperHTML`<script>
-     function toggleMDNStatus(div) {
-       div.parentNode.classList.toggle('wrapped');
-     }
+  document.head.appendChild(
+    html`<style>
+      ${mdnCss}
+    </style>`
+  );
+  document.head.appendChild(html`<script>
+    function toggleMDNStatus(div) {
+      div.parentNode.classList.toggle("wrapped");
+    }
   </script>`);
   const nodesWithId = document.querySelectorAll("[id]");
   [...nodesWithId]

--- a/src/core/render-biblio.js
+++ b/src/core/render-biblio.js
@@ -4,7 +4,7 @@
 
 import { addId, getIntlData } from "./utils.js";
 import { biblio } from "./biblio.js";
-import { hyperHTML } from "./import-maps.js";
+import { html } from "./import-maps.js";
 import { pub } from "./pubsubhub.js";
 
 export const name = "core/render-biblio";
@@ -75,10 +75,10 @@ export function run(conf) {
 
   const refSection =
     document.querySelector("section#references") ||
-    hyperHTML`<section id='references'></section>`;
+    html`<section id="references"></section>`;
 
   if (!document.querySelector("section#references > h2")) {
-    refSection.prepend(hyperHTML`<h2>${l10n.references}</h2>`);
+    refSection.prepend(html`<h2>${l10n.references}</h2>`);
   }
 
   refSection.classList.add("appendix");
@@ -87,12 +87,11 @@ export function run(conf) {
     const refs = type === "Normative" ? norms : informs;
     if (!refs.length) continue;
 
-    const sec = hyperHTML`
-      <section>
-        <h3>${
-          type === "Normative" ? l10n.norm_references : l10n.info_references
-        }</h3>
-      </section>`;
+    const sec = html` <section>
+      <h3>
+        ${type === "Normative" ? l10n.norm_references : l10n.info_references}
+      </h3>
+    </section>`;
     addId(sec);
 
     const { goodRefs, badRefs } = refs.map(toRefContent).reduce(
@@ -123,10 +122,9 @@ export function run(conf) {
         a.ref.toLocaleLowerCase().localeCompare(b.ref.toLocaleLowerCase())
       );
 
-    sec.appendChild(hyperHTML`
-      <dl class='bibliography'>
-        ${refsToShow.map(showRef)}
-      </dl>`);
+    sec.appendChild(html` <dl class="bibliography">
+      ${refsToShow.map(showRef)}
+    </dl>`);
     refSection.appendChild(sec);
 
     const aliases = getAliases(goodRefs);
@@ -172,7 +170,9 @@ function toRefContent(ref) {
 export function renderInlineCitation(ref) {
   const key = ref.replace(/^(!|\?)/, "");
   const href = `#bib-${key.toLowerCase()}`;
-  return hyperHTML`[<cite><a class="bibref" href="${href}" data-link-type="biblio">${key}</a></cite>]`;
+  return html`[<cite
+      ><a class="bibref" href="${href}" data-link-type="biblio">${key}</a></cite
+    >]`;
 }
 
 /**
@@ -181,12 +181,12 @@ export function renderInlineCitation(ref) {
 function showRef({ ref, refcontent }) {
   const refId = `bib-${ref.toLowerCase()}`;
   if (refcontent) {
-    return hyperHTML`
+    return html`
       <dt id="${refId}">[${ref}]</dt>
       <dd>${{ html: stringifyReference(refcontent) }}</dd>
     `;
   } else {
-    return hyperHTML`
+    return html`
       <dt id="${refId}">[${ref}]</dt>
       <dd><em class="respec-offending-element">Reference not found.</em></dd>
     `;
@@ -209,7 +209,7 @@ export function wireReference(rawRef, target = "_blank") {
   const ref = Object.assign({}, defaultsReference, rawRef);
   const authors = ref.authors.join("; ") + (ref.etAl ? " et al" : "");
   const status = REF_STATUSES.get(ref.status) || ref.status;
-  return hyperHTML.wire(ref)`
+  return html.wire(ref)`
     <cite>
       <a
         href="${ref.href}"

--- a/src/core/requirements.js
+++ b/src/core/requirements.js
@@ -1,0 +1,40 @@
+// @ts-check
+// Module core/requirements
+// This module does two things:
+//
+// 1.  It finds and marks all requirements. These are elements with class "req".
+//     When a requirement is found, it is reported using the "req" event. This
+//     can be used by a containing shell to extract them.
+//     Requirements are automatically numbered.
+//
+// 2.  It allows referencing requirements by their ID simply using an empty <a>
+//     element with its href pointing to the requirement it should be referencing
+//     and a class of "reqRef".
+import { html } from "./import-maps.js";
+import { pub } from "./pubsubhub.js";
+
+export const name = "core/requirements";
+
+export function run() {
+  document.querySelectorAll(".req").forEach((req, i) => {
+    const frag = `#${req.getAttribute("id")}`;
+    const el = html`<a href="${frag}">Req. ${i + 1}</a>`;
+    req.prepend(el, ": ");
+  });
+
+  document.querySelectorAll("a.reqRef[href]").forEach(ref => {
+    const href = ref.getAttribute("href");
+    const id = href.substring(1); // href looks like `#id`
+    const req = document.getElementById(id);
+    let txt;
+    if (req) {
+      txt = req.querySelector("a:first-child").textContent;
+    } else {
+      txt = `Req. not found '${id}'`;
+      const msg = `Requirement not found in element \`a.reqRef\`: ${id}`;
+      pub("error", msg);
+      console.warn(msg, ref);
+    }
+    ref.textContent = txt;
+  });
+}

--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -11,7 +11,7 @@
 //  - maxTocLevel: only generate a TOC so many levels deep
 
 import { addId, getIntlData, parents, renameElement } from "./utils.js";
-import { hyperHTML } from "./import-maps.js";
+import { html } from "./import-maps.js";
 
 const lowerHeaderTags = ["h2", "h3", "h4", "h5", "h6"];
 const headerTags = ["h1", ...lowerHeaderTags];
@@ -65,7 +65,7 @@ function scanSections(sections, maxTocLevel, { prefix = "" } = {}) {
     return null;
   }
   /** @type {HTMLElement} */
-  const ol = hyperHTML`<ol class='toc'>`;
+  const ol = html`<ol class="toc"></ol>`;
   for (const section of sections) {
     if (section.isAppendix && !prefix && !appendixMode) {
       lastNonAppendix = index;
@@ -87,7 +87,7 @@ function scanSections(sections, maxTocLevel, { prefix = "" } = {}) {
 
     if (!section.isIntro) {
       index += 1;
-      section.header.prepend(hyperHTML`<bdi class='secno'>${secno} </bdi>`);
+      section.header.prepend(html`<bdi class="secno">${secno} </bdi>`);
     }
 
     if (level <= maxTocLevel) {
@@ -152,10 +152,10 @@ function getSectionTree(parent, { tocIntroductory = false } = {}) {
  * @param {string} id
  */
 function createTocListItem(header, id) {
-  const anchor = hyperHTML`<a href="${`#${id}`}" class="tocxref"/>`;
+  const anchor = html`<a href="${`#${id}`}" class="tocxref" />`;
   anchor.append(...header.cloneNode(true).childNodes);
   filterHeader(anchor);
-  return hyperHTML`<li class='tocline'>${anchor}</li>`;
+  return html`<li class="tocline">${anchor}</li>`;
 }
 
 /**
@@ -226,8 +226,8 @@ function createTableOfContents(ol) {
   if (!ol) {
     return;
   }
-  const nav = hyperHTML`<nav id="toc">`;
-  const h2 = hyperHTML`<h2 class="introductory">${l10n.toc}</h2>`;
+  const nav = html`<nav id="toc"></nav>`;
+  const h2 = html`<h2 class="introductory">${l10n.toc}</h2>`;
   addId(h2);
   nav.append(h2, ol);
   const ref =
@@ -242,6 +242,8 @@ function createTableOfContents(ol) {
     }
   }
 
-  const link = hyperHTML`<p role='navigation' id='back-to-top'><a href='#title'><abbr title='Back to Top'>&uarr;</abbr></a></p>`;
+  const link = html`<p role="navigation" id="back-to-top">
+    <a href="#title"><abbr title="Back to Top">&uarr;</abbr></a>
+  </p>`;
   document.body.append(link);
 }

--- a/src/core/title.js
+++ b/src/core/title.js
@@ -11,7 +11,7 @@
  */
 
 import { getIntlData, norm, showInlineError } from "./utils.js";
-import { hyperHTML } from "./import-maps.js";
+import { html } from "./import-maps.js";
 export const name = "core/title";
 
 const localizationStrings = {
@@ -28,7 +28,7 @@ const l10n = getIntlData(localizationStrings);
 export function run(conf) {
   /** @type {HTMLElement} */
   const h1Elem =
-    document.querySelector("h1#title") || hyperHTML`<h1 id="title">`;
+    document.querySelector("h1#title") || html`<h1 id="title"></h1>`;
 
   // check existing element is ok to use
   if (h1Elem.isConnected && h1Elem.textContent.trim() === "") {
@@ -62,7 +62,7 @@ function setDocumentTitle(conf, h1Elem) {
 
   if (conf.isPreview && conf.prNumber) {
     const prUrl = conf.prUrl || `${conf.github.repoURL}pull/${conf.prNumber}`;
-    const { childNodes } = hyperHTML`
+    const { childNodes } = html`
       Preview of PR <a href="${prUrl}">#${conf.prNumber}</a>:
     `;
     h1Elem.prepend(...childNodes);

--- a/src/core/ui.js
+++ b/src/core/ui.js
@@ -9,7 +9,7 @@
 //      - save to GitHub
 //  - make a release candidate that people can test
 //  - once we have something decent, merge, ship as 3.2.0
-import { hyperHTML, pluralize } from "./import-maps.js";
+import { html, pluralize } from "./import-maps.js";
 import { fetchAsset } from "./text-loader.js";
 import { markdownToHtml } from "./markdown.js";
 import shortcut from "../../js/shortcut.js";
@@ -45,10 +45,20 @@ function ariaDecorate(elem, ariaMap) {
   });
 }
 
-const respecUI = hyperHTML`<div id='respec-ui' class='removeOnSave' hidden></div>`;
-const menu = hyperHTML`<ul id=respec-menu role=menu aria-labelledby='respec-pill' hidden></ul>`;
-const closeButton = hyperHTML`<button class="close-button" onclick=${() =>
-  ui.closeModal()} title="Close">❌</button>`;
+const respecUI = html`<div id="respec-ui" class="removeOnSave" hidden></div>`;
+const menu = html`<ul
+  id="respec-menu"
+  role="menu"
+  aria-labelledby="respec-pill"
+  hidden
+></ul>`;
+const closeButton = html`<button
+  class="close-button"
+  onclick=${() => ui.closeModal()}
+  title="Close"
+>
+  ❌
+</button>`;
 window.addEventListener("load", () => trapFocus(menu));
 let modal;
 let overlay;
@@ -59,7 +69,7 @@ const buttons = {};
 sub("start-all", () => document.body.prepend(respecUI), { once: true });
 sub("end-all", () => document.body.prepend(respecUI), { once: true });
 
-const respecPill = hyperHTML`<button id='respec-pill' disabled>ReSpec</button>`;
+const respecPill = html`<button id="respec-pill" disabled>ReSpec</button>`;
 respecUI.appendChild(respecPill);
 respecPill.addEventListener("click", e => {
   e.stopPropagation();
@@ -141,10 +151,13 @@ function errWarn(msg, arr, butName, title) {
 
 function createWarnButton(butName, arr, title) {
   const buttonId = `respec-pill-${butName}`;
-  const button = hyperHTML`<button id='${buttonId}' class='respec-info-button'>`;
+  const button = html`<button
+    id="${buttonId}"
+    class="respec-info-button"
+  ></button>`;
   button.addEventListener("click", () => {
     button.setAttribute("aria-expanded", "true");
-    const ol = hyperHTML`<ol class='${`respec-${butName}-list`}'></ol>`;
+    const ol = html`<ol class="${`respec-${butName}-list`}"></ol>`;
     for (const err of arr) {
       const fragment = document
         .createRange()
@@ -187,10 +200,14 @@ export const ui = {
   addCommand(label, handler, keyShort, icon) {
     icon = icon || "";
     const id = `respec-button-${label.toLowerCase().replace(/\s+/, "-")}`;
-    const button = hyperHTML`<button id="${id}" class="respec-option" title="${keyShort}">
+    const button = html`<button
+      id="${id}"
+      class="respec-option"
+      title="${keyShort}"
+    >
       <span class="respec-cmd-icon" aria-hidden="true">${icon}</span> ${label}…
     </button>`;
-    const menuItem = hyperHTML`<li role=menuitem>${button}</li>`;
+    const menuItem = html`<li role="menuitem">${button}</li>`;
     menuItem.addEventListener("click", handler);
     menu.appendChild(menuItem);
     if (keyShort) shortcut.add(keyShort, handler);
@@ -222,13 +239,18 @@ export const ui = {
   freshModal(title, content, currentOwner) {
     if (modal) modal.remove();
     if (overlay) overlay.remove();
-    overlay = hyperHTML`<div id='respec-overlay' class='removeOnSave'></div>`;
+    overlay = html`<div id="respec-overlay" class="removeOnSave"></div>`;
     const id = `${currentOwner.id}-modal`;
     const headingId = `${id}-heading`;
-    modal = hyperHTML`<div id='${id}' class='respec-modal removeOnSave' role='dialog' aria-labelledby='${headingId}'>
+    modal = html`<div
+      id="${id}"
+      class="respec-modal removeOnSave"
+      role="dialog"
+      aria-labelledby="${headingId}"
+    >
       ${closeButton}
       <h3 id="${headingId}">${title}</h3>
-      <div class='inside'>${content}</div>
+      <div class="inside">${content}</div>
     </div>`;
     const ariaMap = new Map([["labelledby", headingId]]);
     ariaDecorate(modal, ariaMap);

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -3,7 +3,7 @@
 // As the name implies, this contains a ragtag gang of methods that just don't fit
 // anywhere else.
 import { lang as docLang } from "./l10n.js";
-import { hyperHTML } from "./import-maps.js";
+import { html } from "./import-maps.js";
 import { pub } from "./pubsubhub.js";
 export const name = "core/utils";
 
@@ -507,8 +507,8 @@ export async function fetchAndCache(input, maxAge = 86400000) {
 
 export function htmlJoinComma(array, mapper = item => item) {
   const items = array.map(mapper);
-  const joined = items.slice(0, -1).map(item => hyperHTML`${item}, `);
-  return hyperHTML`${joined}${items[items.length - 1]}`;
+  const joined = items.slice(0, -1).map(item => html`${item}, `);
+  return html`${joined}${items[items.length - 1]}`;
 }
 
 /**
@@ -523,10 +523,10 @@ export function htmlJoinAnd(array, mapper = item => item) {
     case 1: // "x"
       return items[0];
     case 2: // x and y
-      return hyperHTML`${items[0]}${l10n.x_and_y}${items[1]}`;
+      return html`${items[0]}${l10n.x_and_y}${items[1]}`;
     default: {
       const joined = htmlJoinComma(items.slice(0, -1));
-      return hyperHTML`${joined}${l10n.x_y_and_z}${items[items.length - 1]}`;
+      return html`${joined}${l10n.x_y_and_z}${items[items.length - 1]}`;
     }
   }
 }

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -11,7 +11,7 @@ import {
   xmlEscape,
 } from "./utils.js";
 import { decorateDfn, findDfn } from "./dfn-finder.js";
-import { hyperHTML, webidl2 } from "./import-maps.js";
+import { html, webidl2 } from "./import-maps.js";
 import { addCopyIDLButton } from "./webidl-clipboard.js";
 import { fetchAsset } from "./text-loader.js";
 import { registerDefinition } from "./dfn-map.js";
@@ -32,15 +32,15 @@ const templates = {
     if (!t.trim()) {
       return t;
     }
-    return hyperHTML`<span class='idlSectionComment'>${t}</span>`;
+    return html`<span class="idlSectionComment">${t}</span>`;
   },
   generic(keyword) {
     // Shepherd classifies "interfaces" as starting with capital letters,
     // like Promise, FrozenArray, etc.
     return /^[A-Z]/.test(keyword)
-      ? hyperHTML`<a data-xref-type="interface" data-cite="WebIDL">${keyword}</a>`
+      ? html`<a data-xref-type="interface" data-cite="WebIDL">${keyword}</a>`
       : // Other keywords like sequence, maplike, etc...
-        hyperHTML`<a data-xref-type="dfn" data-cite="WebIDL">${keyword}</a>`;
+        html`<a data-xref-type="dfn" data-cite="WebIDL">${keyword}</a>`;
   },
   reference(wrapped, unescaped, context) {
     if (context.type === "extended-attribute" && context.name !== "Exposed") {
@@ -71,12 +71,13 @@ const templates = {
         }
       }
     }
-    return hyperHTML`<a
-      data-xref-type="${type}" data-cite="${cite}" data-lt="${lt}">${wrapped}</a>`;
+    return html`<a data-xref-type="${type}" data-cite="${cite}" data-lt="${lt}"
+      >${wrapped}</a
+    >`;
   },
   name(escaped, { data, parent }) {
     if (data.idlType && data.idlType.type === "argument-type") {
-      return hyperHTML`<span class="idlParamName">${escaped}</span>`;
+      return html`<span class="idlParamName">${escaped}</span>`;
     }
     const idlLink = defineIdlName(escaped, data, parent);
     if (data.type !== "enum-value") {
@@ -94,28 +95,34 @@ const templates = {
     }
   },
   type(contents) {
-    return hyperHTML`<span class="idlType">${contents}</span>`;
+    return html`<span class="idlType">${contents}</span>`;
   },
   inheritance(contents) {
-    return hyperHTML`<span class="idlSuperclass">${contents}</span>`;
+    return html`<span class="idlSuperclass">${contents}</span>`;
   },
   definition(contents, { data, parent }) {
     const className = getIdlDefinitionClassName(data);
     switch (data.type) {
       case "includes":
       case "enum-value":
-        return hyperHTML`<span class='${className}'>${contents}</span>`;
+        return html`<span class="${className}">${contents}</span>`;
     }
     const parentName = parent ? parent.name : "";
     const { name, idlId } = getNameAndId(data, parentName);
-    return hyperHTML`<span class='${className}' id='${idlId}' data-idl data-title='${name}'>${contents}</span>`;
+    return html`<span
+      class="${className}"
+      id="${idlId}"
+      data-idl
+      data-title="${name}"
+      >${contents}</span
+    >`;
   },
   extendedAttribute(contents) {
-    const result = hyperHTML`<span class="extAttr">${contents}</span>`;
+    const result = html`<span class="extAttr">${contents}</span>`;
     return result;
   },
   extendedAttributeReference(name) {
-    return hyperHTML`<a data-xref-type="extended-attribute">${name}</a>`;
+    return html`<a data-xref-type="extended-attribute">${name}</a>`;
   },
 };
 
@@ -136,12 +143,13 @@ function defineIdlName(escaped, data, parent) {
     }
     decorateDfn(dfn, data, parentName, name);
     const href = `#${dfn.id}`;
-    return hyperHTML`<a
+    return html`<a
       data-link-for="${parentName}"
       data-link-type="${linkType}"
       href="${href}"
       class="internalDFN"
-      ><code>${escaped}</code></a>`;
+      ><code>${escaped}</code></a
+    >`;
   }
 
   const isDefaultJSON =
@@ -149,23 +157,26 @@ function defineIdlName(escaped, data, parent) {
     data.name === "toJSON" &&
     data.extAttrs.some(({ name }) => name === "Default");
   if (isDefaultJSON) {
-    return hyperHTML`<a
-     data-link-type="dfn"
-     data-lt="default toJSON operation">${escaped}</a>`;
+    return html`<a data-link-type="dfn" data-lt="default toJSON operation"
+      >${escaped}</a
+    >`;
   }
   if (!data.partial) {
-    const dfn = hyperHTML`<dfn data-export data-dfn-type="${linkType}">${escaped}</dfn>`;
+    const dfn = html`<dfn data-export data-dfn-type="${linkType}"
+      >${escaped}</dfn
+    >`;
     registerDefinition(dfn, [name]);
     decorateDfn(dfn, data, parentName, name);
     return dfn;
   }
 
-  const unlinkedAnchor = hyperHTML`<a
+  const unlinkedAnchor = html`<a
     data-idl="${data.partial ? "partial" : null}"
     data-link-type="${linkType}"
     data-title="${data.name}"
     data-xref-type="${linkType}"
-    >${escaped}</a>`;
+    >${escaped}</a
+  >`;
 
   const showWarnings =
     name && data.type !== "typedef" && !(data.partial && !dfn);
@@ -297,6 +308,10 @@ function getDefnName(defn) {
   }
 }
 
+/**
+ * @param {Element} idlElement
+ * @param {number} index
+ */
 function renderWebIDL(idlElement, index) {
   let parse;
   try {
@@ -315,9 +330,8 @@ function renderWebIDL(idlElement, index) {
   }
   // we add "idl" as the canonical match, so both "webidl" and "idl" work
   idlElement.classList.add("def", "idl");
-  const html = webidl2.write(parse, { templates });
-  const render = hyperHTML.bind(idlElement);
-  render`${html}`;
+  const highlights = webidl2.write(parse, { templates });
+  html.bind(idlElement)`${highlights}`;
   idlElement.querySelectorAll("[data-idl]").forEach(elem => {
     if (elem.dataset.dfnFor) {
       return;
@@ -348,10 +362,9 @@ function renderWebIDL(idlElement, index) {
  */
 export function addIDLHeader(pre) {
   addHashId(pre, "webidl");
-  const header = hyperHTML`<span class="idlHeader"><a
-      class="self-link"
-      href="${`#${pre.id}`}"
-    >WebIDL</a></span>`;
+  const header = html`<span class="idlHeader"
+    ><a class="self-link" href="${`#${pre.id}`}">WebIDL</a></span
+  >`;
   pre.prepend(header);
   addCopyIDLButton(header);
 }

--- a/src/dini/conformance.js
+++ b/src/dini/conformance.js
@@ -2,7 +2,7 @@
 // Module dini/conformance
 // Handle the conformance section properly.
 import { getIntlData, htmlJoinAnd } from "../core/utils.js";
-import { hyperHTML as html } from "../core/import-maps.js";
+import { html } from "../core/import-maps.js";
 import { pub } from "../core/pubsubhub.js";
 import { renderInlineCitation } from "../core/render-biblio.js";
 import { rfc2119Usage } from "../core/inlines.js";

--- a/src/dini/templates/headers.js
+++ b/src/dini/templates/headers.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { getIntlData } from "../../core/utils.js";
-import { hyperHTML as html } from "../../core/import-maps.js";
+import { html } from "../../core/import-maps.js";
 import { pub } from "../../core/pubsubhub.js";
 import showLink from "./show-link.js";
 import showLogo from "./show-logo.js";

--- a/src/dini/templates/show-link.js
+++ b/src/dini/templates/show-link.js
@@ -1,7 +1,6 @@
 // @ts-check
-import { hyperHTML } from "../../core/import-maps.js";
+import { html } from "../../core/import-maps.js";
 import { pub } from "../../core/pubsubhub.js";
-const html = hyperHTML;
 
 export default link => {
   if (!link.key) {

--- a/src/dini/templates/show-logo.js
+++ b/src/dini/templates/show-logo.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { hyperHTML as html } from "../../core/import-maps.js";
+import { html } from "../../core/import-maps.js";
 import { showInlineWarning } from "../../core/utils.js";
 
 export default obj => {

--- a/src/dini/templates/show-people.js
+++ b/src/dini/templates/show-people.js
@@ -5,7 +5,7 @@ import {
   toShortIsoDate,
 } from "../../core/utils.js";
 import { lang as defaultLang } from "../../core/l10n.js";
-import { hyperHTML as html } from "../../core/import-maps.js";
+import { html } from "../../core/import-maps.js";
 
 const localizationStrings = {
   en: {

--- a/src/geonovum/conformance.js
+++ b/src/geonovum/conformance.js
@@ -2,7 +2,7 @@
 // Module geonovum/conformance
 // Handle the conformance section properly.
 // based on W3C conformance, but because Geonovum has different requirements, have a separate module
-import { hyperHTML as html } from "../core/import-maps.js";
+import { html } from "../core/import-maps.js";
 export const name = "geonovum/conformance";
 
 /**

--- a/src/geonovum/l10n.js
+++ b/src/geonovum/l10n.js
@@ -2,15 +2,27 @@
 // Module geonovum/l10n
 // Looks at the lang attribute on the root element and uses it to manage the config.l10n object so
 // that other parts of the system can localise their text
-import { hyperHTML } from "../core/import-maps.js";
+import { html } from "../core/import-maps.js";
 import { l10n } from "../core/l10n.js";
 export const name = "geonovum/l10n";
 const additions = {
   en: {
-    status_at_publication: hyperHTML`This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current Geonovum publications and the latest revision of this document can be found via <a href='https://www.geonovum.nl/geo-standaarden/alle-standaarden'>https://www.geonovum.nl/geo-standaarden/alle-standaarden</a>(in Dutch).`,
+    status_at_publication: html`This section describes the status of this
+      document at the time of its publication. Other documents may supersede
+      this document. A list of current Geonovum publications and the latest
+      revision of this document can be found via
+      <a href="https://www.geonovum.nl/geo-standaarden/alle-standaarden"
+        >https://www.geonovum.nl/geo-standaarden/alle-standaarden</a
+      >(in Dutch).`,
   },
   nl: {
-    status_at_publication: hyperHTML`Deze paragraaf beschrijft de status van dit document ten tijde van publicatie. Het is mogelijk dat er actuelere versies van dit document bestaan. Een lijst van Geonovum publicaties en de laatste gepubliceerde versie van dit document zijn te vinden op <a href='https://www.geonovum.nl/geo-standaarden/alle-standaarden'>https://www.geonovum.nl/geo-standaarden/alle-standaarden</a>.`,
+    status_at_publication: html`Deze paragraaf beschrijft de status van dit
+      document ten tijde van publicatie. Het is mogelijk dat er actuelere
+      versies van dit document bestaan. Een lijst van Geonovum publicaties en de
+      laatste gepubliceerde versie van dit document zijn te vinden op
+      <a href="https://www.geonovum.nl/geo-standaarden/alle-standaarden"
+        >https://www.geonovum.nl/geo-standaarden/alle-standaarden</a
+      >.`,
   },
 };
 

--- a/src/ui/about-respec.js
+++ b/src/ui/about-respec.js
@@ -2,7 +2,7 @@
 // Module ui/about-respec
 // A simple about dialog with pointer to the help
 import { getIntlData } from "../core/utils.js";
-import { hyperHTML } from "../core/import-maps.js";
+import { html } from "../core/import-maps.js";
 import { ui } from "../core/ui.js";
 
 const localizationStrings = {
@@ -27,7 +27,7 @@ const l10n = getIntlData(localizationStrings);
 // window.respecVersion is added at build time (see tools/builder.js)
 window.respecVersion = window.respecVersion || "Developer Edition";
 const div = document.createElement("div");
-const render = hyperHTML.bind(div);
+const render = html.bind(div);
 const button = ui.addCommand(
   `${l10n.about_respec} ${window.respecVersion}`,
   show,
@@ -83,7 +83,7 @@ function show() {
 
 function perfEntryToTR({ name, duration }) {
   const moduleURL = `https://github.com/w3c/respec/blob/develop/src/${name}.js`;
-  return hyperHTML`
+  return html`
     <tr>
       <td><a href="${moduleURL}">${name}</a></td>
       <td>${duration}</td>

--- a/src/ui/dfn-list.js
+++ b/src/ui/dfn-list.js
@@ -3,7 +3,7 @@
 // Displays all definitions with links to the defining element.
 import { definitionMap } from "../core/dfn-map.js";
 import { getIntlData } from "../core/utils.js";
-import { hyperHTML } from "../core/import-maps.js";
+import { html } from "../core/import-maps.js";
 import { ui } from "../core/ui.js";
 
 const localizationStrings = {
@@ -35,7 +35,7 @@ const button = ui.addCommand(
 
 const ul = document.createElement("ul");
 ul.classList.add("respec-dfn-list");
-const render = hyperHTML.bind(ul);
+const render = html.bind(ul);
 
 ul.addEventListener("click", ev => {
   if (ev.target instanceof HTMLElement && ev.target.matches("a")) {
@@ -48,7 +48,7 @@ function show() {
   const definitionLinks = Array.from(definitionMap)
     .sort(([keyA], [keyB]) => keyA.localeCompare(keyB))
     .map(([, [dfn]]) => {
-      return hyperHTML.wire(dfn, ":li>a")`
+      return html.wire(dfn, ":li>a")`
         <li>
           <a href="${`#${dfn.id}`}">
             ${dfn.textContent}
@@ -68,7 +68,7 @@ function show() {
 function labelDfnIfExported(dfn) {
   const isExported = dfn.hasAttribute("data-export");
   if (isExported) {
-    return hyperHTML`<span class="dfn-status exported">exported</span>`;
+    return html`<span class="dfn-status exported">exported</span>`;
   }
   return null;
 }
@@ -80,7 +80,7 @@ function labelDfnIfExported(dfn) {
 function labelDfnIfUnused(dfn) {
   const isUsed = document.querySelector(`a[href^="#${dfn.id}"]`);
   if (!isUsed) {
-    return hyperHTML`<span class="dfn-status unused">unused</span>`;
+    return html`<span class="dfn-status unused">unused</span>`;
   }
   return null;
 }

--- a/src/ui/save-html.js
+++ b/src/ui/save-html.js
@@ -2,7 +2,7 @@
 // Module ui/save-html
 // Saves content to HTML when asked to
 import { getIntlData } from "../core/utils.js";
-import { hyperHTML } from "../core/import-maps.js";
+import { html } from "../core/import-maps.js";
 import { pub } from "../core/pubsubhub.js";
 import { rsDocToDataURL } from "../core/exporter.js";
 import { ui } from "../core/ui.js";
@@ -64,24 +64,23 @@ const downloadLinks = [
 
 function toDownloadLink(details) {
   const { id, href, fileName, title, type } = details;
-  return hyperHTML`
-    <a
-      href="${href}"
-      id="${id}"
-      download="${fileName}"
-      type="${type}"
-      class="respec-save-button"
-      onclick=${() => ui.closeModal()}
-    >${title}</a>`;
+  return html` <a
+    href="${href}"
+    id="${id}"
+    download="${fileName}"
+    type="${type}"
+    class="respec-save-button"
+    onclick=${() => ui.closeModal()}
+    >${title}</a
+  >`;
 }
 
 const saveDialog = {
   async show(button) {
     await document.respecIsReady;
-    const div = hyperHTML`
-      <div class="respec-save-buttons">
-        ${downloadLinks.map(toDownloadLink)}
-      </div>`;
+    const div = html` <div class="respec-save-buttons">
+      ${downloadLinks.map(toDownloadLink)}
+    </div>`;
     ui.freshModal(l10n.save_snapshot, div, button);
   },
 };

--- a/src/ui/search-specref.js
+++ b/src/ui/search-specref.js
@@ -2,7 +2,7 @@
 // Module ui/search-specref
 // Search Specref database
 import { getIntlData } from "../core/utils.js";
-import { hyperHTML } from "../core/import-maps.js";
+import { html } from "../core/import-maps.js";
 import { ui } from "../core/ui.js";
 import { wireReference } from "../core/biblio.js";
 
@@ -32,8 +32,8 @@ const specrefURL = "https://specref.herokuapp.com/";
 const refSearchURL = `${specrefURL}search-refs`;
 const reveseLookupURL = `${specrefURL}reverse-lookup`;
 const form = document.createElement("form");
-const renderer = hyperHTML.bind(form);
-const resultList = hyperHTML.bind(document.createElement("div"));
+const renderer = html.bind(form);
+const resultList = html.bind(document.createElement("div"));
 
 form.id = "specref-ui";
 
@@ -65,7 +65,7 @@ function renderResults(resultMap, query, timeTaken) {
 }
 
 function toDefinitionPair([key, entry]) {
-  return hyperHTML.wire(entry)`
+  return html.wire(entry)`
     <dt>
       [${key}]
     </dt>
@@ -144,7 +144,7 @@ function show() {
   input.focus();
 }
 
-const mast = hyperHTML.wire()`
+const mast = html.wire()`
   <header>
     <p>
       An Open-Source, Community-Maintained Database of

--- a/src/ui/search-xref.js
+++ b/src/ui/search-xref.js
@@ -2,7 +2,7 @@
 // Module ui/search-xref
 // Search xref database
 import { lang as defaultLang } from "../core/l10n.js";
-import { hyperHTML } from "../core/import-maps.js";
+import { html } from "../core/import-maps.js";
 import { ui } from "../core/ui.js";
 
 const XREF_URL = "https://respec.org/xref/";
@@ -25,7 +25,7 @@ const button = ui.addCommand(l10n.title, show, "Ctrl+Shift+Alt+x", "📚");
 
 function show() {
   const onLoad = e => e.target.classList.add("ready");
-  const xrefSearchUI = hyperHTML`
+  const xrefSearchUI = html`
     <iframe id="xref-ui" src="${XREF_URL}" onload=${onLoad}></iframe>
     <a href="${XREF_URL}" target="_blank">Open Search UI in a new tab</a>
   `;

--- a/src/w3c/conformance.js
+++ b/src/w3c/conformance.js
@@ -2,7 +2,7 @@
 // Module w3c/conformance
 // Handle the conformance section properly.
 import { getIntlData, htmlJoinAnd } from "../core/utils.js";
-import { hyperHTML as html } from "../core/import-maps.js";
+import { html } from "../core/import-maps.js";
 import { pub } from "../core/pubsubhub.js";
 import { renderInlineCitation } from "../core/render-biblio.js";
 import { rfc2119Usage } from "../core/inlines.js";

--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -88,7 +88,7 @@ import { ISODate, concatDate, htmlJoinAnd } from "../core/utils.js";
 import cgbgHeadersTmpl from "./templates/cgbg-headers.js";
 import cgbgSotdTmpl from "./templates/cgbg-sotd.js";
 import headersTmpl from "./templates/headers.js";
-import { hyperHTML } from "../core/import-maps.js";
+import { html } from "../core/import-maps.js";
 import { pub } from "../core/pubsubhub.js";
 import sotdTmpl from "./templates/sotd.js";
 
@@ -469,7 +469,13 @@ export function run(conf) {
         htmlJoinAnd(conf.alternateFormats, alt => {
           const lang = alt.hasOwnProperty("lang") && alt.lang ? alt.lang : null;
           const type = alt.hasOwnProperty("type") && alt.type ? alt.type : null;
-          return hyperHTML`<a rel='alternate' href='${alt.uri}' hreflang='${lang}' type='${type}'>${alt.label}</a>`;
+          return html`<a
+            rel="alternate"
+            href="${alt.uri}"
+            hreflang="${lang}"
+            type="${type}"
+            >${alt.label}</a
+          >`;
         })
       );
     },
@@ -519,19 +525,22 @@ export function run(conf) {
   if (Array.isArray(conf.wg)) {
     conf.multipleWGs = conf.wg.length > 1;
     conf.wgHTML = htmlJoinAnd(conf.wg, (wg, idx) => {
-      return hyperHTML`the <a href='${conf.wgURI[idx]}'>${wg}</a>`;
+      return html`the <a href="${conf.wgURI[idx]}">${wg}</a>`;
     });
     const pats = [];
     for (let i = 0, n = conf.wg.length; i < n; i++) {
       pats.push(
-        hyperHTML`a <a href='${conf.wgPatentURI[i]}' rel='disclosure'>public list of any patent disclosures (${conf.wg[i]})</a>`
+        html`a
+          <a href="${conf.wgPatentURI[i]}" rel="disclosure"
+            >public list of any patent disclosures (${conf.wg[i]})</a
+          >`
       );
     }
     conf.wgPatentHTML = htmlJoinAnd(pats);
   } else {
     conf.multipleWGs = false;
     if (conf.wg) {
-      conf.wgHTML = hyperHTML`the <a href='${conf.wgURI}'>${conf.wg}</a>`;
+      conf.wgHTML = html`the <a href="${conf.wgURI}">${conf.wg}</a>`;
     }
   }
   if (conf.specStatus === "PR" && !conf.crEnd) {
@@ -584,7 +593,7 @@ export function run(conf) {
     );
   }
   if (!sotd.classList.contains("override")) {
-    hyperHTML.bind(sotd)`${populateSoTD(conf, sotd)}`;
+    html.bind(sotd)`${populateSoTD(conf, sotd)}`;
   }
 
   if (!conf.implementationReportURI && conf.isCR) {

--- a/src/w3c/l10n.js
+++ b/src/w3c/l10n.js
@@ -2,27 +2,51 @@
 // Module w3c/l10n
 // Looks at the lang attribute on the root element and uses it to manage the config.l10n object so
 // that other parts of the system can localise their text
-import { hyperHTML } from "../core/import-maps.js";
+import { html } from "../core/import-maps.js";
 import { l10n } from "../core/l10n.js";
 export const name = "w3c/l10n";
 const additions = {
   en: {
-    status_at_publication: hyperHTML`This section describes the status of this document at the time of its publication. Other documents may supersede this document. A list of current W3C publications and the latest revision of this technical report can be found in the <a href='https://www.w3.org/TR/'>W3C technical reports index</a> at https://www.w3.org/TR/.`,
+    status_at_publication: html`This section describes the status of this
+      document at the time of its publication. Other documents may supersede
+      this document. A list of current W3C publications and the latest revision
+      of this technical report can be found in the
+      <a href="https://www.w3.org/TR/">W3C technical reports index</a> at
+      https://www.w3.org/TR/.`,
   },
   ko: {
-    status_at_publication: hyperHTML`이 부분은 현재 문서의 발행 당시 상태에 대해 기술합니다. 다른 문서가 이 문서를 대체할 수 있습니다. W3C 발행 문서의 최신 목록 및 테크니컬 리포트 최신판을 https://www.w3.org/TR/ 의 <a href='https://www.w3.org/TR/'>W3C technical reports index</a> 에서 열람할 수 있습니다.`,
+    status_at_publication: html`이 부분은 현재 문서의 발행 당시 상태에 대해
+      기술합니다. 다른 문서가 이 문서를 대체할 수 있습니다. W3C 발행 문서의 최신
+      목록 및 테크니컬 리포트 최신판을 https://www.w3.org/TR/ 의
+      <a href="https://www.w3.org/TR/">W3C technical reports index</a> 에서
+      열람할 수 있습니다.`,
   },
   zh: {
-    status_at_publication: hyperHTML`本章节描述了本文档的发布状态。其它更新版本可能会覆盖本文档。W3C的文档列 表和最新版本可通过<a href='https://www.w3.org/TR/'>W3C技术报告</a>索引访问。`,
+    status_at_publication: html`本章节描述了本文档的发布状态。其它更新版本可能会覆盖本文档。W3C的文档列
+      表和最新版本可通过<a href="https://www.w3.org/TR/">W3C技术报告</a
+      >索引访问。`,
   },
   ja: {
-    status_at_publication: hyperHTML`この節には、公開時点でのこの文書の位置づけが記されている。他の文書によって置き換えられる可能性がある。現時点でのW3Cの発行文書とこのテクニカルレポートの最新版は、下記から参照できる。 <a href='https://www.w3.org/TR/'>W3C technical reports index</a> (https://www.w3.org/TR/)`,
+    status_at_publication: html`この節には、公開時点でのこの文書の位置づけが記されている。他の文書によって置き換えられる可能性がある。現時点でのW3Cの発行文書とこのテクニカルレポートの最新版は、下記から参照できる。
+      <a href="https://www.w3.org/TR/">W3C technical reports index</a>
+      (https://www.w3.org/TR/)`,
   },
   es: {
-    status_at_publication: hyperHTML`Esta sección describe el estado del presente documento al momento de su publicación. El presente documento puede ser remplazado por otros. Una lista de las publicaciones actuales del W3C y la última revisión del presente informe técnico puede hallarse en http://www.w3.org/TR/ <a href='https://www.w3.org/TR/'>el índice de informes técnicos</a> del W3C.`,
+    status_at_publication: html`Esta sección describe el estado del presente
+      documento al momento de su publicación. El presente documento puede ser
+      remplazado por otros. Una lista de las publicaciones actuales del W3C y la
+      última revisión del presente informe técnico puede hallarse en
+      http://www.w3.org/TR/
+      <a href="https://www.w3.org/TR/">el índice de informes técnicos</a> del
+      W3C.`,
   },
   de: {
-    status_at_publication: hyperHTML`Dieser Abschnitt beschreibt den Status des Dokuments zum Zeitpunkt der Publikation. Neuere Dokumente können dieses Dokument obsolet machen. Eine Liste der aktuellen Publikatinen des W3C und die aktuellste Fassung dieser Spezifikation kann im <a href='https://www.w3.org/TR/'>W3C technical reports index</a> unter https://www.w3.org/TR/ abgerufen werden.`,
+    status_at_publication: html`Dieser Abschnitt beschreibt den Status des
+      Dokuments zum Zeitpunkt der Publikation. Neuere Dokumente können dieses
+      Dokument obsolet machen. Eine Liste der aktuellen Publikatinen des W3C und
+      die aktuellste Fassung dieser Spezifikation kann im
+      <a href="https://www.w3.org/TR/">W3C technical reports index</a> unter
+      https://www.w3.org/TR/ abgerufen werden.`,
   },
 };
 

--- a/src/w3c/templates/cgbg-headers.js
+++ b/src/w3c/templates/cgbg-headers.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { hyperHTML as html } from "../../core/import-maps.js";
+import { html } from "../../core/import-maps.js";
 import { l10n } from "./headers.js";
 import showLink from "./show-link.js";
 import showLogo from "./show-logo.js";

--- a/src/w3c/templates/cgbg-sotd.js
+++ b/src/w3c/templates/cgbg-sotd.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { hyperHTML as html } from "../../core/import-maps.js";
+import { html } from "../../core/import-maps.js";
 import { l10n } from "./sotd.js";
 
 export default (conf, opts) => {

--- a/src/w3c/templates/headers.js
+++ b/src/w3c/templates/headers.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { getIntlData } from "../../core/utils.js";
-import { hyperHTML as html } from "../../core/import-maps.js";
+import { html } from "../../core/import-maps.js";
 import { pub } from "../../core/pubsubhub.js";
 import showLink from "./show-link.js";
 import showLogo from "./show-logo.js";

--- a/src/w3c/templates/show-link.js
+++ b/src/w3c/templates/show-link.js
@@ -1,7 +1,6 @@
 // @ts-check
-import { hyperHTML } from "../../core/import-maps.js";
+import { html } from "../../core/import-maps.js";
 import { pub } from "../../core/pubsubhub.js";
-const html = hyperHTML;
 
 export default link => {
   if (!link.key) {

--- a/src/w3c/templates/show-logo.js
+++ b/src/w3c/templates/show-logo.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { hyperHTML as html } from "../../core/import-maps.js";
+import { html } from "../../core/import-maps.js";
 import { showInlineWarning } from "../../core/utils.js";
 
 export default obj => {

--- a/src/w3c/templates/show-people.js
+++ b/src/w3c/templates/show-people.js
@@ -5,7 +5,7 @@ import {
   toShortIsoDate,
 } from "../../core/utils.js";
 import { lang as defaultLang } from "../../core/l10n.js";
-import { hyperHTML as html } from "../../core/import-maps.js";
+import { html } from "../../core/import-maps.js";
 
 const localizationStrings = {
   en: {

--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { getIntlData } from "../../core/utils.js";
-import { hyperHTML as html } from "../../core/import-maps.js";
+import { html } from "../../core/import-maps.js";
 
 const localizationStrings = {
   en: {

--- a/tests/spec/core/utils-spec.js
+++ b/tests/spec/core/utils-spec.js
@@ -1,7 +1,7 @@
 "use strict";
 
 import * as utils from "../../../src/core/utils.js";
-import { hyperHTML } from "../../../src/core/import-maps.js";
+import { html } from "../../../src/core/import-maps.js";
 
 describe("Core - Utils", () => {
   describe("fetchAndCache", () => {
@@ -394,33 +394,33 @@ describe("Core - Utils", () => {
   describe("htmlJoinAnd", () => {
     it("joins with proper commas and 'and'", () => {
       const div = document.createElement("div");
-      const render = hyperHTML.bind(div);
+      const render = html.bind(div);
 
-      render`${utils.htmlJoinAnd([], item => hyperHTML`<a>${item}</a>`)}`;
+      render`${utils.htmlJoinAnd([], item => html`<a>${item}</a>`)}`;
       expect(div.textContent).toBe("");
       expect(div.getElementsByTagName("a").length).toBe(0);
 
-      render`${utils.htmlJoinAnd(["<x>"], item => hyperHTML`<a>${item}</a>`)}`;
+      render`${utils.htmlJoinAnd(["<x>"], item => html`<a>${item}</a>`)}`;
       expect(div.textContent).toBe("<x>");
       expect(div.getElementsByTagName("a").length).toBe(1);
 
       render`${utils.htmlJoinAnd(
         ["<x>", "<x>"],
-        item => hyperHTML`<a>${item}</a>`
+        item => html`<a>${item}</a>`
       )}`;
       expect(div.textContent).toBe("<x> and <x>");
       expect(div.getElementsByTagName("a").length).toBe(2);
 
       render`${utils.htmlJoinAnd(
         ["<x>", "<x>", "<x>"],
-        item => hyperHTML`<a>${item}</a>`
+        item => html`<a>${item}</a>`
       )}`;
       expect(div.textContent).toBe("<x>, <x>, and <x>");
       expect(div.getElementsByTagName("a").length).toBe(3);
 
       render`${utils.htmlJoinAnd(
         ["<x>", "<x>", "<X>", "<x>"],
-        item => hyperHTML`<a>${item}</a>`
+        item => html`<a>${item}</a>`
       )}`;
       expect(div.textContent).toBe("<x>, <x>, <X>, and <x>");
       expect(div.getElementsByTagName("a").length).toBe(4);


### PR DESCRIPTION
Currently we are mixing the names `hyperHTML` and `html`. As using the shorter de facto standard name `html` enables syntax highlighting and linting from third party tools, this PR replaces the name `hyperHTML` into `html`.