### PR TITLE
chore(ci): remove `ci skip` logic

### DIFF
--- a/.github/workflows/pr-push.yml
+++ b/.github/workflows/pr-push.yml
@@ -6,6 +6,7 @@ on:
       - gh-pages
   pull_request: {}
 
+
 jobs:
   lint:
     name: Check linting issues

--- a/.github/workflows/pr-push.yml
+++ b/.github/workflows/pr-push.yml
@@ -6,7 +6,6 @@ on:
       - gh-pages
   pull_request: {}
 
-
 jobs:
   lint:
     name: Check linting issues

--- a/.github/workflows/pr-push.yml
+++ b/.github/workflows/pr-push.yml
@@ -12,22 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - id: log
-        run: echo "::set-output name=message::$(git log --no-merges -1 --oneline)"
-      - if: "!contains(steps.log.outputs.message, 'ci skip')"
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v1
         with:
           node-version: 10
-      - if: "!contains(steps.log.outputs.message, 'ci skip')"
-        name: Cache node modules
+      - name: Cache node modules
         uses: actions/cache@v1
         with:
           path: ./node_modules
           key: ${{ runner.os }}-node-10-${{ hashFiles('**/package-lock.json') }}
-      - if: "!contains(steps.log.outputs.message, 'ci skip')"
-        run: npm install
-      - if: "!contains(steps.log.outputs.message, 'ci skip')"
-        run: npm run lint
+      - run: npm install
+      - run: npm run lint
 
   test-headless:
     name: Headless Tests
@@ -35,26 +29,20 @@ jobs:
     needs: lint
     steps:
       - uses: actions/checkout@v1
-      - id: log
-        run: echo "::set-output name=message::$(git log --no-merges -1 --oneline)"
-      - if: "!contains(steps.log.outputs.message, 'ci skip')"
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v1
         with:
           node-version: 10
-      - if: "!contains(steps.log.outputs.message, 'ci skip')"
-        name: Cache node modules
+      - name: Cache node modules
         uses: actions/cache@v1
         with:
           path: ./node_modules
           key: ${{ runner.os }}-node-10-${{ hashFiles('**/package-lock.json') }}
-      - if: "!contains(steps.log.outputs.message, 'ci skip')"
-        name: install & build
+      - name: install & build
         run: |
           npm install --ignore-scripts
           npm run builddeps
           npm run build:w3c
-      - if: "!contains(steps.log.outputs.message, 'ci skip')"
-        run: npm run test:headless
+      - run: npm run test:headless
 
   test-karma:
     name: Karma Unit Tests (${{ matrix.browser }})
@@ -65,25 +53,19 @@ jobs:
     needs: lint
     steps:
       - uses: actions/checkout@v1
-      - id: log
-        run: echo "::set-output name=message::$(git log --no-merges -1 --oneline)"
-      - if: "!contains(steps.log.outputs.message, 'ci skip')"
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v1
         with:
           node-version: 10
-      - if: "!contains(steps.log.outputs.message, 'ci skip')"
-        name: Cache node modules
+      - name: Cache node modules
         uses: actions/cache@v1
         with:
           path: ./node_modules
           key: ${{ runner.os }}-node-10-${{ hashFiles('**/package-lock.json') }}
-      - if: "!contains(steps.log.outputs.message, 'ci skip')"
-        name: install & build
+      - name: install & build
         run: |
           npm install --ignore-scripts
           npm run builddeps
           npm run build:w3c & npm run build:geonovum
-      - if: "!contains(steps.log.outputs.message, 'ci skip')"
-        run: npm run test:karma
+      - run: npm run test:karma
         env:
           BROWSERS: ${{ matrix.browser }}


### PR DESCRIPTION
This reverts commit 4f7e1b39b252fdcb192bfacc6bcde82adc1d6458.

[GitHub checks documentation](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-status-checks#skipping-and-requesting-checks-for-individual-commits) says we can skip checks by adding `skip-checks: true` two lines after the commit message. So, this will be a lot cleaner now.

