### PR TITLE
refactor(*/defaults): enable pluralize in core/defaults

### DIFF
--- a/src/core/defaults.js
+++ b/src/core/defaults.js
@@ -32,7 +32,7 @@ export const coreDefaults = {
     "check-charset": false,
     "privsec-section": false,
   },
-  pluralize: false,
+  pluralize: true,
   specStatus: "base",
   highlightVars: true,
   addSectionLinks: true,

--- a/src/dini/defaults.js
+++ b/src/dini/defaults.js
@@ -48,7 +48,6 @@ const diniDefaults = {
     "wpt-tests-exist": false,
   },
   logos: [],
-  pluralize: true,
   prependW3C: false,
   doJsonLd: false,
   license: "cc-by",

--- a/src/w3c/defaults.js
+++ b/src/w3c/defaults.js
@@ -16,7 +16,6 @@ const w3cDefaults = {
     "privsec-section": true,
     "wpt-tests-exist": false,
   },
-  pluralize: true,
   doJsonLd: false,
   license: "w3c-software-doc",
   logos: [

--- a/tests/spec/core/pluralize-spec.js
+++ b/tests/spec/core/pluralize-spec.js
@@ -109,24 +109,6 @@ describe("Core - Pluralize", () => {
     expect(invalidLink.classList).toContain("respec-offending-element");
   });
 
-  it("does nothing if conf.pluralize is not defined", async () => {
-    const body = `
-      <section id="section">
-        <dfn>foo</dfn> can be referenced
-        as <a>foo</a>
-        but not as <a>foos</a>
-      </section>
-    `;
-    const ops = makeStandardOps({ specStatus: "unofficial" }, body);
-    const doc = await makeRSDoc(ops);
-
-    const { id: dfnId } = doc.querySelector("#section dfn");
-    expect(dfnId).toBe("dfn-foo");
-    const [validLink, invalidLink] = [...doc.querySelectorAll("#section a")];
-    expect(validLink.getAttribute("href")).toBe("#dfn-foo");
-    expect(invalidLink.classList).toContain("respec-offending-element");
-  });
-
   it("doesn't pluralize when [data-lt-noDefault] is defined", async () => {
     const body = `
       <section id="section">


### PR DESCRIPTION
Moved `pluralize: true` to `core/defaults` as it's enabled in all profiles anyway.
Also, removed a redundant test (we already have one with `pluralize: false`.