### PR TITLE
Fix for pre block in markdown list

### DIFF
--- a/src/core/markdown.js
+++ b/src/core/markdown.js
@@ -200,6 +200,11 @@ function normalizePadding(text) {
         }
         return chop;
       }, chop);
+    for (const pre of doc.querySelectorAll("pre")) {
+      // HTML parser implicitly removes a newline after <pre> which breaks reindentation
+      // algorithm.
+      pre.prepend("\n");
+    }
   }
   const wrap = document.createElement("body");
   wrap.append(doc);


### PR DESCRIPTION
Fixes #2733 

HTML parser removes a newline after a `<pre>` element when a text string is converted into an document fragment in [normalizePadding](https://github.com/w3c/respec/blob/develop/src/core/markdown.js#L136). This change replaces the missing newline.

Note: This is similar to [convertElement](https://github.com/w3c/respec/blob/develop/src/core/markdown.js#L248-L256), but only one newline seems to be required here.