### PR TITLE
fix(core/markdown): indent idl correctly after a list

### DIFF
--- a/src/core/markdown.js
+++ b/src/core/markdown.js
@@ -246,10 +246,10 @@ function enableBlockLevelMarkdown(element, selector) {
   for (const element of elements) {
     // Double newlines are needed to be parsed as Markdown
     const { innerHTML } = element;
-    if (!innerHTML.match(/^\n\s*\n/)) {
+    if (!/^\n\s*\n/.test(innerHTML)) {
       element.prepend("\n\n");
     }
-    if (!innerHTML.match(/\n\s*\n$/)) {
+    if (!/\n\s*\n$/.test(innerHTML)) {
       element.append("\n\n");
     }
   }

--- a/src/core/markdown.js
+++ b/src/core/markdown.js
@@ -49,7 +49,6 @@ export const name = "core/markdown";
 
 const gtEntity = /&gt;/gm;
 const ampEntity = /&amp;/gm;
-const endsWithSpace = /\s+$/gm;
 
 const inlineElems = new Set([
   "a",
@@ -194,10 +193,7 @@ function normalizePadding(text) {
   }
   const wrap = document.createElement("body");
   wrap.append(doc);
-  const result = endsWithSpace.test(wrap.innerHTML)
-    ? `${wrap.innerHTML.trimRight()}\n`
-    : wrap.innerHTML;
-  return result;
+  return wrap.innerHTML;
 }
 
 /**

--- a/src/core/markdown.js
+++ b/src/core/markdown.js
@@ -249,8 +249,12 @@ function enableBlockLevelMarkdown(element, selector) {
   const elements = element.querySelectorAll(selector);
   for (const element of elements) {
     // Double newlines are needed to be parsed as Markdown
-    if (!element.innerHTML.match(/^\n\s*\n/)) {
+    const { innerHTML } = element;
+    if (!innerHTML.match(/^\n\s*\n/)) {
       element.prepend("\n\n");
+    }
+    if (!innerHTML.match(/\n\s*\n$/)) {
+      element.append("\n\n");
     }
   }
 }

--- a/tests/spec/core/markdown-spec.js
+++ b/tests/spec/core/markdown-spec.js
@@ -424,9 +424,9 @@ describe("Core - Markdown", () => {
     it("parses indented <pre> after a list", async () => {
       const idl = `dictionary Indented {\n  any shouldBeIndented();\n};`;
       const body = `
-        <section>
+        <div>
         1. I lack double newlines between HTML block
-        </section>
+        </div>
         <pre class="idl" id="pre">
         dictionary Indented {
           any shouldBeIndented();

--- a/tests/spec/core/markdown-spec.js
+++ b/tests/spec/core/markdown-spec.js
@@ -360,6 +360,7 @@ describe("Core - Markdown", () => {
       expect(text3.innerHTML).toBe(`test3 text "<code>inner text</code>".`);
     });
   });
+
   describe("data-format=markdown", () => {
     it("replaces processes data-format=markdown sections, but leaves other sections alone", async () => {
       const body = `
@@ -393,6 +394,7 @@ describe("Core - Markdown", () => {
       expect(dontChange).toBe("## this should not change");
     });
   });
+
   describe("Whitespace compatibility", () => {
     it("normalises whitespace, but ignore white with pre tags", async () => {
       const str = `   trim start\n    * trim 3 from start \n\n <pre>trim 1\n   if(x){\n\t party()</pre>\n  foo \n    bar`;
@@ -415,6 +417,27 @@ describe("Core - Markdown", () => {
       expect(preText[0]).toBe("trim 1");
       expect(preText[1]).toBe("   if(x){");
       expect(preText[2]).toBe("     party()");
+    });
+  });
+
+  describe("Markdown-inside-block backward compatibility", () => {
+    it("parses indented <pre> after a list", async () => {
+      const idl = `dictionary Indented {\n  any shouldBeIndented();\n};`;
+      const body = `
+        <section>
+        1. I lack double newlines between HTML block
+        </section>
+        <pre class="idl" id="pre">
+        dictionary Indented {
+          any shouldBeIndented();
+        };
+        </pre>
+      `;
+      const ops = makeStandardOps({ format: "markdown" }, body);
+      const doc = await makeRSDoc(ops);
+      const pre = doc.getElementById("pre");
+
+      expect(pre.textContent).toBe(idl);
     });
   });
 });


### PR DESCRIPTION
Fixing a regression found in wicg/serial:

![image](https://user-images.githubusercontent.com/3396686/71002037-d89c9800-2121-11ea-8fc6-9d87f4c1f3b2.png)

Lack of newlines before HTML end tags caused this.