### PR TITLE
feat(core/inlines): support linking element-attr types

### DIFF
--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -30,15 +30,24 @@ const inlineVariable = /\B\|\w[\w\s]*(?:\s*:[\w\s&;<>]+)?\|\B/; // |var : Type|
 const inlineCitation = /(?:\[\[(?:!|\\|\?)?[A-Za-z0-9.-]+\]\])/; // [[citation]]
 const inlineExpansion = /(?:\[\[\[(?:!|\\|\?)?#?[\w-.]+\]\]\])/; // [[[expand]]]
 const inlineAnchor = /(?:\[=[^=]+=\])/; // Inline [= For/link =]
-const inlineElement = /(?:\[\^[A-Za-z]+(?:-[A-Za-z]+)?\^\])/; // Inline [^element^]
+const inlineElement = /(?:\[\^[^^]+\^\])/; // Inline [^element^]
 
 /**
+ * @example [^iframe^] // [^element^]
+ * @example [^iframe/allow^] // [^element/element-attr^]
  * @param {string} matched
  * @return {HTMLElement}
  */
 function inlineElementMatches(matched) {
   const value = matched.slice(2, -2).trim();
-  const html = hyperHTML`<code><a data-xref-type="element">${value}</a></code>`;
+  const [element, attribute] = value.split("/", 2).map(s => s && s.trim());
+  const [xrefType, xrefFor, textContent] = attribute
+    ? ["element-attr", element, attribute]
+    : ["element", null, element];
+  const html = hyperHTML`<code><a
+    data-xref-type="${xrefType}"
+    data-xref-for="${xrefFor}"
+    >${textContent}</a></code>`;
   return html;
 }
 

--- a/tests/spec/core/inlines-spec.js
+++ b/tests/spec/core/inlines-spec.js
@@ -305,11 +305,15 @@ describe("Core - Inlines", () => {
     const body = `
       <section>
         <p id="test">[^body^]</p>
+        <p id="test2">[^iframe/allow^]</p>
       </section>
     `;
     const doc = await makeRSDoc(makeStandardOps({ xref: ["HTML"] }, body));
     const bodyAnchor = doc.querySelector("#test a");
     expect(bodyAnchor.hash).toBe("#the-body-element");
+    const iframeAllowAnchor = doc.querySelector("#test2 a");
+    expect(iframeAllowAnchor.textContent).toBe("allow");
+    expect(iframeAllowAnchor.hash).toBe("#attr-iframe-allow");
   });
 
   it("processes [= BikeShed style inline links =]", async () => {

--- a/tests/spec/core/xref-spec.js
+++ b/tests/spec/core/xref-spec.js
@@ -237,14 +237,14 @@ describe("Core — xref", () => {
   it("shows error if cannot resolve by data-cite", async () => {
     const body = `
       <section data-cite="svg">
-        <p><a id="link">symbol</a> twice in svg spec.</p>
+        <p id="test">[^symbol^] twice in svg spec.</p>
       </section>
     `;
     const config = { xref: ["svg"], localBiblio };
     const ops = makeStandardOps(config, body);
     const doc = await makeRSDoc(ops);
 
-    const link = doc.getElementById("link");
+    const link = doc.querySelector("#test a");
     expect(link.classList).toContain("respec-offending-element");
     expect(link.title).toBe("Error: Linking an ambiguous dfn.");
   });


### PR DESCRIPTION
Closes https://github.com/w3c/respec/issues/2705
~Blocked on https://github.com/marcoscaceres/respec.org/pull/61~ Updated on respec.org
In future, https://github.com/w3c/respec/pull/2508 might also help.