### PR TITLE
feat(core/dfn-panel): add panel with local dfn references

### DIFF
--- a/assets/dfn-panel.css
+++ b/assets/dfn-panel.css
@@ -66,6 +66,7 @@ dfn {
   top: unset;
   bottom: 2em;
   margin: 0 auto;
-  max-width: calc(100vw - 2.5em);
+  /* 0.75em from padding, 0.5em from left position */
+  max-width: calc(100vw - (0.75em + 0.5em) * 2);
   max-height: 30vh;
 }

--- a/assets/dfn-panel.css
+++ b/assets/dfn-panel.css
@@ -52,6 +52,7 @@ dfn {
   display: inline-block;
   position: fixed;
   left: 0.5em;
+  top: unset;
   bottom: 2em;
   margin: 0 auto;
   max-width: calc(100vw - 1.5em - 0.4em - 0.5em);

--- a/assets/dfn-panel.css
+++ b/assets/dfn-panel.css
@@ -2,6 +2,7 @@
 dfn {
   cursor: pointer;
 }
+
 .dfn-panel {
   position: absolute;
   left: var(--left); /* set via JS */
@@ -18,36 +19,46 @@ dfn {
   color: black;
   border: outset 0.2em;
 }
+
 .dfn-panel * {
   margin: 0;
   padding: 0;
   text-indent: 0;
 }
+
 .dfn-panel > b {
   display: block;
 }
+
 .dfn-panel a[href] {
   color: black;
 }
+
 .dfn-panel a[href].self-link {
   display: inline-block;
 }
+
 .dfn-panel a:not(:hover) {
   text-decoration: none !important;
   border-bottom: none !important;
 }
+
 .dfn-panel a[href]:hover {
   border-bottom-width: 1px;
 }
+
 .dfn-panel > b + b {
   margin-top: 0.25em;
 }
+
 .dfn-panel ul {
   padding: 0;
 }
+
 .dfn-panel li {
   list-style: inside;
 }
+
 .dfn-panel.minimized {
   display: inline-block;
   position: fixed;

--- a/assets/dfn-panel.css
+++ b/assets/dfn-panel.css
@@ -30,12 +30,8 @@ dfn {
   display: block;
 }
 
-.dfn-panel a[href] {
+.dfn-panel ul a[href] {
   color: black;
-}
-
-.dfn-panel a[href].self-link {
-  display: inline-block;
 }
 
 .dfn-panel a:not(:hover) {

--- a/assets/dfn-panel.css
+++ b/assets/dfn-panel.css
@@ -53,7 +53,7 @@ dfn {
   list-style: inside;
 }
 
-.dfn-panel.minimized {
+.dfn-panel.docked {
   display: inline-block;
   position: fixed;
   left: 0.5em;

--- a/assets/dfn-panel.css
+++ b/assets/dfn-panel.css
@@ -22,8 +22,6 @@ dfn {
 
 .dfn-panel * {
   margin: 0;
-  padding: 0;
-  text-indent: 0;
 }
 
 .dfn-panel > b {

--- a/assets/dfn-panel.css
+++ b/assets/dfn-panel.css
@@ -27,6 +27,9 @@ dfn {
 .dfn-panel a[href] {
   color: black;
 }
+.dfn-panel a[href].self-link {
+  display: inline-block;
+}
 .dfn-panel a:not(:hover) {
   text-decoration: none !important;
   border-bottom: none !important;

--- a/assets/dfn-panel.css
+++ b/assets/dfn-panel.css
@@ -66,6 +66,6 @@ dfn {
   top: unset;
   bottom: 2em;
   margin: 0 auto;
-  max-width: calc(100vw - 1.5em - 0.4em - 0.5em);
+  max-width: calc(100vw - 2.5em);
   max-height: 30vh;
 }

--- a/assets/dfn-panel.css
+++ b/assets/dfn-panel.css
@@ -4,6 +4,8 @@ dfn {
 }
 .dfn-panel {
   position: absolute;
+  left: var(--left); /* set via JS */
+  top: var(--top); /* set via JS */
   z-index: 35;
   height: auto;
   width: max-content;

--- a/assets/dfn-panel.css
+++ b/assets/dfn-panel.css
@@ -66,7 +66,7 @@ dfn {
   top: unset;
   bottom: 2em;
   margin: 0 auto;
-  /* 0.75em from padding, 0.5em from left position */
-  max-width: calc(100vw - (0.75em + 0.5em) * 2);
+  /* 0.75em from padding (x2), 0.5em from left position, 0.2em border (x2) */
+  max-width: calc(100vw - 0.75em * 2 - 0.5em - 0.2em * 2);
   max-height: 30vh;
 }

--- a/assets/dfn-panel.css
+++ b/assets/dfn-panel.css
@@ -1,0 +1,56 @@
+dfn {
+  cursor: pointer;
+}
+.dfn-panel {
+  position: absolute;
+  z-index: 35;
+  height: auto;
+  width: max-content;
+  max-width: 300px;
+  max-height: 500px;
+  overflow: auto;
+  padding: 0.5em 0.75em;
+  font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
+  background: #dddddd;
+  color: black;
+  border: outset 0.2em;
+}
+.dfn-panel:not(.on) {
+  display: none;
+}
+.dfn-panel * {
+  margin: 0;
+  padding: 0;
+  text-indent: 0;
+}
+.dfn-panel > b {
+  display: block;
+}
+.dfn-panel a[href] {
+  color: black;
+}
+.dfn-panel a:not(:hover) {
+  text-decoration: none !important;
+  border-bottom: none !important;
+}
+.dfn-panel a[href]:hover {
+  border-bottom-width: 1px;
+}
+.dfn-panel > b + b {
+  margin-top: 0.25em;
+}
+.dfn-panel ul {
+  padding: 0;
+}
+.dfn-panel li {
+  list-style: inside;
+}
+.dfn-panel.activated {
+  display: inline-block;
+  position: fixed;
+  left: 0.5em;
+  bottom: 2em;
+  margin: 0 auto;
+  max-width: calc(100vw - 1.5em - 0.4em - 0.5em);
+  max-height: 30vh;
+}

--- a/assets/dfn-panel.css
+++ b/assets/dfn-panel.css
@@ -1,3 +1,4 @@
+/* dfn popup panel that list all local references to a dfn */
 dfn {
   cursor: pointer;
 }
@@ -14,9 +15,6 @@ dfn {
   background: #dddddd;
   color: black;
   border: outset 0.2em;
-}
-.dfn-panel:not(.on) {
-  display: none;
 }
 .dfn-panel * {
   margin: 0;
@@ -45,7 +43,7 @@ dfn {
 .dfn-panel li {
   list-style: inside;
 }
-.dfn-panel.activated {
+.dfn-panel.minimized {
   display: inline-block;
   position: fixed;
   left: 0.5em;

--- a/profiles/geonovum.js
+++ b/profiles/geonovum.js
@@ -46,6 +46,7 @@ const modules = [
   import("../src/core/data-tests.js"),
   import("../src/core/list-sorter.js"),
   import("../src/core/highlight-vars.js"),
+  import("../src/core/dfn-panel.js"),
   import("../src/core/algorithms.js"),
   import("../src/core/anchor-expander.js"),
   /* Linter must be the last thing to run */

--- a/profiles/w3c-common.js
+++ b/profiles/w3c-common.js
@@ -56,6 +56,7 @@ const modules = [
   import("../src/core/data-tests.js"),
   import("../src/core/list-sorter.js"),
   import("../src/core/highlight-vars.js"),
+  import("../src/core/dfn-panel.js"),
   import("../src/core/data-type.js"),
   import("../src/core/algorithms.js"),
   import("../src/core/anchor-expander.js"),

--- a/profiles/w3c.js
+++ b/profiles/w3c.js
@@ -56,6 +56,7 @@ const modules = [
   import("../src/core/data-tests.js"),
   import("../src/core/list-sorter.js"),
   import("../src/core/highlight-vars.js"),
+  import("../src/core/dfn-panel.js"),
   import("../src/core/data-type.js"),
   import("../src/core/algorithms.js"),
   import("../src/core/anchor-expander.js"),

--- a/src/core/dfn-panel.js
+++ b/src/core/dfn-panel.js
@@ -70,7 +70,7 @@ function createPanel(dfn) {
   /** @type {HTMLElement} */
   const panel = hyperHTML`
     <aside class="dfn-panel" id="dfn-panel">
-      <b><a class="self-link" href="${href}">${href}</a></b>
+      <b><a class="self-link" href="${href}">Permalink</a></b>
       ${
         links.length
           ? hyperHTML`<b>Referenced in:</b>${referencesToHTML(id, links)}`

--- a/src/core/dfn-panel.js
+++ b/src/core/dfn-panel.js
@@ -99,11 +99,11 @@ function referencesToHTML(id, links) {
   });
 
   /**
-   * Takes an "entry" from `titleToIDs`, and converts it to a list that is
-   * easier to render in `listItemToHTML`. The first list item contains title
-   * from `getReferenceTitle`, rest of items contain strings like `(2)`, `(3)`
-   * as title.
-   * @param {[string, string[]]} entry
+   * Returns a list that is easier to render in `listItemToHTML`.
+   * @param {[string, string[]]} entry an entry from `titleToIDs`
+   * @returns {{ title: string, id: string }[]} The first list item contains
+   * title from `getReferenceTitle`, rest of items contain strings like `(2)`,
+   * `(3)` as title.
    */
   const toLinkProps = ([title, ids]) => {
     return [{ title, id: ids[0] }].concat(

--- a/src/core/dfn-panel.js
+++ b/src/core/dfn-panel.js
@@ -68,8 +68,7 @@ function parseAction(clickTarget) {
 function createPanel(dfn) {
   const { id } = dfn;
   const href = `#${id}`;
-
-  const links = [...document.querySelectorAll(`a[href="${href}"]`)];
+  const links = document.querySelectorAll(`a[href="${href}"]`);
 
   /** @type {HTMLElement} */
   const panel = hyperHTML`
@@ -87,7 +86,7 @@ function createPanel(dfn) {
 
 /**
  * @param {string} id dfn id
- * @param {HTMLLinkElement[]} links
+ * @param {NodeListOf<HTMLLinkElement>} links
  * @returns {HTMLUListElement}
  */
 function referencesToHTML(id, links) {

--- a/src/core/dfn-panel.js
+++ b/src/core/dfn-panel.js
@@ -148,11 +148,11 @@ function displayPanel(dfn, panel) {
     left = dfnRect.left - (panelWidth + 5);
     if (left < 0) {
       left = dfnRect.left;
-      top = top + dfnRect.height;
+      top += dfnRect.height;
     }
   }
 
-  // "docked" state can independently set its own position in CSS.
+  // Allows ".docked" rule to override the position, unlike `style.left = left`.
   panel.style.setProperty("--left", `${left}px`);
   panel.style.setProperty("--top", `${top}px`);
 }

--- a/src/core/dfn-panel.js
+++ b/src/core/dfn-panel.js
@@ -5,12 +5,10 @@ import { fetchAsset } from "./text-loader.js";
 import { hyperHTML } from "./import-maps.js";
 import { norm } from "./utils.js";
 
-const cssPromise = loadStyle();
-
 export const name = "core/dfn-panel";
 
 export async function run() {
-  const css = await cssPromise;
+  const css = await loadStyle();
   document.head.insertBefore(
     hyperHTML`<style>${css}</style>`,
     document.querySelector("link")

--- a/src/core/dfn-panel.js
+++ b/src/core/dfn-panel.js
@@ -14,17 +14,18 @@ export async function run() {
     document.querySelector("link")
   );
 
+  let panel = document.getElementById("dfn-panel");
   document.body.addEventListener("click", event => {
     /** @type {HTMLElement} */
     const el = event.target;
-    const panel = document.getElementById("dfn-panel");
 
     const action = deriveAction(el);
     switch (action) {
       case "show": {
         if (panel) panel.remove();
         const dfn = el.closest("dfn");
-        displayPanel(dfn, createPanel(dfn));
+        panel = createPanel(dfn);
+        displayPanel(dfn, panel);
         break;
       }
       case "minimize": {

--- a/src/core/dfn-panel.js
+++ b/src/core/dfn-panel.js
@@ -1,0 +1,159 @@
+// Constructs "dfn panels" which show all the local references to a dfn and a
+// self link to the selected dfn. Based on Bikeshed's dfn panels at
+// https://github.com/tabatkins/bikeshed/blob/ef44162c2e/bikeshed/dfnpanels.py
+import { fetchAsset } from "./text-loader.js";
+import { hyperHTML } from "./import-maps.js";
+import { norm } from "./utils.js";
+
+const cssPromise = loadStyle();
+
+export const name = "core/dfn-panel";
+
+export async function run() {
+  const css = await cssPromise;
+  document.head.insertBefore(
+    hyperHTML`<style>${css}</style>`,
+    document.querySelector("link")
+  );
+
+  document.body.addEventListener("click", event => {
+    /** @type {HTMLElement} */
+    const el = event.target;
+    const panel = document.getElementById("dfn-panel");
+
+    const action = parseAction(el);
+    console.log({ action });
+    switch (action) {
+      case "SHOW": {
+        if (panel) panel.remove();
+        const dfn = el.closest("dfn");
+        displayPanel(dfn, createPanel(dfn));
+        break;
+      }
+      case "ACTIVATE": {
+        panel.classList.add("activated");
+        panel.style.left = null;
+        panel.style.top = null;
+        break;
+      }
+      case "HIDE": {
+        panel.remove();
+        break;
+      }
+    }
+  });
+}
+
+/** @param {HTMLElement} clickTarget */
+function parseAction(clickTarget) {
+  const hitALink = !!clickTarget.closest("a");
+  if (clickTarget.closest("dfn")) {
+    return hitALink ? "NOOP" : "SHOW";
+  }
+  if (clickTarget.closest("#dfn-panel")) {
+    if (hitALink) {
+      const clickedSelfLink = clickTarget.classList.contains("self-link");
+      return clickedSelfLink ? "HIDE" : "ACTIVATE";
+    }
+    const panel = clickTarget.closest("#dfn-panel");
+    return panel.classList.contains("activated") ? "HIDE" : "NOOP";
+  }
+  if (document.getElementById("dfn-panel")) {
+    return "HIDE";
+  }
+  return "NOOP";
+}
+
+/** @param {HTMLElement} dfn */
+function createPanel(dfn) {
+  const { id } = dfn;
+  const href = `#${id}`;
+
+  const links = [...document.querySelectorAll(`a[href="${href}"]`)];
+
+  /** @type {HTMLElement} */
+  const panel = hyperHTML`
+    <aside class="dfn-panel" id="dfn-panel">
+      <b><a class="self-link" href="${href}">${href}</a></b>
+      ${
+        links.length
+          ? hyperHTML`<b>Referenced in:</b>${referencesToHTML(id, links)}`
+          : null
+      }
+    </aside>
+  `;
+  return document.body.appendChild(panel);
+}
+
+/**
+ * @param {string} id dfn id
+ * @param {HTMLLinkElement[]} links
+ * @returns {HTMLUListElement}
+ */
+function referencesToHTML(id, links) {
+  /** @type {Map<string, string[]>} */
+  const titleToIDs = new Map();
+  links.forEach((link, i) => {
+    const linkID = link.id || `ref-for-${id}-${i + 1}`;
+    if (!link.id) link.id = linkID;
+    const title = getReferenceTitle(link);
+    const ids = titleToIDs.get(title) || titleToIDs.set(title, []).get(title);
+    ids.push(linkID);
+  });
+
+  /** @param {[string, string[]]} entry */
+  const toLinkProps = ([title, ids]) => {
+    return [{ title, id: ids[0] }].concat(
+      ids.slice(1).map((id, i) => ({ title: `(${i + 2})`, id }))
+    );
+  };
+
+  /**
+   * @param {[string, string[]]} entry
+   * @returns {HTMLLIElement}
+   */
+  const listItemToHTML = entry =>
+    hyperHTML`<li>${toLinkProps(entry).map(
+      link => hyperHTML`<a href="#${link.id}">${link.title}</a>${" "}`
+    )}</li>`;
+
+  return hyperHTML`<ul>${[...titleToIDs.entries()].map(listItemToHTML)}</ul>`;
+}
+
+/** @param {HTMLAnchorElement} link */
+function getReferenceTitle(link) {
+  const section = link.closest("section");
+  if (!section) return null;
+  const heading = section.querySelector("h1, h2, h3, h4, h5");
+  if (!heading) return null;
+  return norm(heading.textContent);
+}
+
+/**
+ * @param {HTMLElement} dfn
+ * @param {HTMLElement} panel
+ */
+function displayPanel(dfn, panel) {
+  panel.classList.add("on");
+
+  const dfnRect = dfn.getBoundingClientRect();
+  const panelRect = panel.getBoundingClientRect();
+  const panelWidth = panelRect.right - panelRect.left;
+
+  const top = window.scrollY + dfnRect.top;
+  let left = dfnRect.left + dfnRect.width + 5;
+  if (left + panelWidth > document.body.scrollWidth) {
+    // Reposition, because the panel is overflowing
+    left = window.scrollX + dfnRect.left - (panelWidth + 5);
+  }
+
+  Object.assign(panel.style, { left: `${left}px`, top: `${top}px` });
+}
+
+async function loadStyle() {
+  try {
+    return (await import("text!../../assets/dfn-panel.css")).default;
+  } catch {
+    return fetchAsset("dfn-panel.css");
+  }
+}

--- a/src/core/dfn-panel.js
+++ b/src/core/dfn-panel.js
@@ -151,6 +151,9 @@ function displayPanel(dfn, panel) {
     }
   }
 
+  // We're using CSS variables instead of setting style.left explicitly as we
+  // only need to set them for "show" state (and not unset them for "minimized"
+  // state). "minimized" state can indepently set their own position in CSS.
   panel.style.setProperty("--left", `${left}px`);
   panel.style.setProperty("--top", `${top}px`);
 }

--- a/src/core/dfn-panel.js
+++ b/src/core/dfn-panel.js
@@ -97,7 +97,13 @@ function referencesToHTML(id, links) {
     ids.push(linkID);
   });
 
-  /** @param {[string, string[]]} entry */
+  /**
+   * Takes an "entry" from `titleToIDs`, and converts it to a list that is
+   * easier to render in `listItemToHTML`. The first list item contains title
+   * from `getReferenceTitle`, rest of items contain strings like `(2)`, `(3)`
+   * as title.
+   * @param {[string, string[]]} entry
+   */
   const toLinkProps = ([title, ids]) => {
     return [{ title, id: ids[0] }].concat(
       ids.slice(1).map((id, i) => ({ title: `(${i + 2})`, id }))

--- a/src/core/dfn-panel.js
+++ b/src/core/dfn-panel.js
@@ -45,7 +45,7 @@ export async function run() {
 function deriveAction(clickTarget) {
   const hitALink = !!clickTarget.closest("a");
   if (clickTarget.closest("dfn")) {
-    return hitALink ? "noop" : "show";
+    return hitALink ? null : "show";
   }
   if (clickTarget.closest("#dfn-panel")) {
     if (hitALink) {
@@ -53,12 +53,12 @@ function deriveAction(clickTarget) {
       return clickedSelfLink ? "hide" : "minimize";
     }
     const panel = clickTarget.closest("#dfn-panel");
-    return panel.classList.contains("minimized") ? "hide" : "noop";
+    return panel.classList.contains("minimized") ? "hide" : null;
   }
   if (document.getElementById("dfn-panel")) {
     return "hide";
   }
-  return "noop";
+  return null;
 }
 
 /** @param {HTMLElement} dfn */

--- a/src/core/dfn-panel.js
+++ b/src/core/dfn-panel.js
@@ -29,8 +29,8 @@ export async function run() {
         displayPanel(dfn, panel);
         break;
       }
-      case "minimize": {
-        panel.classList.add("minimized");
+      case "dock": {
+        panel.classList.add("docked");
         break;
       }
       case "hide": {
@@ -50,10 +50,10 @@ function deriveAction(clickTarget) {
   if (clickTarget.closest("#dfn-panel")) {
     if (hitALink) {
       const clickedSelfLink = clickTarget.classList.contains("self-link");
-      return clickedSelfLink ? "hide" : "minimize";
+      return clickedSelfLink ? "hide" : "dock";
     }
     const panel = clickTarget.closest("#dfn-panel");
-    return panel.classList.contains("minimized") ? "hide" : null;
+    return panel.classList.contains("docked") ? "hide" : null;
   }
   if (document.getElementById("dfn-panel")) {
     return "hide";
@@ -152,7 +152,7 @@ function displayPanel(dfn, panel) {
     }
   }
 
-  // "minimized" state can independently set its own position in CSS.
+  // "docked" state can independently set its own position in CSS.
   panel.style.setProperty("--left", `${left}px`);
   panel.style.setProperty("--top", `${top}px`);
 }

--- a/src/core/dfn-panel.js
+++ b/src/core/dfn-panel.js
@@ -29,8 +29,6 @@ export async function run() {
       }
       case "minimize": {
         panel.classList.add("minimized");
-        panel.style.left = null;
-        panel.style.top = null;
         break;
       }
       case "hide": {
@@ -151,7 +149,8 @@ function displayPanel(dfn, panel) {
     }
   }
 
-  Object.assign(panel.style, { left: `${left}px`, top: `${top}px` });
+  panel.style.setProperty("--left", `${left}px`);
+  panel.style.setProperty("--top", `${top}px`);
 }
 
 async function loadStyle() {

--- a/src/core/dfn-panel.js
+++ b/src/core/dfn-panel.js
@@ -75,7 +75,7 @@ function createPanel(dfn) {
       ${referencesToHTML(id, links)}
     </aside>
   `;
-  return document.body.appendChild(panel);
+  return panel;
 }
 
 /**
@@ -137,6 +137,8 @@ function getReferenceTitle(link) {
  * @param {HTMLElement} panel
  */
 function displayPanel(dfn, panel) {
+  document.body.appendChild(panel);
+
   const dfnRect = dfn.getBoundingClientRect();
   const panelRect = panel.getBoundingClientRect();
   const panelWidth = panelRect.right - panelRect.left;

--- a/src/core/dfn-panel.js
+++ b/src/core/dfn-panel.js
@@ -27,8 +27,8 @@ export async function run() {
         displayPanel(dfn, createPanel(dfn));
         break;
       }
-      case "activate": {
-        panel.classList.add("activated");
+      case "minimize": {
+        panel.classList.add("minimized");
         panel.style.left = null;
         panel.style.top = null;
         break;
@@ -50,10 +50,10 @@ function deriveAction(clickTarget) {
   if (clickTarget.closest("#dfn-panel")) {
     if (hitALink) {
       const clickedSelfLink = clickTarget.classList.contains("self-link");
-      return clickedSelfLink ? "hide" : "activate";
+      return clickedSelfLink ? "hide" : "minimize";
     }
     const panel = clickTarget.closest("#dfn-panel");
-    return panel.classList.contains("activated") ? "hide" : "noop";
+    return panel.classList.contains("minimized") ? "hide" : "noop";
   }
   if (document.getElementById("dfn-panel")) {
     return "hide";
@@ -130,8 +130,6 @@ function getReferenceTitle(link) {
  * @param {HTMLElement} panel
  */
 function displayPanel(dfn, panel) {
-  panel.classList.add("on");
-
   const dfnRect = dfn.getBoundingClientRect();
   const panelRect = panel.getBoundingClientRect();
   const panelWidth = panelRect.right - panelRect.left;

--- a/src/core/dfn-panel.js
+++ b/src/core/dfn-panel.js
@@ -126,7 +126,7 @@ function referencesToHTML(id, links) {
 function getReferenceTitle(link) {
   const section = link.closest("section");
   if (!section) return null;
-  const heading = section.querySelector("h1, h2, h3, h4, h5");
+  const heading = section.querySelector("h1, h2, h3, h4, h5, h6");
   if (!heading) return null;
   return norm(heading.textContent);
 }

--- a/src/core/dfn-panel.js
+++ b/src/core/dfn-panel.js
@@ -140,11 +140,15 @@ function displayPanel(dfn, panel) {
   const panelRect = panel.getBoundingClientRect();
   const panelWidth = panelRect.right - panelRect.left;
 
-  const top = window.scrollY + dfnRect.top;
+  let top = window.scrollY + dfnRect.top;
   let left = dfnRect.left + dfnRect.width + 5;
   if (left + panelWidth > document.body.scrollWidth) {
     // Reposition, because the panel is overflowing
-    left = window.scrollX + dfnRect.left - (panelWidth + 5);
+    left = dfnRect.left - (panelWidth + 5);
+    if (left < 0) {
+      left = dfnRect.left;
+      top = top + dfnRect.height;
+    }
   }
 
   Object.assign(panel.style, { left: `${left}px`, top: `${top}px` });

--- a/src/core/dfn-panel.js
+++ b/src/core/dfn-panel.js
@@ -19,21 +19,21 @@ export async function run() {
     const el = event.target;
     const panel = document.getElementById("dfn-panel");
 
-    const action = parseAction(el);
+    const action = deriveAction(el);
     switch (action) {
-      case "SHOW": {
+      case "show": {
         if (panel) panel.remove();
         const dfn = el.closest("dfn");
         displayPanel(dfn, createPanel(dfn));
         break;
       }
-      case "ACTIVATE": {
+      case "activate": {
         panel.classList.add("activated");
         panel.style.left = null;
         panel.style.top = null;
         break;
       }
-      case "HIDE": {
+      case "hide": {
         panel.remove();
         break;
       }
@@ -42,23 +42,23 @@ export async function run() {
 }
 
 /** @param {HTMLElement} clickTarget */
-function parseAction(clickTarget) {
+function deriveAction(clickTarget) {
   const hitALink = !!clickTarget.closest("a");
   if (clickTarget.closest("dfn")) {
-    return hitALink ? "NOOP" : "SHOW";
+    return hitALink ? "noop" : "show";
   }
   if (clickTarget.closest("#dfn-panel")) {
     if (hitALink) {
       const clickedSelfLink = clickTarget.classList.contains("self-link");
-      return clickedSelfLink ? "HIDE" : "ACTIVATE";
+      return clickedSelfLink ? "hide" : "activate";
     }
     const panel = clickTarget.closest("#dfn-panel");
-    return panel.classList.contains("activated") ? "HIDE" : "NOOP";
+    return panel.classList.contains("activated") ? "hide" : "noop";
   }
   if (document.getElementById("dfn-panel")) {
-    return "HIDE";
+    return "hide";
   }
-  return "NOOP";
+  return "noop";
 }
 
 /** @param {HTMLElement} dfn */

--- a/src/core/dfn-panel.js
+++ b/src/core/dfn-panel.js
@@ -22,7 +22,6 @@ export async function run() {
     const panel = document.getElementById("dfn-panel");
 
     const action = parseAction(el);
-    console.log({ action });
     switch (action) {
       case "SHOW": {
         if (panel) panel.remove();

--- a/src/core/dfn-panel.js
+++ b/src/core/dfn-panel.js
@@ -14,7 +14,8 @@ export async function run() {
     document.querySelector("link")
   );
 
-  let panel = document.getElementById("dfn-panel");
+  /** @type {HTMLElement} */
+  let panel;
   document.body.addEventListener("click", event => {
     /** @type {HTMLElement} */
     const el = event.target;

--- a/src/core/dfn-panel.js
+++ b/src/core/dfn-panel.js
@@ -152,9 +152,7 @@ function displayPanel(dfn, panel) {
     }
   }
 
-  // We're using CSS variables instead of setting style.left explicitly as we
-  // only need to set them for "show" state (and not unset them for "minimized"
-  // state). "minimized" state can indepently set their own position in CSS.
+  // "minimized" state can independently set its own position in CSS.
   panel.style.setProperty("--left", `${left}px`);
   panel.style.setProperty("--top", `${top}px`);
 }

--- a/src/core/dfn-panel.js
+++ b/src/core/dfn-panel.js
@@ -71,11 +71,8 @@ function createPanel(dfn) {
   const panel = hyperHTML`
     <aside class="dfn-panel" id="dfn-panel">
       <b><a class="self-link" href="${href}">Permalink</a></b>
-      ${
-        links.length
-          ? hyperHTML`<b>Referenced in:</b>${referencesToHTML(id, links)}`
-          : null
-      }
+      <b>Referenced in:</b>
+      ${referencesToHTML(id, links)}
     </aside>
   `;
   return document.body.appendChild(panel);
@@ -87,6 +84,10 @@ function createPanel(dfn) {
  * @returns {HTMLUListElement}
  */
 function referencesToHTML(id, links) {
+  if (!links.length) {
+    return hyperHTML`<ul><li>Not referenced in this document.</li></ul>`;
+  }
+
   /** @type {Map<string, string[]>} */
   const titleToIDs = new Map();
   links.forEach((link, i) => {

--- a/tests/spec/core/dfn-panel-spec.js
+++ b/tests/spec/core/dfn-panel-spec.js
@@ -102,8 +102,7 @@ describe("Core — dfnPanel", () => {
 
     const selfLink = panel.querySelector("a.self-link");
     expect(selfLink.hash).toBe("#dfn-zero");
-    expect(selfLink.textContent).toBe("#dfn-zero");
-    expect(panel.textContent.trim()).toBe("#dfn-zero");
+    expect(panel.textContent.trim()).toBe("Permalink");
   });
 
   it("renders reference with relevant title", async () => {
@@ -114,7 +113,6 @@ describe("Core — dfnPanel", () => {
 
     const selfLink = panel.querySelector("a.self-link");
     expect(selfLink.hash).toBe("#dfn-one");
-    expect(selfLink.textContent).toBe("#dfn-one");
 
     const referenceHeading = panel.querySelectorAll("b")[1];
     expect(referenceHeading.textContent).toBe("Referenced in:");
@@ -136,7 +134,6 @@ describe("Core — dfnPanel", () => {
 
     const selfLink = panel.querySelector("a.self-link");
     expect(selfLink.hash).toBe("#dfn-many");
-    expect(selfLink.textContent).toBe("#dfn-many");
 
     const referenceHeading = panel.querySelectorAll("b")[1];
     expect(referenceHeading.textContent).toBe("Referenced in:");

--- a/tests/spec/core/dfn-panel-spec.js
+++ b/tests/spec/core/dfn-panel-spec.js
@@ -26,7 +26,7 @@ describe("Core — dfnPanel", () => {
       dfn.click();
       const panel = doc.getElementById("dfn-panel");
       expect(panel).not.toBeNull();
-      expect(panel.classList).not.toContain("minimized");
+      expect(panel.classList).not.toContain("docked");
     });
 
     it("closes open panel on external click", async () => {
@@ -57,21 +57,21 @@ describe("Core — dfnPanel", () => {
       expect(doc.getElementById("dfn-panel")).toBe(panel);
     });
 
-    it("minimizes open panel on reference click", async () => {
+    it("docks open panel on reference click", async () => {
       const doc = await makeRSDoc(ops);
       doc.querySelector("dfn").click();
       const panel = doc.getElementById("dfn-panel");
-      expect(panel.classList).not.toContain("minimized");
+      expect(panel.classList).not.toContain("docked");
       panel.querySelector("ul a").click();
-      expect(panel.classList).toContain("minimized");
+      expect(panel.classList).toContain("docked");
     });
 
-    it("closes minimized panel on panel click", async () => {
+    it("closes docked panel on panel click", async () => {
       const doc = await makeRSDoc(ops);
       doc.querySelector("dfn").click();
       const panel = doc.getElementById("dfn-panel");
       panel.querySelector("ul a").click();
-      expect(panel.classList).toContain("minimized");
+      expect(panel.classList).toContain("docked");
 
       panel.click();
       expect(doc.getElementById("dfn-panel")).toBeNull();

--- a/tests/spec/core/dfn-panel-spec.js
+++ b/tests/spec/core/dfn-panel-spec.js
@@ -26,7 +26,7 @@ describe("Core — dfnPanel", () => {
       dfn.click();
       const panel = doc.getElementById("dfn-panel");
       expect(panel).not.toBeNull();
-      expect(panel.classList).not.toContain("minimized")
+      expect(panel.classList).not.toContain("minimized");
     });
 
     it("closes open panel on external click", async () => {

--- a/tests/spec/core/dfn-panel-spec.js
+++ b/tests/spec/core/dfn-panel-spec.js
@@ -1,0 +1,168 @@
+"use strict";
+import { flushIframes, makeRSDoc, makeStandardOps } from "../SpecHelper.js";
+
+describe("Core — dfnPanel", () => {
+  afterAll(flushIframes);
+
+  const body = `
+    <section>
+      <h2>top level heading</h2>
+      <p><dfn>many</dfn>, <dfn>one</dfn>, <dfn>zero</dfn> references.</p>
+      <p>[=many=] [=many=] [=one=]</p>
+      <section>
+        <h3>nested section heading</h3>
+        <p>[=many=] [=many=]</p>
+      </section>
+      <p>[= many =]</p>
+    </section>
+  `;
+  const ops = makeStandardOps(null, body);
+
+  describe("dfnPanel state", () => {
+    it("opens panel on dfn click", async () => {
+      const doc = await makeRSDoc(ops);
+      expect(doc.getElementById("dfn-panel")).toBeNull();
+      const dfn = doc.querySelector("dfn");
+      dfn.click();
+      const panel = doc.getElementById("dfn-panel");
+      expect(panel).not.toBeNull();
+      expect(panel.classList.contains("on")).toBe(true);
+      expect(panel.classList.contains("activated")).not.toBe(true);
+    });
+
+    it("closes open panel on external click", async () => {
+      const doc = await makeRSDoc(ops);
+      doc.querySelector("dfn").click();
+      let panel = doc.getElementById("dfn-panel");
+      expect(panel).not.toBeNull();
+      expect(panel.classList.contains("on")).toBe(true);
+      doc.body.click();
+      panel = doc.getElementById("dfn-panel");
+      expect(panel).toBeNull();
+    });
+
+    it("closes open panel on self link click", async () => {
+      const doc = await makeRSDoc(ops);
+      doc.querySelector("dfn").click();
+      const panel = doc.getElementById("dfn-panel");
+      expect(panel).not.toBeNull();
+      panel.querySelector("a.self-link").click();
+      expect(doc.getElementById("dfn-panel")).toBeNull();
+    });
+
+    it("does not close panel on panel click", async () => {
+      const doc = await makeRSDoc(ops);
+      doc.querySelector("dfn").click();
+      const panel = doc.getElementById("dfn-panel");
+
+      panel.click();
+      expect(doc.getElementById("dfn-panel")).toBe(panel);
+    });
+
+    it("minimizes open panel on reference click", async () => {
+      const doc = await makeRSDoc(ops);
+      doc.querySelector("dfn").click();
+      const panel = doc.getElementById("dfn-panel");
+      expect(panel.classList.contains("on")).toBe(true);
+      panel.querySelector("ul a").click();
+      expect(panel.classList.contains("activated")).toBe(true);
+    });
+
+    it("closes minimized panel on panel click", async () => {
+      const doc = await makeRSDoc(ops);
+      doc.querySelector("dfn").click();
+      const panel = doc.getElementById("dfn-panel");
+      panel.querySelector("ul a").click();
+      expect(panel.classList.contains("activated")).toBe(true);
+
+      panel.click();
+      expect(doc.getElementById("dfn-panel")).toBeNull();
+    });
+
+    it("opens a new panel if another dfn is clicked", async () => {
+      const doc = await makeRSDoc(ops);
+      expect(doc.getElementById("dfn-panel")).toBeNull();
+      const [dfnMany, dfnOne] = doc.querySelectorAll("dfn");
+
+      dfnMany.click();
+      let panel = doc.getElementById("dfn-panel");
+      expect(panel.querySelector("a.self-link").hash).toBe("#dfn-many");
+
+      dfnOne.click();
+      expect(doc.querySelectorAll(".dfn-panel").length).toBe(1);
+      expect(doc.getElementById("dfn-panel")).not.toBe(panel);
+      panel = doc.getElementById("dfn-panel");
+      expect(panel.querySelector("a.self-link").hash).toBe("#dfn-one");
+    });
+  });
+
+  it("renders only self link to dfn if no local references", async () => {
+    const doc = await makeRSDoc(ops);
+    const dfnZero = doc.querySelector("dfn#dfn-zero");
+    dfnZero.click();
+    const panel = doc.getElementById("dfn-panel");
+
+    const selfLink = panel.querySelector("a.self-link");
+    expect(selfLink.hash).toBe("#dfn-zero");
+    expect(selfLink.textContent).toBe("#dfn-zero");
+    expect(panel.textContent.trim()).toBe("#dfn-zero");
+  });
+
+  it("renders reference with relevant title", async () => {
+    const doc = await makeRSDoc(ops);
+    const dfnOne = doc.querySelector("dfn#dfn-one");
+    dfnOne.click();
+    const panel = doc.getElementById("dfn-panel");
+
+    const selfLink = panel.querySelector("a.self-link");
+    expect(selfLink.hash).toBe("#dfn-one");
+    expect(selfLink.textContent).toBe("#dfn-one");
+
+    const referenceHeading = panel.querySelectorAll("b")[1];
+    expect(referenceHeading.textContent).toBe("Referenced in:");
+
+    const referenceListItems = panel.querySelectorAll("ul li");
+    expect(referenceListItems.length).toBe(1);
+
+    const references = panel.querySelectorAll("ul li a");
+    expect(references.length).toBe(1);
+    expect(references[0].textContent).toBe("1. top level heading");
+    expect(references[0].hash).toBe("#ref-for-dfn-one-1");
+  });
+
+  it("renders multiple references with relevant titles", async () => {
+    const doc = await makeRSDoc(ops);
+    const dfnMany = doc.querySelector("dfn#dfn-many");
+    dfnMany.click();
+    const panel = doc.getElementById("dfn-panel");
+
+    const selfLink = panel.querySelector("a.self-link");
+    expect(selfLink.hash).toBe("#dfn-many");
+    expect(selfLink.textContent).toBe("#dfn-many");
+
+    const referenceHeading = panel.querySelectorAll("b")[1];
+    expect(referenceHeading.textContent).toBe("Referenced in:");
+
+    const referenceListItems = panel.querySelectorAll("ul li");
+    expect(referenceListItems.length).toBe(2);
+    const [item1, item2] = referenceListItems;
+
+    const item1Links = item1.querySelectorAll("a");
+    expect(item1Links.length).toBe(3);
+    expect(item1Links[0].textContent).toBe("1. top level heading");
+    expect(item1Links[0].hash).toBe("#ref-for-dfn-many-1");
+    expect(item1Links[1].textContent).toBe("(2)");
+    expect(item1Links[1].hash).toBe("#ref-for-dfn-many-2");
+    expect(item1Links[2].textContent).toBe("(3)");
+    expect(item1Links[2].hash).toBe("#ref-for-dfn-many-5");
+    expect(item1.textContent).toBe("1. top level heading (2) (3) ");
+
+    const item2Links = item2.querySelectorAll("a");
+    expect(item2Links.length).toBe(2);
+    expect(item2Links[0].textContent).toBe("1.1 nested section heading");
+    expect(item2Links[0].hash).toBe("#ref-for-dfn-many-3");
+    expect(item2Links[1].textContent).toBe("(2)");
+    expect(item2Links[1].hash).toBe("#ref-for-dfn-many-4");
+    expect(item2.textContent).toBe("1.1 nested section heading (2) ");
+  });
+});

--- a/tests/spec/core/dfn-panel-spec.js
+++ b/tests/spec/core/dfn-panel-spec.js
@@ -26,8 +26,7 @@ describe("Core — dfnPanel", () => {
       dfn.click();
       const panel = doc.getElementById("dfn-panel");
       expect(panel).not.toBeNull();
-      expect(panel.classList.contains("on")).toBe(true);
-      expect(panel.classList.contains("activated")).not.toBe(true);
+      expect(panel.classList.contains("minimized")).not.toBe(true);
     });
 
     it("closes open panel on external click", async () => {
@@ -35,7 +34,6 @@ describe("Core — dfnPanel", () => {
       doc.querySelector("dfn").click();
       let panel = doc.getElementById("dfn-panel");
       expect(panel).not.toBeNull();
-      expect(panel.classList.contains("on")).toBe(true);
       doc.body.click();
       panel = doc.getElementById("dfn-panel");
       expect(panel).toBeNull();
@@ -63,9 +61,9 @@ describe("Core — dfnPanel", () => {
       const doc = await makeRSDoc(ops);
       doc.querySelector("dfn").click();
       const panel = doc.getElementById("dfn-panel");
-      expect(panel.classList.contains("on")).toBe(true);
+      expect(panel.classList.contains("minimized")).toBe(false);
       panel.querySelector("ul a").click();
-      expect(panel.classList.contains("activated")).toBe(true);
+      expect(panel.classList.contains("minimized")).toBe(true);
     });
 
     it("closes minimized panel on panel click", async () => {
@@ -73,7 +71,7 @@ describe("Core — dfnPanel", () => {
       doc.querySelector("dfn").click();
       const panel = doc.getElementById("dfn-panel");
       panel.querySelector("ul a").click();
-      expect(panel.classList.contains("activated")).toBe(true);
+      expect(panel.classList.contains("minimized")).toBe(true);
 
       panel.click();
       expect(doc.getElementById("dfn-panel")).toBeNull();

--- a/tests/spec/core/dfn-panel-spec.js
+++ b/tests/spec/core/dfn-panel-spec.js
@@ -4,98 +4,97 @@ import { flushIframes, makeRSDoc, makeStandardOps } from "../SpecHelper.js";
 describe("Core — dfnPanel", () => {
   afterAll(flushIframes);
 
-  const body = `
-    <section>
-      <h2>top level heading</h2>
-      <p><dfn>many</dfn>, <dfn>one</dfn>, <dfn>zero</dfn> references.</p>
-      <p>[=many=] [=many=] [=one=]</p>
+  let doc;
+  beforeAll(async () => {
+    const body = `
       <section>
-        <h3>nested section heading</h3>
-        <p>[=many=] [=many=]</p>
+        <h2>top level heading</h2>
+        <p><dfn>many</dfn>, <dfn>one</dfn>, <dfn>zero</dfn> references.</p>
+        <p>[=many=] [=many=] [=one=]</p>
+        <section>
+          <h3>nested section heading</h3>
+          <p>[=many=] [=many=]</p>
+        </section>
+        <p>[= many =]</p>
       </section>
-      <p>[= many =]</p>
-    </section>
-  `;
-  const ops = makeStandardOps(null, body);
+    `;
+    const ops = makeStandardOps(null, body);
+    doc = await makeRSDoc(ops);
+  });
 
-  describe("dfnPanel state", () => {
-    it("opens panel on dfn click", async () => {
-      const doc = await makeRSDoc(ops);
-      expect(doc.getElementById("dfn-panel")).toBeNull();
-      const dfn = doc.querySelector("dfn");
-      dfn.click();
-      const panel = doc.getElementById("dfn-panel");
-      expect(panel).not.toBeNull();
-      expect(panel.classList.contains("minimized")).not.toBe(true);
-    });
+  beforeEach(() => {
+    const panel = doc.getElementById("dfn-panel");
+    if (panel) panel.remove();
+  });
 
-    it("closes open panel on external click", async () => {
-      const doc = await makeRSDoc(ops);
-      doc.querySelector("dfn").click();
-      let panel = doc.getElementById("dfn-panel");
-      expect(panel).not.toBeNull();
-      doc.body.click();
-      panel = doc.getElementById("dfn-panel");
-      expect(panel).toBeNull();
-    });
+  it("opens panel on dfn click", async () => {
+    expect(doc.getElementById("dfn-panel")).toBeNull();
+    const dfn = doc.querySelector("dfn");
+    dfn.click();
+    const panel = doc.getElementById("dfn-panel");
+    expect(panel).not.toBeNull();
+    expect(panel.classList.contains("minimized")).not.toBe(true);
+  });
 
-    it("closes open panel on self link click", async () => {
-      const doc = await makeRSDoc(ops);
-      doc.querySelector("dfn").click();
-      const panel = doc.getElementById("dfn-panel");
-      expect(panel).not.toBeNull();
-      panel.querySelector("a.self-link").click();
-      expect(doc.getElementById("dfn-panel")).toBeNull();
-    });
+  it("closes open panel on external click", async () => {
+    doc.querySelector("dfn").click();
+    let panel = doc.getElementById("dfn-panel");
+    expect(panel).not.toBeNull();
+    doc.body.click();
+    panel = doc.getElementById("dfn-panel");
+    expect(panel).toBeNull();
+  });
 
-    it("does not close panel on panel click", async () => {
-      const doc = await makeRSDoc(ops);
-      doc.querySelector("dfn").click();
-      const panel = doc.getElementById("dfn-panel");
+  it("closes open panel on self link click", async () => {
+    doc.querySelector("dfn").click();
+    const panel = doc.getElementById("dfn-panel");
+    expect(panel).not.toBeNull();
+    panel.querySelector("a.self-link").click();
+    expect(doc.getElementById("dfn-panel")).toBeNull();
+  });
 
-      panel.click();
-      expect(doc.getElementById("dfn-panel")).toBe(panel);
-    });
+  it("does not close panel on panel click", async () => {
+    doc.querySelector("dfn").click();
+    const panel = doc.getElementById("dfn-panel");
 
-    it("minimizes open panel on reference click", async () => {
-      const doc = await makeRSDoc(ops);
-      doc.querySelector("dfn").click();
-      const panel = doc.getElementById("dfn-panel");
-      expect(panel.classList.contains("minimized")).toBe(false);
-      panel.querySelector("ul a").click();
-      expect(panel.classList.contains("minimized")).toBe(true);
-    });
+    panel.click();
+    expect(doc.getElementById("dfn-panel")).toBe(panel);
+  });
 
-    it("closes minimized panel on panel click", async () => {
-      const doc = await makeRSDoc(ops);
-      doc.querySelector("dfn").click();
-      const panel = doc.getElementById("dfn-panel");
-      panel.querySelector("ul a").click();
-      expect(panel.classList.contains("minimized")).toBe(true);
+  it("minimizes open panel on reference click", async () => {
+    doc.querySelector("dfn").click();
+    const panel = doc.getElementById("dfn-panel");
+    expect(panel.classList.contains("minimized")).toBe(false);
+    panel.querySelector("ul a").click();
+    expect(panel.classList.contains("minimized")).toBe(true);
+  });
 
-      panel.click();
-      expect(doc.getElementById("dfn-panel")).toBeNull();
-    });
+  it("closes minimized panel on panel click", async () => {
+    doc.querySelector("dfn").click();
+    const panel = doc.getElementById("dfn-panel");
+    panel.querySelector("ul a").click();
+    expect(panel.classList.contains("minimized")).toBe(true);
 
-    it("opens a new panel if another dfn is clicked", async () => {
-      const doc = await makeRSDoc(ops);
-      expect(doc.getElementById("dfn-panel")).toBeNull();
-      const [dfnMany, dfnOne] = doc.querySelectorAll("dfn");
+    panel.click();
+    expect(doc.getElementById("dfn-panel")).toBeNull();
+  });
 
-      dfnMany.click();
-      let panel = doc.getElementById("dfn-panel");
-      expect(panel.querySelector("a.self-link").hash).toBe("#dfn-many");
+  it("opens a new panel if another dfn is clicked", async () => {
+    expect(doc.getElementById("dfn-panel")).toBeNull();
+    const [dfnMany, dfnOne] = doc.querySelectorAll("dfn");
 
-      dfnOne.click();
-      expect(doc.querySelectorAll(".dfn-panel").length).toBe(1);
-      expect(doc.getElementById("dfn-panel")).not.toBe(panel);
-      panel = doc.getElementById("dfn-panel");
-      expect(panel.querySelector("a.self-link").hash).toBe("#dfn-one");
-    });
+    dfnMany.click();
+    let panel = doc.getElementById("dfn-panel");
+    expect(panel.querySelector("a.self-link").hash).toBe("#dfn-many");
+
+    dfnOne.click();
+    expect(doc.querySelectorAll(".dfn-panel").length).toBe(1);
+    expect(doc.getElementById("dfn-panel")).not.toBe(panel);
+    panel = doc.getElementById("dfn-panel");
+    expect(panel.querySelector("a.self-link").hash).toBe("#dfn-one");
   });
 
   it("renders only self link to dfn if no local references", async () => {
-    const doc = await makeRSDoc(ops);
     const dfnZero = doc.querySelector("dfn#dfn-zero");
     dfnZero.click();
     const panel = doc.getElementById("dfn-panel");
@@ -107,7 +106,6 @@ describe("Core — dfnPanel", () => {
   });
 
   it("renders reference with relevant title", async () => {
-    const doc = await makeRSDoc(ops);
     const dfnOne = doc.querySelector("dfn#dfn-one");
     dfnOne.click();
     const panel = doc.getElementById("dfn-panel");
@@ -129,7 +127,6 @@ describe("Core — dfnPanel", () => {
   });
 
   it("renders multiple references with relevant titles", async () => {
-    const doc = await makeRSDoc(ops);
     const dfnMany = doc.querySelector("dfn#dfn-many");
     dfnMany.click();
     const panel = doc.getElementById("dfn-panel");

--- a/tests/spec/core/dfn-panel-spec.js
+++ b/tests/spec/core/dfn-panel-spec.js
@@ -26,7 +26,7 @@ describe("Core — dfnPanel", () => {
       dfn.click();
       const panel = doc.getElementById("dfn-panel");
       expect(panel).not.toBeNull();
-      expect(panel.classList.contains("minimized")).not.toBe(true);
+      expect(panel.classList).not.toContain("minimized")
     });
 
     it("closes open panel on external click", async () => {
@@ -61,9 +61,9 @@ describe("Core — dfnPanel", () => {
       const doc = await makeRSDoc(ops);
       doc.querySelector("dfn").click();
       const panel = doc.getElementById("dfn-panel");
-      expect(panel.classList.contains("minimized")).toBe(false);
+      expect(panel.classList).not.toContain("minimized");
       panel.querySelector("ul a").click();
-      expect(panel.classList.contains("minimized")).toBe(true);
+      expect(panel.classList).toContain("minimized");
     });
 
     it("closes minimized panel on panel click", async () => {
@@ -71,7 +71,7 @@ describe("Core — dfnPanel", () => {
       doc.querySelector("dfn").click();
       const panel = doc.getElementById("dfn-panel");
       panel.querySelector("ul a").click();
-      expect(panel.classList.contains("minimized")).toBe(true);
+      expect(panel.classList).toContain("minimized");
 
       panel.click();
       expect(doc.getElementById("dfn-panel")).toBeNull();

--- a/tests/spec/core/dfn-panel-spec.js
+++ b/tests/spec/core/dfn-panel-spec.js
@@ -102,7 +102,12 @@ describe("Core — dfnPanel", () => {
 
     const selfLink = panel.querySelector("a.self-link");
     expect(selfLink.hash).toBe("#dfn-zero");
-    expect(panel.textContent.trim()).toBe("Permalink");
+
+    const referenceSection = panel.querySelector("ul");
+    expect(referenceSection).not.toBeNull();
+    expect(referenceSection.textContent.trim()).toBe(
+      "Not referenced in this document."
+    );
   });
 
   it("renders reference with relevant title", async () => {


### PR DESCRIPTION
Closes https://github.com/w3c/respec/issues/1103 (finally! :tada:)
:sparkles: Check out the demo at respec-preview (in checks below or [here](https://deploy-preview-2626--respec-pr.netlify.com/)) :sparkles:
Markup and style are same as bikeshed for consistency.

Should we add a resize handler to reposition the panel?
 
// TODO
- [x] Add tests