### PR TITLE
fix(core/linter-rules): extract correct name for WPT directory

### DIFF
--- a/src/core/linter-rules/wpt-tests-exist.js
+++ b/src/core/linter-rules/wpt-tests-exist.js
@@ -75,8 +75,10 @@ async function getFilesInWPT(testSuiteURI, githubAPIBase) {
   let wptDirectory;
   try {
     const testSuiteURL = new URL(testSuiteURI);
-    if (testSuiteURL.pathname.startsWith("/web-platform-tests/wpt/")) {
-      const re = /web-platform-tests\/wpt\/(.+)/;
+    if (
+      testSuiteURL.pathname.startsWith("/web-platform-tests/wpt/tree/master/")
+    ) {
+      const re = /web-platform-tests\/wpt\/tree\/master\/(.+)/;
       wptDirectory = testSuiteURL.pathname.match(re)[1].replace(/\//g, "");
     } else {
       wptDirectory = testSuiteURL.pathname.replace(/\//g, "");

--- a/tests/spec/core/linter-rules/tests-exist-spec.js
+++ b/tests/spec/core/linter-rules/tests-exist-spec.js
@@ -56,7 +56,8 @@ describe("Core Linter Rule - 'wpt-tests-exist'", () => {
     doc.body.innerHTML = `<p data-tests="404.html"></p>`;
     const conf = {
       ...config,
-      testSuiteURI: "https://github.com/web-platform-tests/wpt/whatever",
+      testSuiteURI:
+        "https://github.com/web-platform-tests/wpt/tree/master/whatever",
     };
     const result = await rule.lint(conf, doc);
     expect(result.name).toBe("wpt-tests-exist");


### PR DESCRIPTION
The current rule doesn't work on github.org/web-platform-tests/wpt URLs