### PR TITLE
fix(core/markdown): more forgiving WebIDL language tag

### DIFF
--- a/src/core/markdown.js
+++ b/src/core/markdown.js
@@ -89,7 +89,7 @@ const inlineElems = new Set([
 class Renderer extends marked.Renderer {
   code(code, language, isEscaped) {
     // regex to check whether the language is webidl
-    if (/(^webidl$|^idl$)/i.test(language)) {
+    if (/(^webidl$)/i.test(language)) {
       return `<pre class="idl">${code}</pre>`;
     }
     return super.code(code, language, isEscaped);

--- a/src/core/markdown.js
+++ b/src/core/markdown.js
@@ -95,7 +95,7 @@ class Renderer extends marked.Renderer {
   }
 
   isWebidlLanguageTag(tag) {
-    return /(^webidl$|^idl$)/i.test(tag);
+    return /(^(web)?idl$)/i.test(tag);
   }
 }
 

--- a/src/core/markdown.js
+++ b/src/core/markdown.js
@@ -88,14 +88,11 @@ const inlineElems = new Set([
 
 class Renderer extends marked.Renderer {
   code(code, language, isEscaped) {
-    if (this.isWebidlLanguageTag(language)) {
+    // regex to check whether the language is webidl
+    if (/(^webidl$|^idl$)/i.test(language)) {
       return `<pre class="idl">${code}</pre>`;
     }
     return super.code(code, language, isEscaped);
-  }
-
-  isWebidlLanguageTag(tag) {
-    return /(^(web)?idl$)/i.test(tag);
   }
 }
 

--- a/src/core/markdown.js
+++ b/src/core/markdown.js
@@ -88,10 +88,14 @@ const inlineElems = new Set([
 
 class Renderer extends marked.Renderer {
   code(code, language, isEscaped) {
-    if (language === "webidl") {
+    if (this.isWebidlLanguageTag(language)) {
       return `<pre class="idl">${code}</pre>`;
     }
     return super.code(code, language, isEscaped);
+  }
+
+  isWebidlLanguageTag(tag) {
+    return /(^webidl$|^idl$)/i.test(tag);
   }
 }
 

--- a/tests/spec/core/markdown-spec.js
+++ b/tests/spec/core/markdown-spec.js
@@ -344,34 +344,28 @@ describe("Core - Markdown", () => {
 
     expect(missingLettersInTag.classList).not.toContain("idl");
     expect(missingLettersInTag.querySelector("code.hljs")).toBeTruthy();
-    expect(
-      missingLettersInTag.querySelector("code.language-webid")
-    ).toBeTruthy();
+    expect(missingLettersInTag.querySelector("code.webid")).toBeTruthy();
     expect(
       missingLettersInTag.querySelector(".respec-button-copy-paste")
     ).toBeFalsy();
 
     expect(extraLettersInTag.classList).not.toContain("idl");
     expect(extraLettersInTag.querySelector("code.hljs")).toBeTruthy();
-    expect(
-      extraLettersInTag.querySelector("code.language-webidll")
-    ).toBeTruthy();
+    expect(extraLettersInTag.querySelector("code.webidll")).toBeTruthy();
     expect(
       extraLettersInTag.querySelector(".respec-button-copy-paste")
     ).toBeFalsy();
 
     expect(repeatedIdlTags.classList).not.toContain("idl");
     expect(repeatedIdlTags.querySelector("code.hljs")).toBeTruthy();
-    expect(repeatedIdlTags.querySelector("code.language-idlidl")).toBeTruthy();
+    expect(repeatedIdlTags.querySelector("code.idlidl")).toBeTruthy();
     expect(
       repeatedIdlTags.querySelector(".respec-button-copy-paste")
     ).toBeFalsy();
 
     expect(repeatedWebidlTags.classList).not.toContain("idl");
     expect(repeatedWebidlTags.querySelector("code.hljs")).toBeTruthy();
-    expect(
-      repeatedWebidlTags.querySelector("code.language-webidlwebidl")
-    ).toBeTruthy();
+    expect(repeatedWebidlTags.querySelector("code.webidlwebidl")).toBeTruthy();
     expect(
       repeatedWebidlTags.querySelector(".respec-button-copy-paste")
     ).toBeFalsy();

--- a/tests/spec/core/markdown-spec.js
+++ b/tests/spec/core/markdown-spec.js
@@ -297,38 +297,11 @@ describe("Core - Markdown", () => {
       [Exposed=Window]
       interface FooIdl {};
       \`\`\`
-
-      \`\`\` webid
-      [Exposed=Window]
-      interface FooWebid {};
-      \`\`\`
-
-      \`\`\` webidll
-      [Exposed=Window]
-      interface FooWebIdll {};
-      \`\`\`
-
-      \`\`\` idlidl
-      [Exposed=Window]
-      interface FooIdlIdl {};
-      \`\`\`
-
-      \`\`\` webidlwebidl
-      [Exposed=Window]
-      interface FooWebidlWebidl {};
-      \`\`\`
     `;
 
     const ops = makeStandardOps({ format: "markdown" }, body);
     const doc = await makeRSDoc(ops);
-    const [
-      mixedCaseWebidl,
-      mixedCaseIdl,
-      missingLettersInTag,
-      extraLettersInTag,
-      repeatedIdlTags,
-      repeatedWebidlTags,
-    ] = doc.querySelectorAll("pre");
+    const [mixedCaseWebidl, mixedCaseIdl] = doc.querySelectorAll("pre");
 
     expect(mixedCaseWebidl.classList).toContain("idl");
     expect(mixedCaseWebidl.querySelector("code.hljs")).toBeFalsy();
@@ -341,34 +314,6 @@ describe("Core - Markdown", () => {
     expect(
       mixedCaseIdl.querySelector(".respec-button-copy-paste")
     ).toBeTruthy();
-
-    expect(missingLettersInTag.classList).not.toContain("idl");
-    expect(missingLettersInTag.querySelector("code.hljs")).toBeTruthy();
-    expect(missingLettersInTag.querySelector("code.webid")).toBeTruthy();
-    expect(
-      missingLettersInTag.querySelector(".respec-button-copy-paste")
-    ).toBeFalsy();
-
-    expect(extraLettersInTag.classList).not.toContain("idl");
-    expect(extraLettersInTag.querySelector("code.hljs")).toBeTruthy();
-    expect(extraLettersInTag.querySelector("code.webidll")).toBeTruthy();
-    expect(
-      extraLettersInTag.querySelector(".respec-button-copy-paste")
-    ).toBeFalsy();
-
-    expect(repeatedIdlTags.classList).not.toContain("idl");
-    expect(repeatedIdlTags.querySelector("code.hljs")).toBeTruthy();
-    expect(repeatedIdlTags.querySelector("code.idlidl")).toBeTruthy();
-    expect(
-      repeatedIdlTags.querySelector(".respec-button-copy-paste")
-    ).toBeFalsy();
-
-    expect(repeatedWebidlTags.classList).not.toContain("idl");
-    expect(repeatedWebidlTags.querySelector("code.hljs")).toBeTruthy();
-    expect(repeatedWebidlTags.querySelector("code.webidlwebidl")).toBeTruthy();
-    expect(
-      repeatedWebidlTags.querySelector(".respec-button-copy-paste")
-    ).toBeFalsy();
   });
 
   describe("nolinks options", () => {

--- a/tests/spec/core/markdown-spec.js
+++ b/tests/spec/core/markdown-spec.js
@@ -337,7 +337,7 @@ describe("Core - Markdown", () => {
     ).toBeTruthy();
 
     expect(mixedCaseIdl.classList).toContain("idl");
-    expect(mixedCaseWebidl.querySelector("code.hljs")).toBeFalsy();
+    expect(mixedCaseIdl.querySelector("code.hljs")).toBeFalsy();
     expect(
       mixedCaseIdl.querySelector(".respec-button-copy-paste")
     ).toBeTruthy();

--- a/tests/spec/core/markdown-spec.js
+++ b/tests/spec/core/markdown-spec.js
@@ -292,27 +292,16 @@ describe("Core - Markdown", () => {
       [Exposed=Window]
       interface FooWebidl {};
       \`\`\`
-
-      \`\`\` IdL
-      [Exposed=Window]
-      interface FooIdl {};
-      \`\`\`
     `;
 
     const ops = makeStandardOps({ format: "markdown" }, body);
     const doc = await makeRSDoc(ops);
-    const [mixedCaseWebidl, mixedCaseIdl] = doc.querySelectorAll("pre");
+    const [mixedCaseWebidl] = doc.querySelectorAll("pre");
 
     expect(mixedCaseWebidl.classList).toContain("idl");
     expect(mixedCaseWebidl.querySelector("code.hljs")).toBeFalsy();
     expect(
       mixedCaseWebidl.querySelector(".respec-button-copy-paste")
-    ).toBeTruthy();
-
-    expect(mixedCaseIdl.classList).toContain("idl");
-    expect(mixedCaseIdl.querySelector("code.hljs")).toBeFalsy();
-    expect(
-      mixedCaseIdl.querySelector(".respec-button-copy-paste")
     ).toBeTruthy();
   });
 

--- a/tests/spec/core/markdown-spec.js
+++ b/tests/spec/core/markdown-spec.js
@@ -280,6 +280,99 @@ describe("Core - Markdown", () => {
     expect(normalBlock.querySelector(".respec-button-copy-paste")).toBeFalsy();
   });
 
+  it("is case insensitive for webidl language tags", async () => {
+    const body = `
+      ## test
+
+      \`\`\` weBiDl
+      [Exposed=Window]
+      interface FooWebidl {};
+      \`\`\`
+
+      \`\`\` IdL
+      [Exposed=Window]
+      interface FooIdl {};
+      \`\`\`
+
+      \`\`\` webid
+      [Exposed=Window]
+      interface FooWebid {};
+      \`\`\`
+
+      \`\`\` webidll
+      [Exposed=Window]
+      interface FooWebIdll {};
+      \`\`\`
+
+      \`\`\` idlidl
+      [Exposed=Window]
+      interface FooIdlIdl {};
+      \`\`\`
+
+      \`\`\` webidlwebidl
+      [Exposed=Window]
+      interface FooWebidlWebidl {};
+      \`\`\`
+    `;
+
+    const ops = makeStandardOps({ format: "markdown" }, body);
+    const doc = await makeRSDoc(ops);
+    const [
+      mixedCaseWebidl,
+      mixedCaseIdl,
+      missingLettersInTag,
+      extraLettersInTag,
+      repeatedIdlTags,
+      repeatedWebidlTags,
+    ] = doc.querySelectorAll("pre");
+
+    expect(mixedCaseWebidl.classList).toContain("idl");
+    expect(mixedCaseWebidl.querySelector("code.hljs")).toBeFalsy();
+    expect(
+      mixedCaseWebidl.querySelector(".respec-button-copy-paste")
+    ).toBeTruthy();
+
+    expect(mixedCaseIdl.classList).toContain("idl");
+    expect(mixedCaseWebidl.querySelector("code.hljs")).toBeFalsy();
+    expect(
+      mixedCaseIdl.querySelector(".respec-button-copy-paste")
+    ).toBeTruthy();
+
+    expect(missingLettersInTag.classList).not.toContain("idl");
+    expect(missingLettersInTag.querySelector("code.hljs")).toBeTruthy();
+    expect(
+      missingLettersInTag.querySelector("code.language-webid")
+    ).toBeTruthy();
+    expect(
+      missingLettersInTag.querySelector(".respec-button-copy-paste")
+    ).toBeFalsy();
+
+    expect(extraLettersInTag.classList).not.toContain("idl");
+    expect(extraLettersInTag.querySelector("code.hljs")).toBeTruthy();
+    expect(
+      extraLettersInTag.querySelector("code.language-webidll")
+    ).toBeTruthy();
+    expect(
+      extraLettersInTag.querySelector(".respec-button-copy-paste")
+    ).toBeFalsy();
+
+    expect(repeatedIdlTags.classList).not.toContain("idl");
+    expect(repeatedIdlTags.querySelector("code.hljs")).toBeTruthy();
+    expect(repeatedIdlTags.querySelector("code.language-idlidl")).toBeTruthy();
+    expect(
+      repeatedIdlTags.querySelector(".respec-button-copy-paste")
+    ).toBeFalsy();
+
+    expect(repeatedWebidlTags.classList).not.toContain("idl");
+    expect(repeatedWebidlTags.querySelector("code.hljs")).toBeTruthy();
+    expect(
+      repeatedWebidlTags.querySelector("code.language-webidlwebidl")
+    ).toBeTruthy();
+    expect(
+      repeatedWebidlTags.querySelector(".respec-button-copy-paste")
+    ).toBeFalsy();
+  });
+
   describe("nolinks options", () => {
     it("automatically links URLs in pre when missing (smoke test)", async () => {
       const body = `


### PR DESCRIPTION
Fixes issue [#2596](https://github.com/w3c/respec/issues/2596).

Thanks for guiding me through respec's test workflow and also for general help, @marcoscaceres!