### PR TITLE
feat(core/structure): prefer `heading.id` over `section.id`

### DIFF
--- a/src/core/id-headers.js
+++ b/src/core/id-headers.js
@@ -13,9 +13,13 @@ export function run(conf) {
     `section:not(.head):not(.introductory) h2, h3, h4, h5, h6`
   );
   for (const h of headings) {
-    addId(h);
+    // prefer for ID: heading.id > parentElement.id > newly generated heading.id
+    let id = h.id;
+    if (!id) {
+      addId(h);
+      id = h.parentElement.id || h.id;
+    }
     if (!conf.addSectionLinks) continue;
-    const id = h.parentElement.id || h.id;
     h.appendChild(hyperHTML`
       <a href="${`#${id}`}" class="self-link" aria-label="§"></a>
     `);

--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -80,7 +80,8 @@ function scanSections(sections, maxTocLevel, { prefix = "" } = {}) {
     }
 
     if (level <= maxTocLevel) {
-      const item = createTocListItem(section.header, section.element.id);
+      const id = section.header.id || section.element.id;
+      const item = createTocListItem(section.header, id);
       const sub = scanSections(section.subsections, maxTocLevel, {
         prefix: secno,
       });

--- a/tests/spec/core/id-headers-spec.js
+++ b/tests/spec/core/id-headers-spec.js
@@ -9,7 +9,7 @@ describe("Core - ID headers", () => {
     <section class="introductory"><h2>Intro</h2></section>
     <section id="t0"><p>BLAH</p><h6>FOO</h6></section>
     <section><h2>test-1</h2></section>
-    <section><h2>Pass</h2></section>
+    <section><h2 id="custom-id">Pass</h2></section>
     <section id="sotd">
     <p>...</p>
     <section>
@@ -59,7 +59,7 @@ describe("Core - ID headers", () => {
       expect(test1.getAttribute("href")).toBe("#test-1");
 
       const test2 = doc.querySelector("#pass > h2 > a.self-link");
-      expect(test2.getAttribute("href")).toBe("#pass");
+      expect(test2.getAttribute("href")).toBe("#custom-id");
     });
 
     it("doesn't add section links to h2s .introductory, but h3, h4s are ok", () => {

--- a/tests/spec/core/structure-spec.js
+++ b/tests/spec/core/structure-spec.js
@@ -1,6 +1,11 @@
 "use strict";
 
-import { makeBasicConfig, makeDefaultBody, makeRSDoc } from "../SpecHelper.js";
+import {
+  makeBasicConfig,
+  makeDefaultBody,
+  makeRSDoc,
+  makeStandardOps,
+} from "../SpecHelper.js";
 import { children } from "../../../src/core/utils.js";
 
 describe("Core - Structure", () => {
@@ -232,5 +237,20 @@ describe("Core - Structure", () => {
       expect(anchor.classList).toContain("sec-ref");
       expect(anchor.textContent).toContain("Sample Interface");
     });
+  });
+
+  it("prefers heading id over section id for linking", async () => {
+    const body = `
+      <section><h2>ONE</h2></section>
+      <section><h2 id="zwei">TWO</h2></section>
+    `;
+
+    const ops = makeStandardOps(null, body);
+    const doc = await makeRSDoc(ops);
+    const links = doc.querySelectorAll("#toc li > a");
+    expect(links[0].hash).toBe("#one");
+    expect(links[0].textContent).toBe("1. ONE");
+    expect(links[1].hash).toBe("#zwei");
+    expect(links[1].textContent).toBe("2. TWO");
   });
 });


### PR DESCRIPTION
Prefer `heading.id` for TOC linking and self linking.