### PR TITLE
fix(w3c/headers): construct PR preview URL if `prUrl` is missing

### DIFF
--- a/src/w3c/templates/headers.js
+++ b/src/w3c/templates/headers.js
@@ -99,8 +99,9 @@ function getSpecTitleElem(conf) {
     specTitleElem.id = "title";
   }
   if (conf.isPreview && conf.prNumber) {
+    const prUrl = conf.prUrl || `${conf.github.repoURL}pull/${conf.prNumber}`;
     const { childNodes } = html`
-      Preview of PR <a href="${conf.prUrl}">#${conf.prNumber}</a>:
+      Preview of PR <a href="${prUrl}">#${conf.prNumber}</a>:
     `;
     specTitleElem.prepend(...childNodes);
   }

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -1607,6 +1607,21 @@ describe("W3C — Headers", () => {
       expect(h1.querySelector("a").href).toBe("http://w3c.github.io/respec/");
     });
 
+    it("constructs PR URL when prURL is not provided", async () => {
+      const ops = makeStandardOps({ github: "w3c/some-spec" });
+      const doc = await makeRSDoc(
+        ops,
+        "spec/core/simple.html?isPreview=true&prNumber=123"
+      );
+      expect(doc.title).toBe("Preview of PR #123: Simple Spec");
+      const h1 = doc.querySelector("h1#title");
+      expect(h1.textContent).toContain("Preview of PR #123:");
+      expect(h1.textContent).toContain("Simple Spec");
+      expect(h1.querySelector("a").href).toBe(
+        "https://github.com/w3c/some-spec/pull/123"
+      );
+    });
+
     it("when only <h1> title is present", async () => {
       const ops = {
         config: {


### PR DESCRIPTION
Fixes https://github.com/w3c/respec/issues/2731