### PR TITLE
fix(core/l10n): fallback to 'en' for missing l10n keys

### DIFF
--- a/src/core/best-practices.js
+++ b/src/core/best-practices.js
@@ -4,7 +4,7 @@
 // The summary is generated if there is a section in the document with ID bp-summary.
 // Best practices are marked up with span.practicelab.
 import { addId, makeSafeCopy } from "./utils.js";
-import { lang as defaultLang } from "../core/l10n.js";
+import { lang as defaultLang, getIntlData } from "../core/l10n.js";
 import { hyperHTML } from "./import-maps.js";
 import { pub } from "./pubsubhub.js";
 
@@ -15,12 +15,12 @@ const localizationStrings = {
     best_practice: "Best Practice ",
   },
 };
+const l10n = getIntlData(localizationStrings);
 const lang = defaultLang in localizationStrings ? defaultLang : "en";
 
 export function run() {
   /** @type {NodeListOf<HTMLElement>} */
   const bps = document.querySelectorAll(".practicelab");
-  const l10n = localizationStrings[lang];
   const bpSummary = document.getElementById("bp-summary");
   const summaryItems = bpSummary ? document.createElement("ul") : null;
   [...bps].forEach((bp, num) => {

--- a/src/core/data-tests.js
+++ b/src/core/data-tests.js
@@ -9,11 +9,11 @@
  *
  * Docs: https://github.com/w3c/respec/wiki/data-tests
  */
-import { lang as defaultLang } from "./l10n.js";
+import { getIntlData } from "./l10n.js";
 import { hyperHTML } from "./import-maps.js";
 import { pub } from "./pubsubhub.js";
 import { showInlineWarning } from "./utils.js";
-const l10n = {
+const localizationStrings = {
   en: {
     missing_test_suite_uri:
       "Found tests in your spec, but missing '" +
@@ -23,9 +23,9 @@ const l10n = {
   },
 };
 
-export const name = "core/data-tests";
+const l10n = getIntlData(localizationStrings);
 
-const lang = defaultLang in l10n ? defaultLang : "en";
+export const name = "core/data-tests";
 
 function toListItem(href) {
   const emojiList = [];
@@ -82,7 +82,7 @@ export function run(conf) {
     return;
   }
   if (!conf.testSuiteURI) {
-    pub("error", l10n[lang].missing_test_suite_uri);
+    pub("error", l10n.missing_test_suite_uri);
     return;
   }
 
@@ -105,7 +105,7 @@ function toTestURLs(tests, testSuiteURI) {
       try {
         return new URL(test, testSuiteURI).href;
       } catch {
-        pub("warn", `${l10n[lang].bad_uri}: ${test}`);
+        pub("warn", `Bad URI: ${test}`);
       }
     })
     .filter(href => href);

--- a/src/core/examples.js
+++ b/src/core/examples.js
@@ -7,8 +7,8 @@
 // be used by a containing shell to extract all examples.
 
 import { addId } from "./utils.js";
-import { lang as defaultLang } from "../core/l10n.js";
 import { fetchAsset } from "./text-loader.js";
+import { getIntlData } from "../core/l10n.js";
 import { hyperHTML as html } from "./import-maps.js";
 import { pub } from "./pubsubhub.js";
 
@@ -26,9 +26,7 @@ const localizationStrings = {
   },
 };
 
-const lang = defaultLang in localizationStrings ? defaultLang : "en";
-
-const l10n = localizationStrings[lang];
+const l10n = getIntlData(localizationStrings);
 
 const cssPromise = loadStyle();
 

--- a/src/core/figures.js
+++ b/src/core/figures.js
@@ -5,7 +5,7 @@
 // Generates a Table of Figures wherever there is a #tof element.
 
 import { addId, renameElement, showInlineWarning, wrapInner } from "./utils.js";
-import { lang as defaultLang } from "../core/l10n.js";
+import { getIntlData } from "../core/l10n.js";
 import { hyperHTML } from "./import-maps.js";
 
 export const name = "core/figures";
@@ -37,9 +37,7 @@ const localizationStrings = {
   },
 };
 
-const lang = defaultLang in localizationStrings ? defaultLang : "en";
-
-const l10n = localizationStrings[lang];
+const l10n = getIntlData(localizationStrings);
 
 export function run() {
   normalizeImages(document);

--- a/src/core/github.js
+++ b/src/core/github.js
@@ -5,7 +5,7 @@
  * @see https://github.com/w3c/respec/wiki/github
  */
 
-import { lang as defaultLang } from "../core/l10n.js";
+import { getIntlData } from "../core/l10n.js";
 import { pub } from "./pubsubhub.js";
 export const name = "core/github";
 
@@ -37,8 +37,7 @@ const localizationStrings = {
     participate: "Participe",
   },
 };
-const lang = defaultLang in localizationStrings ? defaultLang : "en";
-const l10n = localizationStrings[lang];
+const l10n = getIntlData(localizationStrings);
 
 export async function run(conf) {
   if (!conf.hasOwnProperty("github") || !conf.github) {

--- a/src/core/informative.js
+++ b/src/core/informative.js
@@ -1,7 +1,7 @@
 // @ts-check
 // Module core/informative
 // Mark specific sections as informative, based on CSS
-import { lang as defaultLang } from "../core/l10n.js";
+import { getIntlData } from "../core/l10n.js";
 import { hyperHTML } from "./import-maps.js";
 
 export const name = "core/informative";
@@ -15,9 +15,7 @@ const localizationStrings = {
   },
 };
 
-const lang = defaultLang in localizationStrings ? defaultLang : "en";
-
-const l10n = localizationStrings[lang];
+const l10n = getIntlData(localizationStrings);
 
 export function run() {
   Array.from(document.querySelectorAll("section.informative"))

--- a/src/core/issues-notes.js
+++ b/src/core/issues-notes.js
@@ -12,8 +12,8 @@
 // If the configuration has issueBase set to a non-empty string, and issues are
 // manually numbered, a link to the issue is created using issueBase and the issue number
 import { addId, joinAnd, parents } from "./utils.js";
-import { lang as defaultLang } from "../core/l10n.js";
 import { fetchAsset } from "./text-loader.js";
+import { getIntlData } from "../core/l10n.js";
 import { hyperHTML } from "./import-maps.js";
 import { pub } from "./pubsubhub.js";
 
@@ -44,9 +44,7 @@ async function loadStyle() {
   }
 }
 
-const lang = defaultLang in localizationStrings ? defaultLang : "en";
-
-const l10n = localizationStrings[lang];
+const l10n = getIntlData(localizationStrings);
 
 /**
  * @typedef {object} Report

--- a/src/core/l10n.js
+++ b/src/core/l10n.js
@@ -171,6 +171,22 @@ l10n["zh-cn"] = l10n.zh;
 
 export const lang = html && html.lang in l10n ? html.lang : "en";
 
+/**
+ * @typedef {Record<string, Record<string, string|Function>>} LanguageData
+ * @type {<T extends LanguageData>(obj: T) => T[keyof T]}
+ */
+export function getIntlData(languageData) {
+  // Proxy return type is a known bug:
+  // https://github.com/Microsoft/TypeScript/issues/20846
+  // @ts-ignore
+  return new Proxy(languageData, {
+    /** @param {string} key */
+    get(data, key) {
+      return data[lang][key] || data.en[key] || key;
+    },
+  });
+}
+
 export function run(config) {
   config.l10n = l10n[lang] || l10n.en;
 }

--- a/src/core/l10n.js
+++ b/src/core/l10n.js
@@ -182,7 +182,11 @@ export function getIntlData(languageData) {
   return new Proxy(languageData, {
     /** @param {string} key */
     get(data, key) {
-      return data[lang][key] || data.en[key] || key;
+      const result = data[lang][key] || data.en[key];
+      if (!result) {
+        throw new Error(`No l10n data for key: "${key}"`);
+      }
+      return result;
     },
   });
 }

--- a/src/core/l10n.js
+++ b/src/core/l10n.js
@@ -175,11 +175,11 @@ export const lang = html && html.lang in l10n ? html.lang : "en";
  * @typedef {Record<string, Record<string, string|Function>>} LanguageData
  * @type {<T extends LanguageData>(obj: T) => T[keyof T]}
  */
-export function getIntlData(languageData) {
+export function getIntlData(localizationStrings) {
   // Proxy return type is a known bug:
   // https://github.com/Microsoft/TypeScript/issues/20846
   // @ts-ignore
-  return new Proxy(languageData, {
+  return new Proxy(localizationStrings, {
     /** @param {string} key */
     get(data, key) {
       const result = data[lang][key] || data.en[key];

--- a/src/core/l10n.js
+++ b/src/core/l10n.js
@@ -172,10 +172,7 @@ l10n["zh-cn"] = l10n.zh;
 export const lang = html && html.lang in l10n ? html.lang : "en";
 
 /**
- * @typedef {Record<string, Record<string, string|Function>>} LocalizationStrings
- */
-/**
- * @template {LocalizationStrings} T
+ * @template {Record<string, Record<string, string|Function>>} T
  * @param {T} localizationStrings
  * @returns {T[keyof T]}
  */

--- a/src/core/l10n.js
+++ b/src/core/l10n.js
@@ -172,8 +172,12 @@ l10n["zh-cn"] = l10n.zh;
 export const lang = html && html.lang in l10n ? html.lang : "en";
 
 /**
- * @typedef {Record<string, Record<string, string|Function>>} LanguageData
- * @type {<T extends LanguageData>(obj: T) => T[keyof T]}
+ * @typedef {Record<string, Record<string, string|Function>>} LocalizationStrings
+ */
+/**
+ * @template {LocalizationStrings} T
+ * @param {T} localizationStrings
+ * @returns {T[keyof T]}
  */
 export function getIntlData(localizationStrings) {
   // Proxy return type is a known bug:

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -10,12 +10,13 @@ import {
   wrapInner,
 } from "./utils.js";
 import { run as addExternalReferences } from "./xref.js";
-import { lang as defaultLang } from "./l10n.js";
 import { definitionMap } from "./dfn-map.js";
+import { getIntlData } from "./l10n.js";
 import { linkInlineCitations } from "./data-cite.js";
 import { pub } from "./pubsubhub.js";
 export const name = "core/link-to-dfn";
-const l10n = {
+
+const localizationStrings = {
   en: {
     /**
      * @param {string} title
@@ -26,7 +27,7 @@ const l10n = {
     duplicateTitle: "This is defined more than once in the document.",
   },
 };
-const lang = defaultLang in l10n ? defaultLang : "en";
+const l10n = getIntlData(localizationStrings);
 
 class CaseInsensitiveMap extends Map {
   /**
@@ -107,8 +108,8 @@ function mapTitleToDfns() {
     if (duplicates.length > 0) {
       showInlineError(
         duplicates,
-        l10n[lang].duplicateMsg(title),
-        l10n[lang].duplicateTitle
+        l10n.duplicateMsg(title),
+        l10n.duplicateTitle
       );
     }
   });

--- a/src/core/render-biblio.js
+++ b/src/core/render-biblio.js
@@ -4,7 +4,7 @@
 
 import { addId } from "./utils.js";
 import { biblio } from "./biblio.js";
-import { lang as defaultLang } from "../core/l10n.js";
+import { getIntlData } from "../core/l10n.js";
 import { hyperHTML } from "./import-maps.js";
 import { pub } from "./pubsubhub.js";
 
@@ -28,9 +28,7 @@ const localizationStrings = {
   },
 };
 
-const lang = defaultLang in localizationStrings ? defaultLang : "en";
-
-const l10n = localizationStrings[lang];
+const l10n = getIntlData(localizationStrings);
 
 const REF_STATUSES = new Map([
   ["CR", "W3C Candidate Recommendation"],

--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -11,7 +11,7 @@
 //  - maxTocLevel: only generate a TOC so many levels deep
 
 import { addId, children, parents, renameElement } from "./utils.js";
-import { lang as defaultLang } from "../core/l10n.js";
+import { getIntlData } from "../core/l10n.js";
 import { hyperHTML } from "./import-maps.js";
 
 const lowerHeaderTags = ["h2", "h3", "h4", "h5", "h6"];
@@ -32,9 +32,7 @@ const localizationStrings = {
   },
 };
 
-const lang = defaultLang in localizationStrings ? defaultLang : "en";
-
-const l10n = localizationStrings[lang];
+const l10n = getIntlData(localizationStrings);
 
 /**
  * @typedef {object} SectionInfo


### PR DESCRIPTION
We were doing l10n migration to modules wrong :fire:  
We were assuming if we have some translations for a language, we have all translations for that language.
This was taken into account when we had `core/l10n`, where we added default as `en` by Object spread.

Consider:
``` js
const localizationStrings = {
  en: { key1, key2, key3 },
  ja: { key1 } // we assumed `lang` as "ja" even when key2, key3 are undefined 
}
```

Also, a little refactor as we don't have to `const lang = defaultLang in l10n ? defaultLang : "en";` in every module.

Alternate approach considered: `{...en, ...[lang]}`. Decided to go against it as it creates a new clone (not sure how bad it could be though).
Proxy approach also allows us to show a missing translation/invalid key warning if we want to.