### PR TITLE
chore(tools/release): sync with `develop` branch

### DIFF
--- a/tools/release.js
+++ b/tools/release.js
@@ -362,7 +362,7 @@ const run = async () => {
     // 2. Bump the version in `package.json`.
     const version = await Prompts.askBumpVersion();
     await Prompts.askBuildAddCommitMergeTag();
-    await npm(`version ${version} -m "v${version}" --no-git-tag-version --allow-same-version`);
+    await npm(`version ${version} -m "v${version}" --no-git-tag-version`);
 
     // 3. Run the build script (node tools/build-w3c-common.js).
     await npm("run builddeps");


### PR DESCRIPTION
develop and gh-pages branch got out of sync somehow some time ago, causing GitHub Action failures (lint errors) on gh-pages branch. 
Lets hope this doesn't cause issues (merge conflict or something) in next release.
**PS: This PR is to gh-pages branch, not develop**