### PR TITLE
refactor(core/utils): remove `children` util

### DIFF
--- a/src/core/list-sorter.js
+++ b/src/core/list-sorter.js
@@ -1,5 +1,4 @@
 // @ts-check
-import { children } from "./utils.js";
 import { pub } from "./pubsubhub.js";
 export const name = "core/list-sorter";
 
@@ -15,7 +14,7 @@ function makeSorter(direction) {
  * @returns {DocumentFragment}
  */
 export function sortListItems(elem, dir) {
-  const elements = [...children(elem, "li")];
+  const elements = [...elem.querySelectorAll(":scope > li")];
   const sortedElements = elements.sort(makeSorter(dir)).reduce((frag, elem) => {
     frag.appendChild(elem);
     return frag;
@@ -30,7 +29,7 @@ export function sortListItems(elem, dir) {
  * @returns {DocumentFragment}
  */
 export function sortDefinitionTerms(dl, dir) {
-  const elements = [...children(dl, "dt")];
+  const elements = [...dl.querySelectorAll(":scope > dt")];
   const sortedElements = elements.sort(makeSorter(dir)).reduce((frag, elem) => {
     const { nodeType, nodeName } = elem;
     const children = document.createDocumentFragment();

--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -10,13 +10,7 @@
 //  - lang: can change the generated text (supported: en, fr)
 //  - maxTocLevel: only generate a TOC so many levels deep
 
-import {
-  addId,
-  children,
-  getIntlData,
-  parents,
-  renameElement,
-} from "./utils.js";
+import { addId, getIntlData, parents, renameElement } from "./utils.js";
 import { hyperHTML } from "./import-maps.js";
 
 const lowerHeaderTags = ["h2", "h3", "h4", "h5", "h6"];
@@ -123,10 +117,10 @@ function scanSections(sections, maxTocLevel, { prefix = "" } = {}) {
  * @param {Element} parent
  */
 function getSectionTree(parent, { tocIntroductory = false } = {}) {
-  const sectionElements = children(
-    parent,
-    tocIntroductory ? "section" : "section:not(.introductory)"
-  );
+  /** @type {NodeListOf<HTMLElement>} */
+  const sectionElements = tocIntroductory
+    ? parent.querySelectorAll(":scope > section")
+    : parent.querySelectorAll(":scope > section:not(.introductory)");
   /** @type {Section[]} */
   const sections = [];
 

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -768,34 +768,6 @@ export function parents(element, selector) {
 }
 
 /**
- * Applies the selector for direct descendants.
- * This is a helper function for browsers without :scope support.
- * Note that this doesn't support comma separated selectors.
- * @param {Element} element
- * @param {string} selector
- * @returns {NodeListOf<HTMLElement>}
- */
-export function children(element, selector) {
-  try {
-    return element.querySelectorAll(`:scope > ${selector}`);
-  } catch {
-    let tempId = "";
-    // We give a temporary id, to overcome lack of ":scope" support in Edge.
-    if (!element.id) {
-      tempId = `temp-${String(Math.random()).substr(2)}`;
-      element.id = tempId;
-    }
-    const query = `#${element.id} > ${selector}`;
-    /** @type {NodeListOf<HTMLElement>} */
-    const elements = element.parentElement.querySelectorAll(query);
-    if (tempId) {
-      element.id = "";
-    }
-    return elements;
-  }
-}
-
-/**
  * Calculates indentation when the element starts after a newline.
  * The value will be empty if no newline or any non-whitespace exists after one.
  * @param {Element} element

--- a/tests/spec/core/structure-spec.js
+++ b/tests/spec/core/structure-spec.js
@@ -6,7 +6,6 @@ import {
   makeRSDoc,
   makeStandardOps,
 } from "../SpecHelper.js";
-import { children } from "../../../src/core/utils.js";
 
 describe("Core - Structure", () => {
   const body = `
@@ -137,10 +136,12 @@ describe("Core - Structure", () => {
     const doc = await makeRSDoc(ops);
     const toc = doc.getElementById("toc");
     expect(toc.querySelector("h2").textContent).toBe("Table of Contents");
-    expect(children(toc, "ol > li").length).toBe(7);
+    expect(toc.querySelectorAll(":scope > ol > li").length).toBe(7);
     expect(toc.querySelectorAll("li").length).toBe(19);
     expect(toc.querySelector("ol > li").textContent).toBe("Abstract");
-    expect(children(toc, "ol > li a[href='#intro']").length).toBe(1);
+    expect(
+      toc.querySelectorAll(":scope > ol > li a[href='#intro']").length
+    ).toBe(1);
   });
 
   it("should limit ToC depth with maxTocLevel", async () => {


### PR DESCRIPTION
Part of https://github.com/w3c/respec/issues/2374