### PR TITLE
chore(.github): point OpenCollective in Sponsors

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: respec


### PR DESCRIPTION
This way we can get a nice Sponsor button at the top of the GitHub page, [as parceljs has](https://github.com/parcel-bundler/parcel/blob/v2/.github/FUNDING.yml). 

![image](https://user-images.githubusercontent.com/3396686/70863261-714be000-1f89-11ea-9829-381c1647d5a6.png)
