### PR TITLE
fix(assets/ui.css): align first paragraph to warning marker

### DIFF
--- a/assets/ui.css
+++ b/assets/ui.css
@@ -216,6 +216,11 @@
   display: inline-block;
 }
 
+.respec-error-list li > p:first-child,
+.respec-warning-list li > p:first-child {
+  display: inline;
+}
+
 #respec-overlay {
   display: block;
   position: fixed;


### PR DESCRIPTION
When a warning/error contains a `<details>` (which in turn causes marked to wrap `li.textContent` in a `<p>`), the warning/error emoji is not aligned to the paragraph. Saw it first with WebIDL errors.

Without `display: inline`:
![image](https://user-images.githubusercontent.com/8426945/75921709-9a448880-5e87-11ea-8236-4d4a1f6244fc.png)

With `display: inline`:
![image](https://user-images.githubusercontent.com/8426945/75921757-af211c00-5e87-11ea-9226-6797838da008.png)

(yes, I don't have native emoji support)
