### PR TITLE
refactor(core/webidl-clipboard): always use navigator.clipboard

### DIFF
--- a/src/core/webidl-clipboard.js
+++ b/src/core/webidl-clipboard.js
@@ -33,28 +33,7 @@ export function addCopyIDLButton(idlHeader) {
   const { textContent: idlText } = idl;
   const button = copyButton.cloneNode(true);
   button.addEventListener("click", () => {
-    clipboardWriteText(idlText);
+    navigator.clipboard.writeText(idlText);
   });
   idlHeader.append(button);
-}
-
-/**
- * Mocks navigator.clipboard.writeText()
- * @param {string} text
- */
-function clipboardWriteText(text) {
-  if (navigator.clipboard) {
-    return navigator.clipboard.writeText(text);
-  }
-  return new Promise(resolve => {
-    document.addEventListener(
-      "copy",
-      ev => {
-        ev.clipboardData.setData("text/plain", text);
-        resolve();
-      },
-      { once: true }
-    );
-    document.execCommand("copy");
-  });
 }


### PR DESCRIPTION
Part of #2374.