### PR TITLE
refactor(w3c/templates/cgbg-sotd): contain its own l10n strings

### DIFF
--- a/src/w3c/templates/cgbg-sotd.js
+++ b/src/w3c/templates/cgbg-sotd.js
@@ -1,9 +1,10 @@
 // @ts-check
 import { hyperHTML as html } from "../../core/import-maps.js";
+import { l10n } from "./sotd.js";
 
 export default (conf, opts) => {
   return html`
-    <h2>${conf.l10n.sotd}</h2>
+    <h2>${l10n.sotd}</h2>
     ${conf.isPreview
       ? html`
           <details class="annoying-warning" open="">

--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -23,7 +23,7 @@ const localizationStrings = {
   },
 };
 
-const l10n = getIntlData(localizationStrings);
+export const l10n = getIntlData(localizationStrings);
 
 export default (conf, opts) => {
   return html`


### PR DESCRIPTION
refactor code for issue #2084 