### PR TITLE
refactor(core/utils): no `arguments`

### DIFF
--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -403,16 +403,11 @@ export function linkCSS(doc, styles) {
  * @this {any}
  * @param {string} [flist]
  */
-export function runTransforms(content, flist) {
-  let args = [this, content];
-  const funcArgs = Array.from(arguments);
-  funcArgs.shift();
-  funcArgs.shift();
-  args = args.concat(funcArgs);
+export function runTransforms(content, flist, ...funcArgs) {
+  const args = [this, content, ...funcArgs];
   if (flist) {
     const methods = flist.split(/\s+/);
-    for (let j = 0; j < methods.length; j++) {
-      const meth = methods[j];
+    for (const meth of methods) {
       /** @type {any} */
       const method = window[meth];
       if (method) {


### PR DESCRIPTION
Can't remove this horrible function as [several specs already are using it](https://github.com/search?l=HTML&q=respec+oninclude+org%3Aw3c&type=Code) 🤦‍♀️