### PR TITLE
Add level config

### DIFF
--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -273,6 +273,7 @@ export function run(conf) {
 
   if (conf.level) {
     conf.title = `${conf.title} Level ${conf.level}`;
+    conf.shortName = `${conf.shortName}-${conf.level}`;
   }
 
   if (!conf.subtitle) conf.subtitle = "";

--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -2,6 +2,7 @@
 // Module w3c/headers
 // Generate the headers material based on the provided configuration.
 // CONFIGURATION
+//  - level: TODO SOME EXPLANATION HERE
 //  - specStatus: the short code for the specification's maturity level or type (required)
 //  - shortName: the small name that is used after /TR/ in published reports (required)
 //  - editors: an array of people editing the document (at least one is required). People
@@ -269,6 +270,11 @@ export function run(conf) {
   if (document.title && conf.isPreview && conf.prNumber) {
     document.title = `Preview of PR #${conf.prNumber}: ${document.title}`;
   }
+
+  if (conf.level) {
+    conf.title = `${conf.title} Level ${conf.level}`;
+  }
+
   if (!conf.subtitle) conf.subtitle = "";
   conf.publishDate = validateDateAndRecover(
     conf,

--- a/src/w3c/templates/headers.js
+++ b/src/w3c/templates/headers.js
@@ -109,7 +109,12 @@ function getSpecTitleElem(conf) {
   specTitleElem.classList.add("title", "p-name");
   if (document.querySelector("title") === null) {
     document.title = conf.title;
-  } else if (document.title !== conf.title) {
+  } else if (
+    conf.level &&
+    `${document.title} Level ${conf.level}` != conf.title
+  ) {
+    pub("warn", "The document's title and the `<title>` element differ.");
+  } else if (!conf.level && document.title !== conf.title) {
     pub("warn", "The document's title and the `<title>` element differ.");
   }
   return specTitleElem;

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -67,6 +67,58 @@ describe("W3C — Headers", () => {
     });
   });
 
+  describe("levels", () => {
+    describe("is present in config", () => {
+      it("updates the page title with the level when document.title is present", async () => {
+        const body = `
+        <title>Navigation Timing</title>${makeDefaultBody()}`;
+        const ops = makeStandardOps({}, body);
+        const newProps = { specStatus: "REC", shortName: "xxx", level: "3" };
+        Object.assign(ops.config, newProps);
+
+        const doc = await makeRSDoc(ops);
+
+        const titleElem = doc.querySelector("#title");
+        expect(titleElem).toBeTruthy();
+        expect(titleElem.textContent).toBe("Navigation Timing Level 3");
+      });
+
+      it("uses the default title and adds the level when document.title is not present", async () => {
+        const ops = makeStandardOps();
+        const newProps = {
+          level: "3",
+        };
+        Object.assign(ops.config, newProps);
+        const doc = await makeRSDoc(ops);
+
+        expect(doc.title).toBe("No Title Level 3");
+      });
+    });
+
+    describe("is absent in config", () => {
+      it("uses the given title when document.title is present", async () => {
+        const body = `
+        <title>Navigation Timing</title>${makeDefaultBody()}`;
+        const ops = makeStandardOps({}, body);
+        const newProps = {};
+        Object.assign(ops.config, newProps);
+
+        const doc = await makeRSDoc(ops);
+
+        expect(doc.title).toBe("Navigation Timing");
+      });
+
+      it("uses the default title when document.title is not present", async () => {
+        const ops = makeStandardOps();
+        const newProps = {};
+        Object.assign(ops.config, newProps);
+        const doc = await makeRSDoc(ops);
+
+        expect(doc.title).toBe("No Title");
+      });
+    });
+  });
+
   describe("editors", () => {
     const findEditor = findContent("Editor:");
     describe("retiredDate", () => {

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -93,6 +93,25 @@ describe("W3C — Headers", () => {
 
         expect(doc.title).toBe("No Title Level 3");
       });
+
+      it("takes shortName and level into account when both are present", async () => {
+        const ops = makeStandardOps();
+        const newProps = {
+          level: 3,
+          specStatus: "REC",
+          shortName: "xxx",
+        };
+        Object.assign(ops.config, newProps);
+        const doc = await makeRSDoc(ops);
+
+        const terms = doc.querySelectorAll("dt");
+        expect(terms[0].textContent).toBe("This version:");
+        expect(terms[0].nextElementSibling.localName).toBe("dd");
+        expect(terms[0].nextElementSibling.textContent).toContain("REC-xxx-3");
+        expect(terms[1].textContent).toBe("Latest published version:");
+        expect(terms[1].nextElementSibling.localName).toBe("dd");
+        expect(terms[1].nextElementSibling.textContent).toContain("TR/xxx-3/");
+      });
     });
 
     describe("is absent in config", () => {


### PR DESCRIPTION
Closes [#2406](https://github.com/w3c/respec/issues/2406)

 - [x] combines the level with the shortName (so... page-visibility becomes "page-visibility-2")
- [x] automatically appends the "Level X" to the title of the document.
- [x] makes sure all appropriate links also get the level, though these are probably just derived from the shortName.