### PR TITLE
feat: allow overriding copyright using HTML

### DIFF
--- a/src/w3c/templates/cgbg-headers.js
+++ b/src/w3c/templates/cgbg-headers.js
@@ -114,7 +114,7 @@ export default conf => {
           `
         : ""}
       ${existingCopyright
-        ? [existingCopyright]
+        ? existingCopyright
         : html`
             <p class="copyright">
               <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright"

--- a/src/w3c/templates/cgbg-headers.js
+++ b/src/w3c/templates/cgbg-headers.js
@@ -5,6 +5,10 @@ import showLogo from "./show-logo.js";
 import showPeople from "./show-people.js";
 
 export default conf => {
+  const existingCopyright = document.querySelector(".copyright");
+  if (existingCopyright) {
+    existingCopyright.remove();
+  }
   return html`
     <div class="head">
       ${conf.logos.map(showLogo)}
@@ -109,41 +113,48 @@ export default conf => {
             </p>
           `
         : ""}
-      <p class="copyright">
-        <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright"
-          >Copyright</a
-        >
-        &copy;
-        ${conf.copyrightStart
-          ? `${conf.copyrightStart}-`
-          : ""}${conf.publishYear}
-        ${conf.additionalCopyrightHolders
-          ? html`
-              ${[conf.additionalCopyrightHolders]} &amp;
-            `
-          : ""}
-        the Contributors to the ${conf.title} Specification, published by the
-        <a href="${conf.wgURI}">${conf.wg}</a> under the
-        ${conf.isCGFinal
-          ? html`
-              <a href="https://www.w3.org/community/about/agreements/fsa/"
-                >W3C Community Final Specification Agreement (FSA)</a
-              >. A human-readable
-              <a href="https://www.w3.org/community/about/agreements/fsa-deed/"
-                >summary</a
+      ${existingCopyright
+        ? [existingCopyright]
+        : html`
+            <p class="copyright">
+              <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright"
+                >Copyright</a
               >
-              is available.
-            `
-          : html`
-              <a href="https://www.w3.org/community/about/agreements/cla/"
-                >W3C Community Contributor License Agreement (CLA)</a
-              >. A human-readable
-              <a href="https://www.w3.org/community/about/agreements/cla-deed/"
-                >summary</a
-              >
-              is available.
-            `}
-      </p>
+              &copy;
+              ${conf.copyrightStart
+                ? `${conf.copyrightStart}-`
+                : ""}${conf.publishYear}
+              ${conf.additionalCopyrightHolders
+                ? html`
+                    ${[conf.additionalCopyrightHolders]} &amp;
+                  `
+                : ""}
+              the Contributors to the ${conf.title} Specification, published by
+              the
+              <a href="${conf.wgURI}">${conf.wg}</a> under the
+              ${conf.isCGFinal
+                ? html`
+                    <a href="https://www.w3.org/community/about/agreements/fsa/"
+                      >W3C Community Final Specification Agreement (FSA)</a
+                    >. A human-readable
+                    <a
+                      href="https://www.w3.org/community/about/agreements/fsa-deed/"
+                      >summary</a
+                    >
+                    is available.
+                  `
+                : html`
+                    <a href="https://www.w3.org/community/about/agreements/cla/"
+                      >W3C Community Contributor License Agreement (CLA)</a
+                    >. A human-readable
+                    <a
+                      href="https://www.w3.org/community/about/agreements/cla-deed/"
+                      >summary</a
+                    >
+                    is available.
+                  `}
+            </p>
+          `}
       <hr title="Separator for header" />
     </div>
   `;

--- a/src/w3c/templates/headers.js
+++ b/src/w3c/templates/headers.js
@@ -201,6 +201,18 @@ function linkLicense(text, url, cssClass) {
 }
 
 function renderCopyright(conf) {
+  // If there is already a copyright, let's relocate it.
+  const existingCopyright = document.querySelector(".copyright");
+  if (existingCopyright) {
+    existingCopyright.remove();
+    return existingCopyright;
+  }
+  if (conf.hasOwnProperty("overrideCopyright")) {
+    const msg =
+      "The `overrideCopyright` configuration option is deprecated. " +
+      'Please use `<p class="copyright">` instead.';
+    pub("warn", msg);
+  }
   return conf.isUnofficial
     ? conf.additionalCopyrightHolders
       ? html`

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -922,6 +922,36 @@ describe("W3C — Headers", () => {
     });
   });
 
+  it("it allows custom copyright directly in document, which gets relocated to the .head", async () => {
+    const body = `
+      <p class="copyright">
+        No copyright intended.
+      </p>
+    `;
+    const ops = makeStandardOps({}, body);
+    const doc = await makeRSDoc(ops);
+    const copyright = doc.querySelector(".head p.copyright");
+    expect(copyright).toBeTruthy();
+    expect(copyright.textContent.trim()).toBe("No copyright intended.");
+    expect(doc.querySelectorAll(".copyright").length).toBe(1);
+  });
+
+  it("it allows custom copyright for different kinds of documents", async () => {
+    const body = `
+      <p class="copyright">
+        No copyright intended.
+      </p>
+    `;
+    for (const specStatus of ["CD-DRAFT", "unofficial", "CG-FINAL"]) {
+      const ops = makeStandardOps({ specStatus }, body);
+      const doc = await makeRSDoc(ops);
+      const copyright = doc.querySelector(".head p.copyright");
+      expect(copyright).toBeTruthy();
+      expect(copyright.textContent.trim()).toBe("No copyright intended.");
+      expect(doc.querySelectorAll(".copyright").length).toBe(1);
+    }
+  });
+
   describe("overrideCopyright", () => {
     it("takes overrideCopyright into account", async () => {
       const ops = makeStandardOps();


### PR DESCRIPTION
This allows editors to provide their own copyright markup via:

```HTML
<p class="copyright">
  My custom copyright.  
</p>
```

Closes #263
Closes #2243
