### PR TITLE
perf(core/xref): remove unused slow code

### DIFF
--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -311,16 +311,6 @@ function addDataCite(elem, query, result, conf) {
   const dataset = { cite, citePath, citeFrag, type };
   Object.assign(elem.dataset, dataset);
 
-  // update indirect links (data-lt, data-plurals)
-  /** @type {NodeListOf<HTMLElement>} */
-  const indirectLinks = document.querySelectorAll(
-    `[data-dfn-type="xref"][data-xref="${term.toLowerCase()}"]`
-  );
-  indirectLinks.forEach(el => {
-    el.removeAttribute("data-xref");
-    Object.assign(el.dataset, dataset);
-  });
-
   addToReferences(elem, cite, normative, term, conf);
 }
 


### PR DESCRIPTION
Getting nearly ~200ms benefits in `core/link-to-dfn` (payment-request spec, all cached requests)

Before:
![image](https://user-images.githubusercontent.com/8426945/70831768-696d2e00-1e19-11ea-916c-0402bffa233c.png)


Now:
![image](https://user-images.githubusercontent.com/8426945/70831816-80138500-1e19-11ea-9e8d-a91fb031ba2c.png)
