### PR TITLE
fix(core/issues-notes): fix issue label color contrast

### DIFF
--- a/assets/issues-notes.css
+++ b/assets/issues-notes.css
@@ -52,13 +52,3 @@ input.task-list-item-checkbox {
   border: none;
   display: inline-block;
 }
-
-.issue a.respec-label-dark {
-  color: #fff;
-  background-color: #000;
-}
-
-.issue a.respec-label-light {
-  color: #000;
-  background-color: #fff;
-}

--- a/src/core/issues-notes.js
+++ b/src/core/issues-notes.js
@@ -287,14 +287,6 @@ function makeIssueSectionSummary(issueList) {
   }
 }
 
-function isLight(rgb) {
-  const red = (rgb >> 16) & 0xff;
-  const green = (rgb >> 8) & 0xff;
-  const blue = (rgb >> 0) & 0xff;
-  const illumination = 0.2126 * red + 0.7152 * green + 0.0722 * blue;
-  return illumination > 140;
-}
-
 /**
  * @param {GitHubLabel[]} labels
  * @param {string} title
@@ -316,20 +308,23 @@ function createLabelsGroup(labels, title, repoURL) {
   return hyperHTML`<span class="issue-label">: ${title}${labelsGroup}</span>`;
 }
 
+/** @param {string} bgColorHex background color as a hex value without '#' */
+function textColorFromBgColor(bgColorHex) {
+  return parseInt(bgColorHex, 16) > 0xffffff / 2 ? "#000" : "#fff";
+}
+
 /**
  * @param {GitHubLabel} label
  * @param {string} repoURL
  */
 function createLabel(label, repoURL) {
-  const { color, name } = label;
+  const { color: bgColor, name } = label;
   const issuesURL = new URL("./issues/", repoURL);
   issuesURL.searchParams.set("q", `is:issue is:open label:"${label.name}"`);
-  const rgb = parseInt(color, 16);
-  const textColorClass = isNaN(rgb) || isLight(rgb) ? "light" : "dark";
-  const cssClasses = `respec-gh-label respec-label-${textColorClass}`;
-  const style = `background-color: #${color}`;
+  const color = textColorFromBgColor(bgColor);
+  const style = `background-color: #${bgColor}; color: ${color}`;
   return hyperHTML`<a
-    class="${cssClasses}"
+    class="respec-gh-label"
     style="${style}"
     href="${issuesURL.href}">${name}</a>`;
 }


### PR DESCRIPTION
This resulted in same label text colors as on GitHub, satisfying color contrast guidelines. Also, code is smaller and simpler.