### PR TITLE
test(core/markdown-spec): reenable custom id test

### DIFF
--- a/tests/spec/SpecHelper.js
+++ b/tests/spec/SpecHelper.js
@@ -91,7 +91,10 @@ function decorateDocument(doc, opts) {
     body = "",
     bodyAttrs = {},
   }) {
-    doc.body.innerHTML += `<section id='abstract'>${abstract}</section>${body}`;
+    if (abstract !== null) {
+      doc.body.innerHTML += `<section id='abstract'>${abstract}</section>`;
+    }
+    doc.body.innerHTML += body;
     Object.entries(bodyAttrs).forEach(([key, value]) => {
       doc.body.setAttribute(key, value);
     });

--- a/tests/spec/core/markdown-spec.js
+++ b/tests/spec/core/markdown-spec.js
@@ -101,7 +101,7 @@ describe("Core - Markdown", () => {
     }
   });
 
-  xit("allows custom ids to headers", async () => {
+  it("allows custom ids to headers", async () => {
     const body = `
       ## Heading {#custom-id}
       PASS


### PR DESCRIPTION
Finally had time to figure it out. That part was reverted by #2678.