### PR TITLE
feat(core/a11y): add axe-core integration

### DIFF
--- a/assets/ui.css
+++ b/assets/ui.css
@@ -216,6 +216,17 @@
   display: inline-block;
 }
 
+.respec-error-list li > p:first-child,
+.respec-warning-list li > p:first-child {
+  display: inline;
+}
+
+.respec-warning-list > li li,
+.respec-error-list > li li {
+  margin: 0;
+  list-style: disc;
+}
+
 #respec-overlay {
   display: block;
   position: fixed;

--- a/profiles/w3c-common.js
+++ b/profiles/w3c-common.js
@@ -79,6 +79,7 @@ const modules = [
   import("../src/core/custom-elements/index.js"),
   /* Linter must be the last thing to run */
   import("../src/core/linter.js"),
+  import("../src/core/a11y.js"),
 ];
 
 async function domReady() {

--- a/profiles/w3c.js
+++ b/profiles/w3c.js
@@ -63,6 +63,7 @@ const modules = [
   import("../src/core/anchor-expander.js"),
   import("../src/core/custom-elements/index.js"),
   /* Linter must be the last thing to run */
+  import("../src/core/a11y.js"),
   import("../src/core/linter.js"),
 ];
 

--- a/profiles/w3c.js
+++ b/profiles/w3c.js
@@ -62,9 +62,9 @@ const modules = [
   import("../src/core/algorithms.js"),
   import("../src/core/anchor-expander.js"),
   import("../src/core/custom-elements/index.js"),
-  /* Linter must be the last thing to run */
-  import("../src/core/a11y.js"),
+  /* Linters must be the last thing to run */
   import("../src/core/linter.js"),
+  import("../src/core/a11y.js"),
 ];
 
 async function domReady() {

--- a/src/core/a11y.js
+++ b/src/core/a11y.js
@@ -1,4 +1,8 @@
 // @ts-check
+/**
+ * Module: core/a11y
+ * Lints for accessibility issues using axe-core package.
+ */
 
 import { pub } from "./pubsubhub.js";
 import { showInlineWarning } from "./utils.js";

--- a/src/core/a11y.js
+++ b/src/core/a11y.js
@@ -9,8 +9,11 @@ const DISABLED_RULES = [
   "color-contrast", // too slow 🐢
 ];
 
-export async function run(_conf) {
-  // TODO: run conditionally based on conf
+export async function run(conf) {
+  if (!conf.a11y) {
+    return;
+  }
+
   const violations = await getViolations();
   for (const violation of violations) {
     /**

--- a/src/core/a11y.js
+++ b/src/core/a11y.js
@@ -1,0 +1,86 @@
+import { showInlineWarning } from "./utils.js";
+
+export const name = "core/a11y";
+
+const DISABLED_RULES = [
+  "landmark-one-main", // need to add a <main>, else it marks entire page as errored
+  "landmark-unique",
+  "region",
+  "color-contrast", // too slow 🐢
+];
+
+export async function run(_conf) {
+  // TODO: run conditionally based on conf
+  const violations = await getViolations();
+  for (const violation of violations) {
+    /**
+     * We're grouping by failureSummary as it contains hints to fix the issue.
+     * For example, with color-constrast rule, it tells about the present color
+     * contrast and how to fix it. If we don't group, errors will be repetitive.
+     * @type {Map<string, HTMLElement[]>}
+     */
+    const groupedBySummary = new Map();
+    for (const node of violation.nodes) {
+      const { failureSummary, element } = node;
+      const elements =
+        groupedBySummary.get(failureSummary) ||
+        groupedBySummary.set(failureSummary, []).get(failureSummary);
+      elements.push(element);
+    }
+
+    const { id, help, description, helpUrl } = violation;
+    const title = `a11y/${id}: ${help}`;
+    for (const [failureSummary, elements] of groupedBySummary) {
+      const hints = formatHintsAsMarkdown(failureSummary);
+      const details = `\n\n${description}.\n\n${hints}. ([Learn more](${helpUrl}))`;
+      showInlineWarning(elements, title, title, { details });
+    }
+  }
+}
+
+/**
+ * @typedef {{ failureSummary: string, element: HTMLElement }} ViolationNode
+ * @typedef {{ id: string, help: string, helpUrl: string, description: string, nodes: ViolationNode[] }} Violation
+ * @returns {Promise<Violation[]>}
+ */
+async function getViolations() {
+  const options = {
+    elementRef: true,
+    rules: Object.fromEntries(
+      DISABLED_RULES.map(id => [id, { enabled: false }])
+    ),
+    resultTypes: ["violations"],
+    reporter: "v1", // v1 includes a `failureSummary`
+  };
+
+  try {
+    const axe = await importAxe();
+    const result = await axe.run(document, options);
+    return result.violations;
+  } catch (error) {
+    console.error(error);
+    return [];
+  }
+}
+
+function importAxe() {
+  return new Promise((resolve, reject) => {
+    const script = document.createElement("script");
+    script.classList.add("remove");
+    script.src = "https://unpkg.com/axe-core@3.5.1/axe.min.js";
+    script.onload = () => resolve(window.axe);
+    script.onerror = reject;
+    document.head.appendChild(script);
+  });
+}
+
+/** @param {string} text */
+function formatHintsAsMarkdown(text) {
+  const results = [];
+  for (const group of text.split("\n\n")) {
+    const [msg, ...opts] = group.split(/^\s{2}/m);
+    const options = opts.map(opt => `- ${opt.trimEnd()}`).join("\n");
+    results.push(`${msg}${options}`);
+  }
+  return results.join("\n\n");
+}

--- a/src/core/a11y.js
+++ b/src/core/a11y.js
@@ -63,7 +63,9 @@ async function getViolations(opts) {
   try {
     axe = await importAxe();
   } catch (error) {
-    pub("error", "Failed to load a11y linter.");
+    const msg =
+      "Failed to load a11y linter. See developer console for details.";
+    pub("error", msg);
     console.error(error);
     return [];
   }

--- a/src/core/a11y.js
+++ b/src/core/a11y.js
@@ -15,7 +15,7 @@ export async function run(conf) {
     return;
   }
 
-  const violations = await getViolations();
+  const violations = await getViolations(conf.a11y);
   for (const violation of violations) {
     /**
      * We're grouping by failureSummary as it contains hints to fix the issue.
@@ -43,16 +43,18 @@ export async function run(conf) {
 }
 
 /**
+ * @param {object} opts Options as described at https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#options-parameter
  * @typedef {{ failureSummary: string, element: HTMLElement }} ViolationNode
  * @typedef {{ id: string, help: string, helpUrl: string, description: string, nodes: ViolationNode[] }} Violation
  * @returns {Promise<Violation[]>}
  */
-async function getViolations() {
+async function getViolations(opts) {
   const options = {
-    elementRef: true,
     rules: Object.fromEntries(
       DISABLED_RULES.map(id => [id, { enabled: false }])
     ),
+    ...opts,
+    elementRef: true,
     resultTypes: ["violations"],
     reporter: "v1", // v1 includes a `failureSummary`
   };

--- a/src/core/a11y.js
+++ b/src/core/a11y.js
@@ -50,9 +50,6 @@ export async function run(conf) {
 
 /**
  * @param {object} opts Options as described at https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#options-parameter
- * @typedef {{ failureSummary: string, element: HTMLElement }} ViolationNode
- * @typedef {{ id: string, help: string, helpUrl: string, description: string, nodes: ViolationNode[] }} Violation
- * @returns {Promise<Violation[]>}
  */
 async function getViolations(opts) {
   const options = {
@@ -86,6 +83,7 @@ async function getViolations(opts) {
   }
 }
 
+/** @returns {Promise<typeof window.axe>} */
 function importAxe() {
   const script = document.createElement("script");
   script.classList.add("remove");

--- a/src/core/a11y.js
+++ b/src/core/a11y.js
@@ -81,13 +81,13 @@ async function getViolations(opts) {
 }
 
 function importAxe() {
+  const script = document.createElement("script");
+  script.classList.add("remove");
+  script.src = "https://unpkg.com/axe-core@3/axe.min.js";
+  document.head.appendChild(script);
   return new Promise((resolve, reject) => {
-    const script = document.createElement("script");
-    script.classList.add("remove");
-    script.src = "https://unpkg.com/axe-core@3/axe.min.js";
     script.onload = () => resolve(window.axe);
     script.onerror = reject;
-    document.head.appendChild(script);
   });
 }
 

--- a/src/core/a11y.js
+++ b/src/core/a11y.js
@@ -80,7 +80,7 @@ function importAxe() {
   return new Promise((resolve, reject) => {
     const script = document.createElement("script");
     script.classList.add("remove");
-    script.src = "https://unpkg.com/axe-core@3.5.1/axe.min.js";
+    script.src = "https://unpkg.com/axe-core@3/axe.min.js";
     script.onload = () => resolve(window.axe);
     script.onerror = reject;
     document.head.appendChild(script);

--- a/src/core/a11y.js
+++ b/src/core/a11y.js
@@ -10,10 +10,10 @@ import { showInlineWarning } from "./utils.js";
 export const name = "core/a11y";
 
 const DISABLED_RULES = [
+  "color-contrast", // too slow 🐢
   "landmark-one-main", // need to add a <main>, else it marks entire page as errored
   "landmark-unique",
   "region",
-  "color-contrast", // too slow 🐢
 ];
 
 export async function run(conf) {

--- a/src/core/a11y.js
+++ b/src/core/a11y.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 import { pub } from "./pubsubhub.js";
 import { showInlineWarning } from "./utils.js";
 

--- a/src/core/a11y.js
+++ b/src/core/a11y.js
@@ -1,3 +1,4 @@
+import { pub } from "./pubsubhub.js";
 import { showInlineWarning } from "./utils.js";
 
 export const name = "core/a11y";
@@ -56,11 +57,20 @@ async function getViolations() {
     reporter: "v1", // v1 includes a `failureSummary`
   };
 
+  let axe;
   try {
-    const axe = await importAxe();
+    axe = await importAxe();
+  } catch (error) {
+    pub("error", "Failed to load a11y linter.");
+    console.error(error);
+    return [];
+  }
+
+  try {
     const result = await axe.run(document, options);
     return result.violations;
   } catch (error) {
+    pub("error", "Error while looking for a11y issues.");
     console.error(error);
     return [];
   }

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -128,8 +128,10 @@ export function removeReSpec(doc) {
  * @param {HTMLElement|HTMLElement[]} elems
  * @param {String} msg message to show in warning
  * @param {String=} title error message to add on each element
+ * @param {object} [options]
+ * @param {string} [options.details]
  */
-export function showInlineWarning(elems, msg, title) {
+export function showInlineWarning(elems, msg, title, { details } = {}) {
   if (!Array.isArray(elems)) elems = [elems];
   const links = elems
     .map((element, i) => {
@@ -137,7 +139,11 @@ export function showInlineWarning(elems, msg, title) {
       return generateMarkdownLink(element, i);
     })
     .join(", ");
-  pub("warn", `${msg} at: ${links}.`);
+  let message = `${msg} at: ${links}.`;
+  if (details) {
+    message += `\n\n<details>${details}</details>`;
+  }
+  pub("warn", message);
   console.warn(msg, elems);
 }
 

--- a/src/type-helper.d.ts
+++ b/src/type-helper.d.ts
@@ -15,6 +15,15 @@ declare module "text!*" {
   export default value;
 }
 
+// See: core/a11y
+interface AxeViolation {
+  id: string;
+  help: string;
+  helpUrl: string;
+  description: string;
+  nodes: { failureSummary: string; element: HTMLElement }[];
+}
+
 declare var respecConfig: any;
 interface Window {
   respecVersion: string;
@@ -40,7 +49,7 @@ interface Window {
   $: JQueryStatic;
   jQuery: JQueryStatic;
   axe?: {
-    run(context: HTMLElement, options: any): Promise<any>;
+    run(context: Node, options: any): Promise<{ violations: AxeViolation[] }>;
   };
 }
 

--- a/src/type-helper.d.ts
+++ b/src/type-helper.d.ts
@@ -39,6 +39,9 @@ interface Window {
   };
   $: JQueryStatic;
   jQuery: JQueryStatic;
+  axe?: {
+    run(context: HTMLElement, options: any): Promise<any>;
+  };
 }
 
 interface Document {

--- a/tests/spec/core/a11y-spec.js
+++ b/tests/spec/core/a11y-spec.js
@@ -1,0 +1,66 @@
+"use strict";
+
+import { flushIframes, makeRSDoc, makeStandardOps } from "../SpecHelper.js";
+
+describe("Core — a11y", () => {
+  afterAll(flushIframes);
+
+  const body = `
+    <section id="test">
+      <h2>Test</h2>
+      <img
+        id="image-alt-1"
+        src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C"
+      />
+      <img
+        id="image-alt-2"
+        src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C"
+        alt="W3C Logo"
+      />
+    </section>
+  `;
+
+  it("does nothing if not configured", async () => {
+    const ops = makeStandardOps(null, body);
+    const doc = await makeRSDoc(ops);
+    const offendingElements = doc.querySelectorAll(
+      "#test .respec-offending-element"
+    );
+    expect(offendingElements.length).toBe(0);
+  });
+
+  it("does nothing if disabled", async () => {
+    const ops = makeStandardOps({ a11y: false }, body);
+    const doc = await makeRSDoc(ops);
+    const offendingElements = doc.querySelectorAll(
+      "#test .respec-offending-element"
+    );
+    expect(offendingElements.length).toBe(0);
+  });
+
+  it("runs default tests if enabled", async () => {
+    const ops = makeStandardOps({ a11y: true }, body);
+    const doc = await makeRSDoc(ops);
+    const offendingElements = doc.querySelectorAll(
+      "#test .respec-offending-element"
+    );
+
+    expect(offendingElements.length).toBe(1);
+    expect(offendingElements[0].id).toBe("image-alt-1");
+    expect(offendingElements[0].title).toContain("a11y/image-alt");
+  });
+
+  it("allows overriding options", async () => {
+    const a11yOptions = {
+      runOnly: ["image-alt", "landmark-one-main"],
+    };
+    const ops = makeStandardOps({ a11y: a11yOptions }, body);
+    const doc = await makeRSDoc(ops);
+
+    const offendingElements = doc.querySelectorAll(".respec-offending-element");
+    expect(offendingElements.length).toBe(2);
+    expect(offendingElements[0].id).toContain("a11y-landmark-one-main");
+    expect(offendingElements[0].localName).toBe("html");
+    expect(offendingElements[1].id).toBe("image-alt-1");
+  });
+});

--- a/tests/spec/core/a11y-spec.js
+++ b/tests/spec/core/a11y-spec.js
@@ -6,7 +6,7 @@ describe("Core — a11y", () => {
   afterAll(flushIframes);
 
   const body = `
-    <section id="test">
+    <section>
       <h2>Test</h2>
       <img
         id="image-alt-1"
@@ -23,27 +23,21 @@ describe("Core — a11y", () => {
   it("does nothing if not configured", async () => {
     const ops = makeStandardOps(null, body);
     const doc = await makeRSDoc(ops);
-    const offendingElements = doc.querySelectorAll(
-      "#test .respec-offending-element"
-    );
+    const offendingElements = doc.querySelectorAll(".respec-offending-element");
     expect(offendingElements.length).toBe(0);
   });
 
   it("does nothing if disabled", async () => {
     const ops = makeStandardOps({ a11y: false }, body);
     const doc = await makeRSDoc(ops);
-    const offendingElements = doc.querySelectorAll(
-      "#test .respec-offending-element"
-    );
+    const offendingElements = doc.querySelectorAll(".respec-offending-element");
     expect(offendingElements.length).toBe(0);
   });
 
   it("runs default tests if enabled", async () => {
     const ops = makeStandardOps({ a11y: true }, body);
     const doc = await makeRSDoc(ops);
-    const offendingElements = doc.querySelectorAll(
-      "#test .respec-offending-element"
-    );
+    const offendingElements = doc.querySelectorAll(".respec-offending-element");
 
     expect(offendingElements.length).toBe(1);
     expect(offendingElements[0].id).toBe("image-alt-1");


### PR DESCRIPTION
Closes https://github.com/w3c/respec/issues/2777

- The linter API is not flexible enough with error reporting, so created a new core/a11y module.
- Axe is quite slow on W3C specs. Need to disable a lot of rules, or provide authors a way to select rules. Should be used locally only to fix issues, not on live versions.