### PR TITLE
chore(tools/builder): use IIFE and remove appendBoilerplate

### DIFF
--- a/tools/builder.js
+++ b/tools/builder.js
@@ -126,7 +126,7 @@ const Builder = {
     };
     const outputOptions = {
       file: outPath,
-      format: "commonjs",
+      format: "iife",
       sourcemap: true,
       strict: true,
       banner: `window.respecVersion = "${version}";\n`,

--- a/tools/builder.js
+++ b/tools/builder.js
@@ -128,7 +128,6 @@ const Builder = {
       file: outPath,
       format: "iife",
       sourcemap: true,
-      strict: true,
       banner: `window.respecVersion = "${version}";\n`,
     };
 

--- a/tools/builder.js
+++ b/tools/builder.js
@@ -66,30 +66,6 @@ const usageSections = [
   },
 ];
 
-/**
- * Async function that appends the boilerplate to the generated script
- * and writes out the result. It also creates the source map file.
- *
- * @private
- * @param  {String} outPath Where to write the output to.
- * @param  {String} version The version of the script.
- * @return {Promise} Resolves when done writing the files.
- */
-async function appendBoilerplate(outPath, version, name) {
-  const mapPath = `${path.dirname(outPath)}/respec-${name}.js.map`;
-  const [optimizedJs, sourceMap] = await Promise.all([
-    fsp.readFile(outPath, "utf-8"),
-    fsp.readFile(mapPath, "utf-8"),
-  ]);
-  const respecJs = `"use strict";
-window.respecVersion = "${version}";
-${optimizedJs}`;
-  const respecJsMap = sourceMap.replace(`"mappings":"`, `"mappings":";;`);
-  const promiseToWriteJs = fsp.writeFile(outPath, respecJs, "utf-8");
-  const promiseToWriteMap = fsp.writeFile(mapPath, respecJsMap, "utf-8");
-  await Promise.all([promiseToWriteJs, promiseToWriteMap]);
-}
-
 const Builder = {
   /**
    * Async function that gets the current version of ReSpec from package.json
@@ -120,7 +96,7 @@ const Builder = {
     console.log(colors.info(`Generating ${outFile}. Please wait...`));
 
     // optimisation settings
-    const buildVersion = await this.getRespecVersion();
+    const version = await this.getRespecVersion();
     const buildDir = path.resolve(__dirname, "../builds/");
     const workerDir = path.resolve(__dirname, "../worker/");
 
@@ -152,12 +128,13 @@ const Builder = {
       file: outPath,
       format: "commonjs",
       sourcemap: true,
+      strict: true,
+      banner: `window.respecVersion = "${version}";\n`,
     };
 
     const bundle = await rollup(inputOptions);
     await bundle.write(outputOptions);
 
-    await appendBoilerplate(outPath, buildVersion, name);
     // copy respec-worker
     await fsp.copyFile(
       `${workerDir}/respec-worker.js`,


### PR DESCRIPTION
Reduces uncompressed build size from 320KB to 284KB - thanks to Terser optimizing IIFE better.
