### PR TITLE
fix(templates/show-link): render otherLinks without href as plain text

### DIFF
--- a/src/w3c/templates/show-link.js
+++ b/src/w3c/templates/show-link.js
@@ -24,7 +24,7 @@ function showLinkData(data) {
         ? html`
             <a href="${data.href}">${data.value || data.href}</a>
           `
-        : ""}
+        : data.value}
     </dd>
   `;
 }

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -987,6 +987,46 @@ describe("W3C — Headers", () => {
     });
   });
 
+  describe("otherLinks", () => {
+    it("renders otherLinks with value and href", async () => {
+      const otherLinks = [
+        {
+          class: "key-other-link",
+          key: "KEY",
+          data: [{ value: "VALUE", href: "HREF" }],
+        },
+      ];
+      const ops = makeStandardOps({ otherLinks });
+      const doc = await makeRSDoc(ops);
+
+      const dt = doc.querySelector(".head dt.key-other-link");
+      expect(dt.textContent).toBe("KEY:");
+      const dd = dt.nextElementSibling;
+      expect(dd.localName).toBe("dd");
+      expect(dd.querySelector("a").textContent).toBe("VALUE");
+      expect(dd.querySelector("a").getAttribute("href")).toBe("HREF");
+    });
+
+    it("renders otherLinks without href", async () => {
+      const otherLinks = [
+        {
+          class: "key-other-link",
+          key: "KEY",
+          data: [{ value: "VALUE" }],
+        },
+      ];
+      const ops = makeStandardOps({ otherLinks });
+      const doc = await makeRSDoc(ops);
+
+      const dt = doc.querySelector(".head dt.key-other-link");
+      expect(dt.textContent).toBe("KEY:");
+      const dd = dt.nextElementSibling;
+      expect(dd.localName).toBe("dd");
+      expect(dd.textContent.trim()).toBe("VALUE");
+      expect(dd.querySelector("a")).toBeNull();
+    });
+  });
+
   describe("testSuiteURI", () => {
     it("takes testSuiteURI into account", async () => {
       const ops = makeStandardOps();


### PR DESCRIPTION
Fixes https://github.com/w3c/respec/issues/2789
[Preview `sdw/time` spec with fixes](https://respec-preview.netlify.com/?spec=https%3A%2F%2Fw3c.github.io%2Fsdw%2Ftime%2F&version=https%3A%2F%2Fdeploy-preview-2790--respec-pr.netlify.com%2Frespec-w3c-common.js)