### PR TITLE
enh(tools/release): release script supports enh prefix

### DIFF
--- a/tools/release.js
+++ b/tools/release.js
@@ -133,6 +133,7 @@ const Prompts = {
       ["a11y", "♿"],
       ["breaking change", "🚨"],
       ["chore", "🔨"],
+      ["enh", "⭐️"],
       ["docs", "📖"],
       ["feat", "⭐️"],
       ["fix", "🐞"],

--- a/tools/release.js
+++ b/tools/release.js
@@ -192,7 +192,7 @@ const Prompts = {
         if (/^breaking/i.test(line)) {
           return "major";
         }
-        if (/^feat/i.test(line)) {
+        if (/^feat/i.test(line) || /^enh/i.test(line)) {
           return "minor";
         }
         return "patch";

--- a/tools/release.js
+++ b/tools/release.js
@@ -143,7 +143,7 @@ const Prompts = {
       ["style", "🖌"],
       ["test", "👍"],
     ]);
-    const commitHints = /^l10n|^docs|^chore|^fix|^style|^refactor|^test|^feat|^breaking\schange/i;
+    const commitHints = /^enh|^l10n|^docs|^chore|^fix|^style|^refactor|^test|^feat|^breaking\schange/i;
     return (
       commits
         .split("\n")


### PR DESCRIPTION
Closes #2618

We didn't really agree on what prefix to support, so I'm going with `enh` only for now. Let me know if y'all prefer other options. Thanks!