### PR TITLE
fix(core/xref): remove false spec context from prefilled UI URL

### DIFF
--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -413,7 +413,7 @@ function showErrors({ ambiguous, notFound }) {
   for (const { query, elems } of notFound.values()) {
     const specs = [...new Set(flatten([], query.specs))].sort();
     const originalTerm = getTermFromElement(elems[0]);
-    const formUrl = getPrefilledFormURL(originalTerm, query, specs);
+    const formUrl = getPrefilledFormURL(originalTerm, query);
     const specsString = specs.map(spec => `\`${spec}\``).join(", ");
     const msg =
       `Couldn't match "**${originalTerm}**" to anything in the document or in any other document cited in this specification: ${specsString}. ` +


### PR DESCRIPTION
Providing `specsContext` that failed to resolve a term doesn't help the user in figuring out which spec actually contains the term. 
So, by not providing a false `specContext`, we properly delegate it to the xref UI.

As an example, instead of using https://respec.org/xref/?term=abort&cite=svg,appmanifest, which fail to resolve `abort`, we use https://respec.org/xref/?term=abort