### PR TITLE
fix(core/webidl): use valid markup inside pre

### DIFF
--- a/assets/webidl.css
+++ b/assets/webidl.css
@@ -11,7 +11,7 @@ pre.idl {
   }
 }
 
-div.idlHeader {
+.idlHeader {
   display: block;
   width: 150px;
   background: #90b8de;
@@ -23,7 +23,7 @@ div.idlHeader {
   line-height: 28px;
 }
 
-div.idlHeader a.self-link {
+.idlHeader a.self-link {
    color: #fff;
    margin-left: .3cm;
    text-decoration: none;

--- a/src/core/webidl-clipboard.js
+++ b/src/core/webidl-clipboard.js
@@ -22,7 +22,7 @@ const copyButton = createButton();
 /**
  * Adds a HTML button that copies WebIDL to the clipboard.
  *
- * @param {HTMLDivElement} idlHeader
+ * @param {HTMLSpanElement} idlHeader
  */
 export function addCopyIDLButton(idlHeader) {
   // There may be multiple <span>s of IDL, so we take everything

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -349,10 +349,10 @@ function renderWebIDL(idlElement, index) {
  */
 export function addIDLHeader(pre) {
   addHashId(pre, "webidl");
-  const header = hyperHTML`<div class="idlHeader"><a
+  const header = hyperHTML`<span class="idlHeader"><a
       class="self-link"
       href="${`#${pre.id}`}"
-    >WebIDL</a></div>`;
+    >WebIDL</a></span>`;
   pre.prepend(header);
   addCopyIDLButton(header);
 }

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -249,7 +249,9 @@ describe("Core - WebIDL", () => {
     expect(aElem.textContent).toBe("noParens");
   });
   it("should handle interfaces", () => {
-    let target = doc.getElementById("if-basic").querySelector("span");
+    let target = doc
+      .getElementById("if-basic")
+      .querySelector("span:not(.idlHeader)");
     let text = "interface SuperStar {};";
     expect(target.textContent).toBe(text);
     expect(
@@ -257,40 +259,54 @@ describe("Core - WebIDL", () => {
     ).toBe(1);
     expect(target.querySelector(".idlID").textContent).toBe("SuperStar");
 
-    target = doc.getElementById("if-extended-attribute").querySelector("span");
+    target = doc
+      .getElementById("if-extended-attribute")
+      .querySelector("span:not(.idlHeader)");
     text = `[Something, Constructor()] ${text}`;
     expect(target.textContent).toBe(text);
     const extAttrs = target.querySelectorAll(".extAttr");
     expect(extAttrs[0].textContent).toBe("Something");
     expect(extAttrs[1].textContent).toBe("Constructor()");
 
-    target = doc.getElementById("if-identifier-list").querySelector("span");
+    target = doc
+      .getElementById("if-identifier-list")
+      .querySelector("span:not(.idlHeader)");
     text = "[Global=Window, Exposed=(Window,Worker)] interface SuperStar {};";
     const rhs = target.querySelectorAll(".extAttr");
     expect(target.textContent).toBe(text);
     expect(rhs[0].textContent).toBe("Global=Window");
     expect(rhs[1].textContent).toBe("Exposed=(Window,Worker)");
 
-    target = doc.getElementById("if-inheritance").querySelector("span");
+    target = doc
+      .getElementById("if-inheritance")
+      .querySelector("span:not(.idlHeader)");
     text = "interface SuperStar : HyperStar {};";
     expect(target.textContent).toBe(text);
     expect(target.querySelector(".idlSuperclass").textContent).toBe(
       "HyperStar"
     );
 
-    target = doc.getElementById("if-partial").querySelector("span");
+    target = doc
+      .getElementById("if-partial")
+      .querySelector("span:not(.idlHeader)");
     text = "partial interface SuperStar {};";
     expect(target.textContent).toBe(text);
 
-    target = doc.getElementById("if-callback").querySelector("span");
+    target = doc
+      .getElementById("if-callback")
+      .querySelector("span:not(.idlHeader)");
     text = "callback interface SuperStar {};";
     expect(target.textContent).toBe(text);
 
-    target = doc.getElementById("if-mixin").querySelector("span");
+    target = doc
+      .getElementById("if-mixin")
+      .querySelector("span:not(.idlHeader)");
     text = "interface mixin SuperStar {};";
     expect(target.textContent).toBe(text);
 
-    target = doc.getElementById("if-partial-mixin").querySelector("span");
+    target = doc
+      .getElementById("if-partial-mixin")
+      .querySelector("span:not(.idlHeader)");
     text = "partial interface mixin SuperStar {};";
     expect(target.textContent).toBe(text);
 
@@ -1490,7 +1506,7 @@ callback CallBack = Z? (X x, optional Y y, /*trivia*/ optional Z z);
       eventInitDict, // skip testing boolean link (next line), tested elsewhere.
       ,
       itWorksMember,
-    ] = doc.querySelectorAll(".idl span a");
+    ] = doc.querySelectorAll(".idl span:not(.idlHeader) a");
 
     expect(banana.textContent).toBe("Banana");
     expect(banana.getAttribute("href")).toBe("#dom-banana");

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -43,7 +43,7 @@ describe("Core - WebIDL", () => {
         const ops = makeStandardOps(null, body);
         const doc = await makeRSDoc(ops);
         const idl = doc.querySelector("pre");
-        const idlHeader = idl.querySelector("pre div.idlHeader");
+        const idlHeader = idl.querySelector("pre span.idlHeader");
         expect(idlHeader).toBeTruthy();
         const anchor = idlHeader.querySelector("a");
         expect(anchor.getAttribute("href")).toBe(`#${idl.id}`);

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -249,9 +249,8 @@ describe("Core - WebIDL", () => {
     expect(aElem.textContent).toBe("noParens");
   });
   it("should handle interfaces", () => {
-    let target = doc
-      .getElementById("if-basic")
-      .querySelector("span:not(.idlHeader)");
+    let target = doc.getElementById("if-basic");
+    target.querySelector(".idlHeader").remove();
     let text = "interface SuperStar {};";
     expect(target.textContent).toBe(text);
     expect(
@@ -259,54 +258,47 @@ describe("Core - WebIDL", () => {
     ).toBe(1);
     expect(target.querySelector(".idlID").textContent).toBe("SuperStar");
 
-    target = doc
-      .getElementById("if-extended-attribute")
-      .querySelector("span:not(.idlHeader)");
+    target = doc.getElementById("if-extended-attribute");
+    target.querySelector(".idlHeader").remove();
     text = `[Something, Constructor()] ${text}`;
     expect(target.textContent).toBe(text);
     const extAttrs = target.querySelectorAll(".extAttr");
     expect(extAttrs[0].textContent).toBe("Something");
     expect(extAttrs[1].textContent).toBe("Constructor()");
 
-    target = doc
-      .getElementById("if-identifier-list")
-      .querySelector("span:not(.idlHeader)");
+    target = doc.getElementById("if-identifier-list");
+    target.querySelector(".idlHeader").remove();
     text = "[Global=Window, Exposed=(Window,Worker)] interface SuperStar {};";
     const rhs = target.querySelectorAll(".extAttr");
     expect(target.textContent).toBe(text);
     expect(rhs[0].textContent).toBe("Global=Window");
     expect(rhs[1].textContent).toBe("Exposed=(Window,Worker)");
 
-    target = doc
-      .getElementById("if-inheritance")
-      .querySelector("span:not(.idlHeader)");
+    target = doc.getElementById("if-inheritance");
+    target.querySelector(".idlHeader").remove();
     text = "interface SuperStar : HyperStar {};";
     expect(target.textContent).toBe(text);
     expect(target.querySelector(".idlSuperclass").textContent).toBe(
       "HyperStar"
     );
 
-    target = doc
-      .getElementById("if-partial")
-      .querySelector("span:not(.idlHeader)");
+    target = doc.getElementById("if-partial");
+    target.querySelector(".idlHeader").remove();
     text = "partial interface SuperStar {};";
     expect(target.textContent).toBe(text);
 
-    target = doc
-      .getElementById("if-callback")
-      .querySelector("span:not(.idlHeader)");
+    target = doc.getElementById("if-callback");
+    target.querySelector(".idlHeader").remove();
     text = "callback interface SuperStar {};";
     expect(target.textContent).toBe(text);
 
-    target = doc
-      .getElementById("if-mixin")
-      .querySelector("span:not(.idlHeader)");
+    target = doc.getElementById("if-mixin");
+    target.querySelector(".idlHeader").remove();
     text = "interface mixin SuperStar {};";
     expect(target.textContent).toBe(text);
 
-    target = doc
-      .getElementById("if-partial-mixin")
-      .querySelector("span:not(.idlHeader)");
+    target = doc.getElementById("if-partial-mixin");
+    target.querySelector(".idlHeader").remove();
     text = "partial interface mixin SuperStar {};";
     expect(target.textContent).toBe(text);
 


### PR DESCRIPTION
We had invalid markup... causing [errors with respec-validator](https://travis-ci.com/w3c/screen-orientation/builds/143352826#L705)
![image](https://user-images.githubusercontent.com/8426945/71877725-e6a56d80-314f-11ea-93a5-89e940c150e5.png)
