### PR TITLE
feat(core/markdown): allow custom ID for headings

### DIFF
--- a/src/core/markdown.js
+++ b/src/core/markdown.js
@@ -59,6 +59,15 @@ class Renderer extends marked.Renderer {
     }
     return super.code(code, language, isEscaped);
   }
+
+  heading(text, level, raw, slugger) {
+    const headingWithIdRegex = /(.+)\s+{#([\w-]+)}$/;
+    if (headingWithIdRegex.test(text)) {
+      const [, textContent, id] = text.match(headingWithIdRegex);
+      return `<h${level} id="${id}">${textContent}</h${level}>`;
+    }
+    return super.heading(text, level, raw, slugger);
+  }
 }
 
 /**

--- a/tests/spec/core/markdown-spec.js
+++ b/tests/spec/core/markdown-spec.js
@@ -103,6 +103,43 @@ describe("Core - Markdown", () => {
     }
   });
 
+  it("allows custom ids to headers", async () => {
+    const body = `
+## Heading {#custom-id}
+PASS
+
+Foo title {#foo}
+=========
+PASS
+
+Bar title {#bar}
+------------------------------
+PASS
+
+## Another title
+PASS
+`;
+    const ops = makeStandardOps({ format: "markdown" }, body);
+    const doc = await makeRSDoc(ops);
+
+    const headings = doc.querySelectorAll("nav ~ section h2, nav ~ section h3");
+    expect(headings.length).toBe(4);
+
+    const [customID, foo, bar, automaticId] = headings;
+
+    expect(customID.id).toBe("custom-id");
+    expect(customID.textContent).toBe("1. Heading");
+
+    expect(foo.id).toBe("foo");
+    expect(foo.textContent).toBe("2. Foo title");
+
+    expect(bar.id).toBe("bar");
+    expect(bar.textContent).toBe("2.1 Bar title");
+
+    expect(automaticId.id).toBe("x2-2-another-title");
+    expect(automaticId.textContent).toBe("2.2 Another title");
+  });
+
   it("structures content in nested sections with appropriate titles", async () => {
     const body = `
 

--- a/tests/spec/core/markdown-spec.js
+++ b/tests/spec/core/markdown-spec.js
@@ -105,24 +105,25 @@ describe("Core - Markdown", () => {
 
   it("allows custom ids to headers", async () => {
     const body = `
-## Heading {#custom-id}
-PASS
+      ## Heading {#custom-id}
+      PASS
 
-Foo title {#foo}
-=========
-PASS
+      Foo title {#foo}
+      =========
+      PASS
 
-Bar title {#bar}
-------------------------------
-PASS
+      Bar title {#bar}
+      ------------------------------
+      PASS
 
-## Another title
-PASS
-`;
+      ## Another title
+      PASS
+    `;
     const ops = makeStandardOps({ format: "markdown" }, body);
+    ops.abstract = null;
     const doc = await makeRSDoc(ops);
 
-    const headings = doc.querySelectorAll("nav ~ section h2, nav ~ section h3");
+    const headings = doc.querySelectorAll("section h2, section h3");
     expect(headings.length).toBe(4);
 
     const [customID, foo, bar, automaticId] = headings;


### PR DESCRIPTION
Allows passing custom headings like:
``` markdown
## Heading {#custom-id}

Foo title {#foo}
================

```