### PR TITLE
chore(tests): skip building profile in dev env

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -46,6 +46,10 @@ module.exports = function(config) {
         included: false,
       },
       {
+        pattern: "profiles/**/*.*",
+        included: false,
+      },
+      {
         pattern: "node_modules/idb/**/*.js",
         included: false,
       },
@@ -97,6 +101,7 @@ module.exports = function(config) {
       "/assets/": "/base/assets/",
       "/js/": "/base/js/",
       "/src/": "/base/src/",
+      "/profiles/": "/base/profiles/",
       "/node_modules/": "/base/node_modules/",
       "/builds/": "/base/builds/",
       "/tests/": "/base/tests/",
@@ -164,6 +169,11 @@ module.exports = function(config) {
       args: ["--grep", config.grep || ""],
     },
   };
+
+  if (process.env.GITHUB_WORKFLOW) {
+    options.files.unshift("tests/use_bundled_profile.js");
+  }
+
   if (process.env.TRAVIS) {
     process.env.CHROME_BIN = require("puppeteer").executablePath();
     options.autoWatch = false;

--- a/tests/spec/SpecHelper.js
+++ b/tests/spec/SpecHelper.js
@@ -67,7 +67,9 @@ function decorateDocument(doc, opts) {
     const { profile } = opts;
     const loader = doc.createElement("script");
     loader.classList.add("remove");
-    loader.src = `/base/builds/respec-${profile}.js`;
+    loader.src = window.USE_BUNDLED_PROFILE
+      ? `/base/builds/respec-${profile}.js`
+      : `/base/profiles/${profile}.js`;
     doc.head.appendChild(loader);
   }
 

--- a/tests/use_bundled_profile.js
+++ b/tests/use_bundled_profile.js
@@ -1,0 +1,1 @@
+window.USE_BUNDLED_PROFILE = true;


### PR DESCRIPTION
TODO: remove build step from tools/dev-server.js, which should make tools/dev-server.js essentially redundant.