### PR TITLE
fix(core/l10n): do not throw if l10n strings don't exist for lang

### DIFF
--- a/src/core/best-practices.js
+++ b/src/core/best-practices.js
@@ -3,8 +3,8 @@
 // Handles the marking up of best practices, and can generate a summary of all of them.
 // The summary is generated if there is a section in the document with ID bp-summary.
 // Best practices are marked up with span.practicelab.
-import { addId, makeSafeCopy } from "./utils.js";
-import { lang as defaultLang, getIntlData } from "../core/l10n.js";
+import { addId, getIntlData, makeSafeCopy } from "./utils.js";
+import { lang as defaultLang } from "../core/l10n.js";
 import { hyperHTML } from "./import-maps.js";
 import { pub } from "./pubsubhub.js";
 

--- a/src/core/data-tests.js
+++ b/src/core/data-tests.js
@@ -9,10 +9,9 @@
  *
  * Docs: https://github.com/w3c/respec/wiki/data-tests
  */
-import { getIntlData } from "./l10n.js";
+import { getIntlData, showInlineWarning } from "./utils.js";
 import { hyperHTML } from "./import-maps.js";
 import { pub } from "./pubsubhub.js";
-import { showInlineWarning } from "./utils.js";
 const localizationStrings = {
   en: {
     missing_test_suite_uri:

--- a/src/core/examples.js
+++ b/src/core/examples.js
@@ -6,9 +6,8 @@
 // When an example is found, it is reported using the "example" event. This can
 // be used by a containing shell to extract all examples.
 
-import { addId } from "./utils.js";
+import { addId, getIntlData } from "./utils.js";
 import { fetchAsset } from "./text-loader.js";
-import { getIntlData } from "../core/l10n.js";
 import { hyperHTML as html } from "./import-maps.js";
 import { pub } from "./pubsubhub.js";
 

--- a/src/core/figures.js
+++ b/src/core/figures.js
@@ -4,8 +4,13 @@
 // Adds width and height to images, if they are missing.
 // Generates a Table of Figures wherever there is a #tof element.
 
-import { addId, renameElement, showInlineWarning, wrapInner } from "./utils.js";
-import { getIntlData } from "../core/l10n.js";
+import {
+  addId,
+  getIntlData,
+  renameElement,
+  showInlineWarning,
+  wrapInner,
+} from "./utils.js";
 import { hyperHTML } from "./import-maps.js";
 
 export const name = "core/figures";

--- a/src/core/github.js
+++ b/src/core/github.js
@@ -5,7 +5,7 @@
  * @see https://github.com/w3c/respec/wiki/github
  */
 
-import { getIntlData } from "../core/l10n.js";
+import { getIntlData } from "../core/utils.js";
 import { pub } from "./pubsubhub.js";
 export const name = "core/github";
 

--- a/src/core/informative.js
+++ b/src/core/informative.js
@@ -1,7 +1,7 @@
 // @ts-check
 // Module core/informative
 // Mark specific sections as informative, based on CSS
-import { getIntlData } from "../core/l10n.js";
+import { getIntlData } from "../core/utils.js";
 import { hyperHTML } from "./import-maps.js";
 
 export const name = "core/informative";

--- a/src/core/issues-notes.js
+++ b/src/core/issues-notes.js
@@ -11,9 +11,8 @@
 // numbered to avoid involuntary clashes.
 // If the configuration has issueBase set to a non-empty string, and issues are
 // manually numbered, a link to the issue is created using issueBase and the issue number
-import { addId, joinAnd, parents } from "./utils.js";
+import { addId, getIntlData, joinAnd, parents } from "./utils.js";
 import { fetchAsset } from "./text-loader.js";
-import { getIntlData } from "../core/l10n.js";
 import { hyperHTML } from "./import-maps.js";
 import { pub } from "./pubsubhub.js";
 

--- a/src/core/l10n.js
+++ b/src/core/l10n.js
@@ -6,7 +6,6 @@
  * to manage the config.l10n object so that other parts of the system can
  * localize their text.
  */
-import { getIntlData } from "./utils.js";
 
 export const name = "core/l10n";
 
@@ -124,8 +123,6 @@ l10n["zh-hans"] = l10n.zh;
 l10n["zh-cn"] = l10n.zh;
 
 export const lang = html && html.lang in l10n ? html.lang : "en";
-
-export { getIntlData };
 
 export function run(config) {
   config.l10n = l10n[lang] || l10n.en;

--- a/src/core/l10n.js
+++ b/src/core/l10n.js
@@ -135,7 +135,7 @@ export function getIntlData(localizationStrings) {
   return new Proxy(localizationStrings, {
     /** @param {string} key */
     get(data, key) {
-      const result = data[lang][key] || data.en[key];
+      const result = (data[lang] && data[lang][key]) || data.en[key];
       if (!result) {
         throw new Error(`No l10n data for key: "${key}"`);
       }

--- a/src/core/l10n.js
+++ b/src/core/l10n.js
@@ -6,6 +6,8 @@
  * to manage the config.l10n object so that other parts of the system can
  * localize their text.
  */
+import { getIntlData } from "./utils.js";
+
 export const name = "core/l10n";
 
 const html = document.documentElement;
@@ -123,26 +125,7 @@ l10n["zh-cn"] = l10n.zh;
 
 export const lang = html && html.lang in l10n ? html.lang : "en";
 
-/**
- * @template {Record<string, Record<string, string|Function>>} T
- * @param {T} localizationStrings
- * @returns {T[keyof T]}
- */
-export function getIntlData(localizationStrings) {
-  // Proxy return type is a known bug:
-  // https://github.com/Microsoft/TypeScript/issues/20846
-  // @ts-ignore
-  return new Proxy(localizationStrings, {
-    /** @param {string} key */
-    get(data, key) {
-      const result = (data[lang] && data[lang][key]) || data.en[key];
-      if (!result) {
-        throw new Error(`No l10n data for key: "${key}"`);
-      }
-      return result;
-    },
-  });
-}
+export { getIntlData };
 
 export function run(config) {
   config.l10n = l10n[lang] || l10n.en;

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -4,6 +4,7 @@
 // to the matching definitions.
 import {
   addId,
+  getIntlData,
   getLinkTargets,
   showInlineError,
   showInlineWarning,
@@ -11,7 +12,6 @@ import {
 } from "./utils.js";
 import { run as addExternalReferences } from "./xref.js";
 import { definitionMap } from "./dfn-map.js";
-import { getIntlData } from "./l10n.js";
 import { linkInlineCitations } from "./data-cite.js";
 import { pub } from "./pubsubhub.js";
 export const name = "core/link-to-dfn";

--- a/src/core/render-biblio.js
+++ b/src/core/render-biblio.js
@@ -2,9 +2,8 @@
 // Module core/render-biblio
 // renders the biblio data pre-processed in core/biblio
 
-import { addId } from "./utils.js";
+import { addId, getIntlData } from "./utils.js";
 import { biblio } from "./biblio.js";
-import { getIntlData } from "../core/l10n.js";
 import { hyperHTML } from "./import-maps.js";
 import { pub } from "./pubsubhub.js";
 

--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -10,8 +10,13 @@
 //  - lang: can change the generated text (supported: en, fr)
 //  - maxTocLevel: only generate a TOC so many levels deep
 
-import { addId, children, parents, renameElement } from "./utils.js";
-import { getIntlData } from "../core/l10n.js";
+import {
+  addId,
+  children,
+  getIntlData,
+  parents,
+  renameElement,
+} from "./utils.js";
 import { hyperHTML } from "./import-maps.js";
 
 const lowerHeaderTags = ["h2", "h3", "h4", "h5", "h6"];

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -292,6 +292,27 @@ export function norm(str) {
   return str.trim().replace(/\s+/g, " ");
 }
 
+/**
+ * @template {Record<string, Record<string, string|Function>>} T
+ * @param {T} localizationStrings
+ * @returns {T[keyof T]}
+ */
+export function getIntlData(localizationStrings) {
+  // Proxy return type is a known bug:
+  // https://github.com/Microsoft/TypeScript/issues/20846
+  // @ts-ignore
+  return new Proxy(localizationStrings, {
+    /** @param {string} key */
+    get(data, key) {
+      const result = (data[docLang] && data[docLang][key]) || data.en[key];
+      if (!result) {
+        throw new Error(`No l10n data for key: "${key}"`);
+      }
+      return result;
+    },
+  });
+}
+
 // --- DATE HELPERS -------------------------------------------------------------------------------
 // Takes a Date object and an optional separator and returns the year,month,day representation with
 // the custom separator (defaulting to none) and proper 0-padding

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -297,14 +297,14 @@ export function norm(str) {
  * @param {T} localizationStrings
  * @returns {T[keyof T]}
  */
-export function getIntlData(localizationStrings) {
+export function getIntlData(localizationStrings, lang = docLang) {
   // Proxy return type is a known bug:
   // https://github.com/Microsoft/TypeScript/issues/20846
   // @ts-ignore
   return new Proxy(localizationStrings, {
     /** @param {string} key */
     get(data, key) {
-      const result = (data[docLang] && data[docLang][key]) || data.en[key];
+      const result = (data[lang] && data[lang][key]) || data.en[key];
       if (!result) {
         throw new Error(`No l10n data for key: "${key}"`);
       }

--- a/src/w3c/templates/headers.js
+++ b/src/w3c/templates/headers.js
@@ -1,7 +1,6 @@
 // @ts-check
-import { getIntlData } from "../../core/l10n.js";
+import { getIntlData, norm } from "../../core/utils.js";
 import { hyperHTML as html } from "../../core/import-maps.js";
-import { norm } from "../../core/utils.js";
 import { pub } from "../../core/pubsubhub.js";
 import showLink from "./show-link.js";
 import showLogo from "./show-logo.js";

--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { getIntlData } from "../../core/l10n.js";
+import { getIntlData } from "../../core/utils.js";
 import { hyperHTML as html } from "../../core/import-maps.js";
 
 const localizationStrings = {

--- a/tests/spec/core/utils-spec.js
+++ b/tests/spec/core/utils-spec.js
@@ -302,6 +302,37 @@ describe("Core - Utils", () => {
     });
   });
 
+  describe("getIntlData", () => {
+    const { getIntlData } = utils;
+    const localizationStrings = {
+      en: { foo: "EN Foo", bar: "EN Bar" },
+      ko: { foo: "KO Foo" },
+    };
+
+    it("returns localized string in given language", () => {
+      const intl = getIntlData(localizationStrings, "ko");
+      expect(intl.foo).toBe("KO Foo");
+
+      const intlEn = getIntlData(localizationStrings, "en");
+      expect(intlEn.foo).toBe("EN Foo");
+    });
+
+    it("falls back to English string if key does not exit in language", () => {
+      const intl = getIntlData(localizationStrings, "ko");
+      expect(intl.bar).toBe("EN Bar");
+    });
+
+    it("falls back to English string if language does not exit in language data", () => {
+      const intl = getIntlData(localizationStrings, "de");
+      expect(intl.bar).toBe("EN Bar");
+    });
+
+    it("throws error if key doesn't exist in either doc lang and English", () => {
+      const intl = getIntlData(localizationStrings, "de");
+      expect(() => intl.baz).toThrowError(/No l10n data for key/);
+    });
+  });
+
   describe("toKeyValuePairs", () => {
     it("converts objects to key values pairs", () => {
       const obj = {


### PR DESCRIPTION
Came across this bug from https://github.com/w3c/respec/pull/2689
~TODO: Move this to utils and add tests~