### PR TITLE
test(core/markdown): <pre> should not parse as markdown

### DIFF
--- a/tests/spec/core/markdown-spec.js
+++ b/tests/spec/core/markdown-spec.js
@@ -330,6 +330,22 @@ function getAnswer() {
     expect(pre.textContent).toBe(idl);
   });
 
+  it("does not parse texts inside <pre> as markdown", async () => {
+    const code = `1 * 2 * 3;`;
+    const body = `
+      <pre class="example">
+      ${code}
+      </pre>
+    `;
+
+    const ops = makeStandardOps({ format: "markdown" }, body);
+    ops.abstract = null;
+    const doc = await makeRSDoc(ops);
+    const pre = doc.querySelector("pre");
+
+    expect(pre.textContent).toBe(code);
+  });
+
   describe("nolinks options", () => {
     it("automatically links URLs in pre when missing (smoke test)", async () => {
       const body = `


### PR DESCRIPTION
Our wiki currently says:

> ## Known issues
> 
> In some cases, the markdown processor gets confused. For example, given: 
> 
> ```HTML
> <pre class="example">
> 1 * 2 * 3;
> </pre>
> ``` 
> 
> The "`*`"s get converted to an `<em>`. Obviously, that's not ideal. A workaround is to wrap the "*" in back-ticks, like this:
> 
> ```HTML
> <pre class="example">
> 1 `*` 2 `*` 3;
> </pre>
> ```

This is not true anymore, so this PR makes sure that won't happen.