### PR TITLE
refactor(w3c/headers): pass alternatesHTML as options

### DIFF
--- a/src/dini/headers.js
+++ b/src/dini/headers.js
@@ -42,9 +42,8 @@
 //      - "cc-by-sa"
 //      - "cc-by"
 //      - "cc0"
-import { ISODate, htmlJoinAnd } from "../core/utils.js";
+import { ISODate } from "../core/utils.js";
 import headersTmpl from "./templates/headers.js";
-import { hyperHTML } from "../core/import-maps.js";
 import { pub } from "../core/pubsubhub.js";
 
 export const name = "dini/headers";
@@ -136,15 +135,6 @@ export function run(conf) {
       pub("error", "All alternate formats must have a uri and a label.");
     }
   });
-  conf.multipleAlternates =
-    conf.alternateFormats && conf.alternateFormats.length > 1;
-  conf.alternatesHTML =
-    conf.alternateFormats &&
-    htmlJoinAnd(conf.alternateFormats, alt => {
-      const lang = alt.hasOwnProperty("lang") && alt.lang ? alt.lang : null;
-      const type = alt.hasOwnProperty("type") && alt.type ? alt.type : null;
-      return hyperHTML`<a rel='alternate' href='${alt.uri}' hreflang='${lang}' type='${type}'>${alt.label}</a>`;
-    });
   if (conf.copyrightStart && conf.copyrightStart == conf.publishYear)
     conf.copyrightStart = "";
   conf.textStatus = status2text[conf.specStatus];

--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -415,15 +415,6 @@ export function run(conf) {
       pub("error", "All alternate formats must have a uri and a label.");
     }
   });
-  conf.multipleAlternates =
-    conf.alternateFormats && conf.alternateFormats.length > 1;
-  conf.alternatesHTML =
-    conf.alternateFormats &&
-    htmlJoinAnd(conf.alternateFormats, alt => {
-      const lang = alt.hasOwnProperty("lang") && alt.lang ? alt.lang : null;
-      const type = alt.hasOwnProperty("type") && alt.type ? alt.type : null;
-      return hyperHTML`<a rel='alternate' href='${alt.uri}' hreflang='${lang}' type='${type}'>${alt.label}</a>`;
-    });
   if (conf.copyrightStart && conf.copyrightStart == conf.publishYear)
     conf.copyrightStart = "";
   conf.longStatus = status2long[conf.specStatus];
@@ -472,8 +463,24 @@ export function run(conf) {
   }
   // configuration done - yay!
 
+  const options = {
+    get multipleAlternates() {
+      return conf.alternateFormats && conf.alternateFormats.length > 1;
+    },
+    get alternatesHTML() {
+      return (
+        conf.alternateFormats &&
+        htmlJoinAnd(conf.alternateFormats, alt => {
+          const lang = alt.hasOwnProperty("lang") && alt.lang ? alt.lang : null;
+          const type = alt.hasOwnProperty("type") && alt.type ? alt.type : null;
+          return hyperHTML`<a rel='alternate' href='${alt.uri}' hreflang='${lang}' type='${type}'>${alt.label}</a>`;
+        })
+      );
+    },
+  };
+
   // insert into document
-  const header = (conf.isCGBG ? cgbgHeadersTmpl : headersTmpl)(conf);
+  const header = (conf.isCGBG ? cgbgHeadersTmpl : headersTmpl)(conf, options);
   document.body.prepend(header);
   document.body.classList.add("h-entry");
 

--- a/src/w3c/templates/cgbg-headers.js
+++ b/src/w3c/templates/cgbg-headers.js
@@ -5,7 +5,7 @@ import showLink from "./show-link.js";
 import showLogo from "./show-logo.js";
 import showPeople from "./show-people.js";
 
-export default conf => {
+export default (conf, options) => {
   const existingCopyright = document.querySelector(".copyright");
   if (existingCopyright) {
     existingCopyright.remove();
@@ -107,10 +107,10 @@ export default conf => {
       ${conf.alternateFormats
         ? html`
             <p>
-              ${conf.multipleAlternates
+              ${options.multipleAlternates
                 ? "This document is also available in these non-normative formats:"
                 : "This document is also available in this non-normative format:"}
-              ${[conf.alternatesHTML]}
+              ${options.alternatesHTML}
             </p>
           `
         : ""}

--- a/src/w3c/templates/headers.js
+++ b/src/w3c/templates/headers.js
@@ -132,7 +132,7 @@ function getSpecSubTitleElem(conf) {
   return specSubTitleElem;
 }
 
-export default conf => {
+export default (conf, options) => {
   return html`
     <div class="head">
       ${conf.logos.map(showLogo)} ${getSpecTitleElem(conf)}
@@ -253,10 +253,10 @@ export default conf => {
       ${conf.alternateFormats
         ? html`
             <p>
-              ${conf.multipleAlternates
+              ${options.multipleAlternates
                 ? "This document is also available in these non-normative formats:"
                 : "This document is also available in this non-normative format:"}
-              ${[conf.alternatesHTML]}
+              ${options.alternatesHTML}
             </p>
           `
         : ""}


### PR DESCRIPTION
This removes additional redundant `${[...]}` and also reduces `conf` pollution.

Partly also #2743.