### PR TITLE
fix(core/a11y): allow overriding rules while keeping disabled ones

### DIFF
--- a/src/core/a11y.js
+++ b/src/core/a11y.js
@@ -21,7 +21,8 @@ export async function run(conf) {
     return;
   }
 
-  const violations = await getViolations(conf.a11y);
+  const options = conf.a11y === true ? {} : conf.a11y;
+  const violations = await getViolations(options);
   for (const violation of violations) {
     /**
      * We're grouping by failureSummary as it contains hints to fix the issue.
@@ -52,7 +53,7 @@ export async function run(conf) {
  * @param {object} opts Options as described at https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#options-parameter
  */
 async function getViolations(opts) {
-  const { rules, ...otherOptions } = opts === true ? {} : opts;
+  const { rules, ...otherOptions } = opts;
   const options = {
     rules: {
       ...Object.fromEntries(DISABLED_RULES.map(id => [id, { enabled: false }])),

--- a/src/core/a11y.js
+++ b/src/core/a11y.js
@@ -52,11 +52,13 @@ export async function run(conf) {
  * @param {object} opts Options as described at https://github.com/dequelabs/axe-core/blob/develop/doc/API.md#options-parameter
  */
 async function getViolations(opts) {
+  const { rules, ...otherOptions } = opts === true ? {} : opts;
   const options = {
-    rules: Object.fromEntries(
-      DISABLED_RULES.map(id => [id, { enabled: false }])
-    ),
-    ...opts,
+    rules: {
+      ...Object.fromEntries(DISABLED_RULES.map(id => [id, { enabled: false }])),
+      ...rules,
+    },
+    ...otherOptions,
     elementRef: true,
     resultTypes: ["violations"],
     reporter: "v1", // v1 includes a `failureSummary`

--- a/tests/spec/core/a11y-spec.js
+++ b/tests/spec/core/a11y-spec.js
@@ -57,4 +57,20 @@ describe("Core — a11y", () => {
     expect(offendingElements[0].localName).toBe("html");
     expect(offendingElements[1].id).toBe("image-alt-1");
   });
+
+  it("allows overriding rules option", async () => {
+    const a11yOptions = {
+      rules: {
+        "landmark-one-main": { enabled: true },
+        "image-alt": { enabled: false },
+      },
+    };
+    const ops = makeStandardOps({ a11y: a11yOptions }, body);
+    const doc = await makeRSDoc(ops);
+
+    const offendingElements = doc.querySelectorAll(".respec-offending-element");
+    expect(offendingElements.length).toBe(1);
+    expect(offendingElements[0].id).toContain("a11y-landmark-one-main");
+    expect(offendingElements[0].localName).toBe("html");
+  });
 });


### PR DESCRIPTION
Earlier, if one added `rules` option, it'll run even the ones we have disabled. One can still enable the rules we've disabled, but would need to be explicit.