### PR TITLE
refactor: remove raw HTML insertions

### DIFF
--- a/src/core/dfn-panel.js
+++ b/src/core/dfn-panel.js
@@ -111,13 +111,16 @@ function referencesToHTML(id, links) {
     );
   };
 
-  const listItems = [...titleToIDs].map(
-    entry =>
-      hyperHTML`<li>${toLinkProps(entry).map(
-        link => hyperHTML`<a href="#${link.id}">${link.title}</a>${" "}`
-      )}</li>`
-  );
+  /**
+   * @param {[string, string[]]} entry
+   * @returns {HTMLLIElement}
+   */
+  const listItemToHTML = entry =>
+    hyperHTML`<li>${toLinkProps(entry).map(
+      link => hyperHTML`<a href="#${link.id}">${link.title}</a>${" "}`
+    )}</li>`;
 
+  const listItems = [...titleToIDs].map(listItemToHTML);
   return hyperHTML`<ul>${listItems}</ul>`;
 }
 

--- a/src/core/dfn-panel.js
+++ b/src/core/dfn-panel.js
@@ -111,16 +111,14 @@ function referencesToHTML(id, links) {
     );
   };
 
-  /**
-   * @param {[string, string[]]} entry
-   * @returns {HTMLLIElement}
-   */
-  const listItemToHTML = entry =>
-    hyperHTML`<li>${toLinkProps(entry).map(
-      link => hyperHTML`<a href="#${link.id}">${link.title}</a>${" "}`
-    )}</li>`;
+  const listItems = [...titleToIDs].map(
+    entry =>
+      hyperHTML`<li>${toLinkProps(entry).map(
+        link => hyperHTML`<a href="#${link.id}">${link.title}</a>${" "}`
+      )}</li>`
+  );
 
-  return hyperHTML`<ul>${[...titleToIDs.entries()].map(listItemToHTML)}</ul>`;
+  return hyperHTML`<ul>${listItems}</ul>`;
 }
 
 /** @param {HTMLAnchorElement} link */

--- a/src/core/inline-idl-parser.js
+++ b/src/core/inline-idl-parser.js
@@ -2,8 +2,8 @@
 // Parses an inline IDL string (`{{ idl string }}`)
 //  and renders its components as HTML
 
+import { htmlJoinComma, showInlineError } from "./utils.js";
 import { hyperHTML } from "./import-maps.js";
-import { showInlineError } from "./utils.js";
 const idlPrimitiveRegex = /^[a-z]+(\s+[a-z]+)+$/; // {{unrestricted double}} {{ double }}
 const exceptionRegex = /\B"([^"]*)"\B/; // {{ "SomeException" }}
 const methodRegex = /(\w+)\((.*)\)$/;
@@ -183,14 +183,14 @@ function renderAttribute(details) {
 function renderMethod(details) {
   const { args, identifier, type, parent, renderParent } = details;
   const { identifier: linkFor } = parent || {};
-  const argsText = args.map(arg => `<var>${arg}</var>`).join(", ");
+  const argsText = htmlJoinComma(args, arg => hyperHTML`<var>${arg}</var>`);
   const searchText = `${identifier}(${args.join(", ")})`;
   const html = hyperHTML`${parent && renderParent ? "." : ""}<a
     data-xref-type="${type}"
     data-link-for="${linkFor}"
     data-xref-for="${linkFor}"
     data-lt="${searchText}"
-    ><code>${identifier}</code></a><code>(${[argsText]})</code>`;
+    ><code>${identifier}</code></a><code>(${argsText})</code>`;
   return html;
 }
 

--- a/src/core/issues-notes.js
+++ b/src/core/issues-notes.js
@@ -368,7 +368,7 @@ export async function run(conf) {
   const css = await cssPromise;
   const { head: headElem } = document;
   headElem.insertBefore(
-    hyperHTML`<style>${[css]}</style>`,
+    hyperHTML`<style>${css}</style>`,
     headElem.querySelector("link")
   );
   handleIssues(issuesAndNotes, ghIssues, conf);

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -486,6 +486,12 @@ export async function fetchAndCache(input, maxAge = 86400000) {
 
 // --- DOM HELPERS -------------------------------
 
+export function htmlJoinComma(array, mapper = item => item) {
+  const items = array.map(mapper);
+  const joined = items.slice(0, -1).map(item => hyperHTML`${item}, `);
+  return hyperHTML`${joined}${items[items.length - 1]}`;
+}
+
 /**
  * Separates each item with proper commas and "and".
  * @param {string[]} array
@@ -500,8 +506,8 @@ export function htmlJoinAnd(array, mapper = item => item) {
     case 2: // x and y
       return hyperHTML`${items[0]} and ${items[1]}`;
     default: {
-      const joinedItems = items.slice(0, -1).map(item => hyperHTML`${item}, `);
-      return hyperHTML`${joinedItems}and ${items[items.length - 1]}`;
+      const joined = htmlJoinComma(items.slice(0, -1));
+      return hyperHTML`${joined}, and ${items[items.length - 1]}`;
     }
   }
 }


### PR DESCRIPTION
Part of #2551

Remaining are all `conf.*HTML` or such, which will cause breaking changes when removed. 