### PR TITLE
perf(core/xref): remove duplicate cite context to reduce query size

### DIFF
--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -132,16 +132,7 @@ function getRequestEntry(elem) {
 
   const term = getTermFromElement(elem, isIDL);
   const specs = getSpecContext(elem);
-  const types = [];
-  if (isIDL) {
-    if (elem.dataset.xrefType) {
-      types.push(...elem.dataset.xrefType.split("|"));
-    } else {
-      types.push("_IDL_");
-    }
-  } else {
-    types.push("_CONCEPT_");
-  }
+  const types = getTypeContext(elem, isIDL);
 
   let { xrefFor: forContext } = elem.dataset;
   if (!forContext && isIDL) {
@@ -219,6 +210,21 @@ function getSpecContext(elem) {
   }
 
   return specs;
+}
+
+/**
+ * @param {HTMLElement} elem
+ * @param {boolean} isIDL
+ */
+function getTypeContext(elem, isIDL) {
+  if (!isIDL) {
+    return ["_CONCEPT_"];
+  }
+
+  if (elem.dataset.xrefType) {
+    return elem.dataset.xrefType.split("|");
+  }
+  return ["_IDL_"];
 }
 
 /**

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -133,17 +133,8 @@ function getRequestEntry(elem) {
   const term = getTermFromElement(elem, isIDL);
   const specs = getSpecContext(elem);
   const types = getTypeContext(elem, isIDL);
+  const forContext = getForContext(elem, isIDL);
 
-  let { xrefFor: forContext } = elem.dataset;
-  if (!forContext && isIDL) {
-    /** @type {HTMLElement} */
-    const dataXrefForElem = elem.closest("[data-xref-for]");
-    if (dataXrefForElem) {
-      forContext = normalize(dataXrefForElem.dataset.xrefFor);
-    }
-  } else if (forContext && typeof forContext === "string") {
-    forContext = normalize(forContext);
-  }
   return {
     term,
     types,
@@ -210,6 +201,28 @@ function getSpecContext(elem) {
   }
 
   return specs;
+}
+
+/**
+ * @param {HTMLElement} elem
+ * @param {boolean} isIDL
+ */
+function getForContext(elem, isIDL) {
+  if (elem.dataset.xrefFor) {
+    return normalize(elem.dataset.xrefFor);
+  }
+
+  if (!isIDL) {
+    // non-idl terms having for context is not presently supported
+    return null;
+  }
+
+  /** @type {HTMLElement} */
+  const dataXrefForElem = elem.closest("[data-xref-for]");
+  if (dataXrefForElem) {
+    return normalize(dataXrefForElem.dataset.xrefFor);
+  }
+  return null;
 }
 
 /**

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -130,9 +130,7 @@ function normalizeConfig(xref) {
 function getRequestEntry(elem) {
   const isIDL = "xrefType" in elem.dataset;
 
-  let term = getTermFromElement(elem);
-  if (!isIDL) term = term.toLowerCase();
-
+  const term = getTermFromElement(elem, isIDL);
   const specs = getSpecContext(elem);
   const types = [];
   if (isIDL) {
@@ -163,12 +161,18 @@ function getRequestEntry(elem) {
   };
 }
 
-/** @param {HTMLElement} elem */
-function getTermFromElement(elem) {
+/**
+ * @param {HTMLElement} elem
+ * @param {boolean} isIDL
+ */
+function getTermFromElement(elem, isIDL) {
   const { lt: linkingText } = elem.dataset;
   let term = linkingText ? linkingText.split("|", 1)[0] : elem.textContent;
   term = normalize(term);
-  return term === "the-empty-string" ? "" : term;
+  if (term === "the-empty-string") {
+    term = "";
+  }
+  return isIDL ? term : term.toLowerCase();
 }
 
 /**
@@ -382,7 +386,7 @@ function showErrors({ ambiguous, notFound }) {
 
   for (const { query, elems } of notFound.values()) {
     const specs = [...new Set(flatten([], query.specs))].sort();
-    const originalTerm = getTermFromElement(elems[0]);
+    const originalTerm = getTermFromElement(elems[0], true);
     const formUrl = getPrefilledFormURL(originalTerm, query, specs);
     const specsString = specs.map(spec => `\`${spec}\``).join(", ");
     const msg =
@@ -394,7 +398,7 @@ function showErrors({ ambiguous, notFound }) {
   for (const { query, elems, results } of ambiguous.values()) {
     const specs = [...new Set(results.map(entry => entry.shortname))].sort();
     const specsString = specs.map(s => `**${s}**`).join(", ");
-    const originalTerm = getTermFromElement(elems[0]);
+    const originalTerm = getTermFromElement(elems[0], true);
     const formUrl = getPrefilledFormURL(originalTerm, query, specs);
     const msg =
       `The term "**${originalTerm}**" is defined in ${specsString} in multiple ways, so it's ambiguous. ` +

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -139,9 +139,14 @@ function getRequestEntry(elem) {
   let dataciteElem = elem.closest("[data-cite]");
   while (dataciteElem) {
     const cite = dataciteElem.dataset.cite.toLowerCase().replace(/[!?]/g, "");
-    const cites = cite.split(/\s+/).filter(s => s);
-    if (cites.length) {
-      specs.push(cites.sort());
+    const cites = cite.split(/\s+/);
+    // if we already have a spec in previous level of fallback chain, skip it
+    // from this level
+    const uniqueCites = [...new Set(cites)].filter(
+      spec => spec && !(specs[specs.length - 1] || []).includes(spec)
+    );
+    if (uniqueCites.length) {
+      specs.push(uniqueCites.sort());
     }
     if (dataciteElem === elem) break;
     dataciteElem = dataciteElem.parentElement.closest("[data-cite]");


### PR DESCRIPTION
On payment-request, the cite/spec context reduced from 1265 specs to 1023 specs and size of entire query reduced from 29833 bytes to 26215 bytes.
This also increases chances of getting common queries across specs on same domain - so we can use more cached results (though still rare).

The basic idea is to make `specs.flat().length` equal to `new Set(specs.flat()).size)`