### PR TITLE
feat(core/dfn-index): generate list of externally referenced terms

### DIFF
--- a/assets/dfn-index.css
+++ b/assets/dfn-index.css
@@ -1,0 +1,23 @@
+/*
+@module "core/dfn-index"
+Extends and overrides some styles from `base.css`.
+*/
+ul.index {
+  columns: 30ch;
+  column-gap: 1.5em;
+}
+
+ul.index li {
+  list-style: inherit;
+}
+
+ul.index li span {
+  color: inherit;
+  cursor: pointer;
+  white-space: normal;
+}
+
+ul.index code {
+  color: inherit;
+  font-size: 0.95em;
+}

--- a/profiles/w3c-common.js
+++ b/profiles/w3c-common.js
@@ -54,6 +54,7 @@ const modules = [
   import("../src/core/webidl-index.js"),
   import("../src/core/link-to-dfn.js"),
   import("../src/core/render-biblio.js"),
+  import("../src/core/dfn-index.js"),
   import("../src/core/contrib.js"),
   import("../src/core/fix-headers.js"),
   import("../src/core/structure.js"),

--- a/profiles/w3c.js
+++ b/profiles/w3c.js
@@ -38,6 +38,7 @@ const modules = [
   import("../src/core/webidl-index.js"),
   import("../src/core/link-to-dfn.js"),
   import("../src/core/render-biblio.js"),
+  import("../src/core/dfn-index.js"),
   import("../src/core/contrib.js"),
   import("../src/core/fix-headers.js"),
   import("../src/core/structure.js"),

--- a/src/core/data-cite.js
+++ b/src/core/data-cite.js
@@ -118,7 +118,7 @@ function makeComponentFinder(component) {
  *
  * @return {(elem: HTMLElement) => CiteDetails};
  */
-function citeDetailsConverter(conf) {
+export function citeDetailsConverter(conf) {
   const findFrag = makeComponentFinder("#");
   const findPath = makeComponentFinder("/");
   return function toCiteDetails(elem) {

--- a/src/core/dfn-index.js
+++ b/src/core/dfn-index.js
@@ -57,8 +57,8 @@ export async function run(conf) {
  */
 function createExternalTermIndex(toCiteDetails) {
   const data = collectExternalTerms(toCiteDetails);
-  const dataSortedBySpec = [...data.entries()].sort((a, b) =>
-    a[0].localeCompare(b[0])
+  const dataSortedBySpec = [...data.entries()].sort(([specA], [specB]) =>
+    specA.localeCompare(specB)
   );
   return html`<ul class="index">
     ${dataSortedBySpec.map(

--- a/src/core/dfn-index.js
+++ b/src/core/dfn-index.js
@@ -10,6 +10,7 @@ import { fetchAsset } from "./text-loader.js";
 import { getTermFromElement } from "./xref.js";
 import { hyperHTML as html } from "./import-maps.js";
 import { renderInlineCitation } from "./render-biblio.js";
+import { sub } from "./pubsubhub.js";
 
 export const name = "core/dfn-index";
 
@@ -39,6 +40,8 @@ export async function run(conf) {
     ${createExternalTermIndex(toCiteDetails)}
   </section>`;
   index.append(externalTermIndex);
+
+  sub("beforesave", cleanup);
 }
 
 /**
@@ -51,7 +54,7 @@ function createExternalTermIndex(toCiteDetails) {
   );
   return html`<ul class="index">
     ${dataSortedBySpec.map(
-      ([spec, entries]) => html`<li>
+      ([spec, entries]) => html`<li data-spec="${spec}">
         ${renderInlineCitation(spec)} defines the following:
         <ul>
           ${entries
@@ -201,4 +204,11 @@ async function loadStyle() {
   } catch {
     return fetchAsset("dfn-index.css");
   }
+}
+
+/** @param {Document} doc */
+function cleanup(doc) {
+  doc
+    .querySelectorAll("#index-defined-elsewhere li[data-spec]")
+    .forEach(el => el.removeAttribute("data-spec"));
 }

--- a/src/core/dfn-index.js
+++ b/src/core/dfn-index.js
@@ -1,0 +1,204 @@
+// @ts-check
+/**
+ * If a `<section id="index">` exists, it is filled by a list terms defined by
+ * reference (external terms).
+ */
+
+import { addId } from "./utils.js";
+import { citeDetailsConverter } from "./data-cite.js";
+import { fetchAsset } from "./text-loader.js";
+import { getTermFromElement } from "./xref.js";
+import { hyperHTML as html } from "./import-maps.js";
+import { renderInlineCitation } from "./render-biblio.js";
+
+export const name = "core/dfn-index";
+
+/**
+ * @typedef {{ term: string, type: string, linkFor: string, elem: HTMLAnchorElement }} Entry
+ */
+
+export async function run(conf) {
+  const index = document.querySelector("section#index");
+  if (!index) {
+    return;
+  }
+
+  const styleEl = document.createElement("style");
+  styleEl.textContent = await loadStyle();
+  document.head.appendChild(styleEl);
+
+  index.classList.add("appendix");
+  if (!index.querySelector("h2")) {
+    index.prepend(html`<h2>Index</h2>`);
+  }
+
+  const toCiteDetails = citeDetailsConverter(conf);
+
+  const externalTermIndex = html`<section id="index-defined-elsewhere">
+    <h3>Terms defined by reference</h3>
+    ${createExternalTermIndex(toCiteDetails)}
+  </section>`;
+  index.append(externalTermIndex);
+}
+
+/**
+ * @param {ReturnType<typeof citeDetailsConverter>} toCiteDetails
+ */
+function createExternalTermIndex(toCiteDetails) {
+  const data = collectExternalTerms(toCiteDetails);
+  const dataSortedBySpec = [...data.entries()].sort((a, b) =>
+    a[0].localeCompare(b[0])
+  );
+  return html`<ul class="index">
+    ${dataSortedBySpec.map(
+      ([spec, entries]) => html`<li>
+        ${renderInlineCitation(spec)} defines the following:
+        <ul>
+          ${entries
+            .sort((a, b) => a.term.localeCompare(b.term))
+            .map(renderExternalTermEntry)}
+        </ul>
+      </li>`
+    )}
+  </ul>`;
+}
+
+/**
+ * @param {ReturnType<typeof citeDetailsConverter>} toCiteDetails
+ */
+function collectExternalTerms(toCiteDetails) {
+  /** @type {Set<string>} */
+  const uniqueReferences = new Set();
+  /** @type {Map<string, Entry[]>} spec => entry[] */
+  const data = new Map();
+
+  /** @type {NodeListOf<HTMLAnchorElement>} */
+  const elements = document.querySelectorAll(`a[data-cite]`);
+  for (const elem of elements) {
+    if (!elem.dataset.cite) {
+      continue;
+    }
+    const uniqueID = elem.href;
+    if (uniqueReferences.has(uniqueID)) {
+      continue;
+    }
+
+    const { type, linkFor } = elem.dataset;
+    const term = getTermFromElement(elem);
+    if (!term) {
+      continue; // <a data-cite="SPEC"></a>
+    }
+    const spec = toCiteDetails(elem).key.toUpperCase();
+
+    const entriesBySpec = data.get(spec) || data.set(spec, []).get(spec);
+    entriesBySpec.push({ term, type, linkFor, elem });
+    uniqueReferences.add(uniqueID);
+  }
+
+  return data;
+}
+
+/**
+ * @param {Entry} entry
+ * @returns {HTMLLIElement}
+ */
+function renderExternalTermEntry(entry) {
+  const { elem } = entry;
+  const text = getTermText(entry);
+  const el = html`<li>
+    <span class="index-term" data-href="${elem.href}">${{ html: text }}</span>
+  </li>`;
+  addId(el.querySelector("span"), "index-term");
+  return el;
+}
+
+// Terms of these _types_ are wrapped in `<code>`.
+const CODE_TYPES = new Set([
+  "attribute",
+  "callback",
+  "dict-member",
+  "dictionary",
+  "element-attr",
+  "element",
+  "enum-value",
+  "enum",
+  "exception",
+  "extended-attribute",
+  "interface",
+  "method",
+  "typedef",
+]);
+
+// Terms of these _types_ are suffixed with their type info.
+const TYPED_TYPES = new Map([
+  ["attribute", "attribute"],
+  ["element-attr", "attribute"],
+  ["element", "element"],
+  ["enum", "enum"],
+  ["exception", "exception"],
+  ["extended-attribute", "extended attribute"],
+  ["interface", "interface"],
+]);
+
+// These _terms_ have type suffix "type".
+const TYPE_TERMS = new Set([
+  // Following are primitive types as per WebIDL spec:
+  "boolean",
+  "byte",
+  "octet",
+  "short",
+  "unsigned short",
+  "long",
+  "unsigned long",
+  "long long",
+  "unsigned long long",
+  "float",
+  "unrestricted float",
+  "double",
+  "unrestricted double",
+  // Following are not primitive types, but aren't interfaces either.
+  "void",
+  "any",
+  "object",
+  "symbol",
+]);
+
+/** @param {Entry} entry */
+function getTermText(entry) {
+  const { term, type, linkFor } = entry;
+  let text = term;
+
+  if (CODE_TYPES.has(type)) {
+    if (type === "extended-attribute") {
+      text = `[${text}]`;
+    }
+    text = `<code>${text}</code>`;
+  }
+
+  const typeSuffix = TYPE_TERMS.has(term) ? "type" : TYPED_TYPES.get(type);
+  if (typeSuffix) {
+    text += ` ${typeSuffix}`;
+  }
+
+  if (linkFor) {
+    let linkForText = linkFor;
+    if (!/\s/.test(linkFor)) {
+      // If linkFor is a single word, highlight it.
+      linkForText = `<code>${linkForText}</code>`;
+    }
+    if (type === "element-attr") {
+      linkForText += " element";
+    }
+    text += ` (for ${linkForText})`;
+  }
+
+  return text;
+}
+
+async function loadStyle() {
+  try {
+    return (await import("text!../../assets/dfn-index.css")).default;
+  } catch {
+    return fetchAsset("dfn-index.css");
+  }
+}

--- a/src/core/dfn-index.js
+++ b/src/core/dfn-index.js
@@ -4,7 +4,7 @@
  * reference (external terms).
  */
 
-import { addId } from "./utils.js";
+import { addId, getIntlData } from "./utils.js";
 import { citeDetailsConverter } from "./data-cite.js";
 import { fetchAsset } from "./text-loader.js";
 import { getTermFromElement } from "./xref.js";
@@ -13,6 +13,14 @@ import { renderInlineCitation } from "./render-biblio.js";
 import { sub } from "./pubsubhub.js";
 
 export const name = "core/dfn-index";
+
+const localizationStrings = {
+  en: {
+    heading: "Index",
+    headingExternal: "Terms defined by reference",
+  },
+};
+const l10n = getIntlData(localizationStrings);
 
 /**
  * @typedef {{ term: string, type: string, linkFor: string, elem: HTMLAnchorElement }} Entry
@@ -30,13 +38,13 @@ export async function run(conf) {
 
   index.classList.add("appendix");
   if (!index.querySelector("h2")) {
-    index.prepend(html`<h2>Index</h2>`);
+    index.prepend(html`<h2>${l10n.heading}</h2>`);
   }
 
   const toCiteDetails = citeDetailsConverter(conf);
 
   const externalTermIndex = html`<section id="index-defined-elsewhere">
-    <h3>Terms defined by reference</h3>
+    <h3>${l10n.headingExternal}</h3>
     ${createExternalTermIndex(toCiteDetails)}
   </section>`;
   index.append(externalTermIndex);

--- a/src/core/dfn-panel.js
+++ b/src/core/dfn-panel.js
@@ -24,7 +24,7 @@ export async function run() {
     switch (action) {
       case "show": {
         if (panel) panel.remove();
-        const dfn = el.closest("dfn");
+        const dfn = el.closest("dfn, .index-term");
         panel = createPanel(dfn);
         displayPanel(dfn, panel);
         break;
@@ -44,7 +44,7 @@ export async function run() {
 /** @param {HTMLElement} clickTarget */
 function deriveAction(clickTarget) {
   const hitALink = !!clickTarget.closest("a");
-  if (clickTarget.closest("dfn")) {
+  if (clickTarget.closest("dfn, .index-term")) {
     return hitALink ? null : "show";
   }
   if (clickTarget.closest("#dfn-panel")) {
@@ -64,7 +64,7 @@ function deriveAction(clickTarget) {
 /** @param {HTMLElement} dfn */
 function createPanel(dfn) {
   const { id } = dfn;
-  const href = `#${id}`;
+  const href = dfn.dataset.href || `#${id}`;
   const links = document.querySelectorAll(`a[href="${href}"]`);
 
   /** @type {HTMLElement} */

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -147,7 +147,7 @@ function getRequestEntry(elem) {
 }
 
 /** @param {HTMLElement} elem */
-function getTermFromElement(elem) {
+export function getTermFromElement(elem) {
   const { lt: linkingText } = elem.dataset;
   let term = linkingText ? linkingText.split("|", 1)[0] : elem.textContent;
   term = normalize(term);
@@ -355,11 +355,12 @@ function addDataCiteToTerms(elems, queryKeys, data, conf) {
  */
 function addDataCite(elem, query, result, conf) {
   const { term } = query;
-  const { uri, shortname: cite, normative, type } = result;
+  const { uri, shortname: cite, normative, type, for: forContext } = result;
 
   const path = uri.includes("/") ? uri.split("/", 1)[1] : uri;
   const [citePath, citeFrag] = path.split("#");
   const dataset = { cite, citePath, citeFrag, type };
+  if (forContext) dataset.linkFor = forContext[0];
   Object.assign(elem.dataset, dataset);
 
   addToReferences(elem, cite, normative, term, conf);

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -448,8 +448,10 @@ function bufferToHexString(buffer) {
 }
 
 function cleanup(doc) {
-  const elems = doc.querySelectorAll("a[data-xref-for], a[data-xref-type]");
-  const attrToRemove = ["data-xref-for", "data-xref-type"];
+  const elems = doc.querySelectorAll(
+    "a[data-xref-for], a[data-xref-type], a[data-link-for]"
+  );
+  const attrToRemove = ["data-xref-for", "data-xref-type", "data-link-for"];
   elems.forEach(el => {
     attrToRemove.forEach(attr => el.removeAttribute(attr));
   });

--- a/tests/spec/core/dfn-index-spec.js
+++ b/tests/spec/core/dfn-index-spec.js
@@ -160,13 +160,28 @@ describe("Core — dfn-index", () => {
         eventHandlerDict,
         fullyActive,
         iframeElement,
-      ] = [...index.querySelectorAll("[data-spec='HTML'] li")].map(el =>
-        el.textContent.trim()
+      ] = [...index.querySelectorAll("li[data-spec='HTML'] .index-term")].map(
+        el => el.textContent
       );
       expect(iframeAllowAttribute).toMatch(/^allow attribute \(for/);
       expect(eventHandlerDict).toBe("EventHandler");
       expect(fullyActive).toMatch(/^fully active \(for/);
       expect(iframeElement).toBe("iframe element");
+
+      const [abortErrorException, booleanType] = [
+        ...index.querySelectorAll("li[data-spec='WEBIDL'] .index-term"),
+      ].map(el => el.textContent);
+      expect(abortErrorException).toBe("AbortError exception");
+      expect(booleanType).toBe("boolean type");
+    });
+
+    it("formats IDL extended attributes", () => {
+      const extendAttrDefault = index.querySelector(
+        "[data-spec='WEBIDL'] li:nth-child(3) .index-term"
+      );
+      expect(extendAttrDefault.textContent).toBe(
+        "[Default] extended attribute"
+      );
     });
 
     it("suffixes term with a 'for' context", async () => {

--- a/tests/spec/core/dfn-index-spec.js
+++ b/tests/spec/core/dfn-index-spec.js
@@ -106,7 +106,7 @@ describe("Core — dfn-index", () => {
     });
 
     it("doesn't list local terms", () => {
-      const terms = index.querySelectorAll("ul li li");
+      const terms = index.querySelectorAll(".index-term");
       const localTerm = [...terms].find(li => li.textContent === "hello");
       expect(localTerm).toBeUndefined();
     });

--- a/tests/spec/core/dfn-index-spec.js
+++ b/tests/spec/core/dfn-index-spec.js
@@ -1,0 +1,229 @@
+"use strict";
+import { flushIframes, makeRSDoc, makeStandardOps } from "../SpecHelper.js";
+
+describe("Core — dfn-index", () => {
+  afterAll(flushIframes);
+
+  xit("adds default heading to section#index", async () => {
+    const body = `<section id="index">
+      <p>PASS</p>
+    </section>`;
+    const ops = makeStandardOps(null, body);
+    const doc = await makeRSDoc(ops);
+    const index = doc.getElementById("index");
+
+    expect(index.classList).toContain("appendix");
+
+    expect(index.querySelectorAll("h2").length).toBe(1);
+    expect(index.querySelector("h2").textContent).toBe("A. Index");
+    expect(index.firstElementChild).toBe(index.querySelector("h2"));
+  });
+
+  xit("doesn't override existing content in section#index", async () => {
+    const body = `<section id="index">
+      <h2 id="custom-heading">el índex</h2>
+      <p id="custom-paragraph">PASS</p>
+    </section>`;
+    const ops = makeStandardOps(null, body);
+    const doc = await makeRSDoc(ops);
+    const index = doc.getElementById("index");
+
+    expect(index.querySelectorAll("h2").length).toBe(1);
+    expect(index.querySelector("h2").textContent).toBe("A. el índex");
+    expect(index.firstElementChild).toBe(
+      index.querySelector("h2#custom-heading")
+    );
+    expect(index.querySelector("p#custom-paragraph").textContent).toBe("PASS");
+
+    const subsections = index.querySelectorAll("section");
+    expect(subsections.length).toBe(1);
+    const [externalIndex] = subsections;
+
+    const externalIndexHeading = externalIndex.querySelector("h3");
+    expect(externalIndexHeading.textContent).toContain(
+      "Terms defined by reference"
+    );
+    expect(
+      externalIndexHeading.nextElementSibling.matches("ul.index")
+    ).toBeTrue();
+  });
+
+  describe("External Terms Index", () => {
+    const body = ` <section id="content">
+        <h2>Whatever</h2>
+        <p class="test"><dfn id="local-concept">hello</dfn> [= hello =]</p>
+        <div class="test" data-dfn-for="Employee" data-link-for="Employee">
+          <pre class="idl">
+            [Exposed=Window]
+            interface Employee {
+              [Default] object toJSON();
+
+              readonly attribute DOMString name;
+              attribute EventHandler onpay;
+
+              [NewObject]
+              Promise&lt;boolean&gt; pay(EventInit init);
+            };
+          </pre>
+          <dfn id="local-idl-1">name</dfn>
+          <dfn id="local-idl-2">onpay</dfn>
+        </div>
+        <p class="test" data-link-for="Employee">
+          {{ name }} {{ onpay }}
+        </p>
+        <ul class="test">
+          <li>[= creating an event =]</li>
+          <li>[= ASCII uppercase =]</li>
+          <li>{{ Event }}</li>
+          <li>[^ iframe ^]</li>
+        </ul>
+        <ul class="test">
+          <li>[= Document/fully active =]</li>
+          <li>[= environment settings object/responsible document =]</li>
+          <li>{{ Event/type }}</li>
+          <li>[^ iframe/allow ^]</li>
+        </ul>
+        <ul class="test">
+          <li>{{ boolean }}</li>
+          <li>{{ AbortError }}</li>
+        </ul>
+        <ul class="test">
+          <li><a data-cite="rfc6454#section-3.2">origin</a></li>
+          <li>
+            <dfn data-cite="ECMASCRIPT/#sec-json.stringify">JSON.stringify</dfn>
+          </li>
+          <li><a>JSON.stringify</a></li>
+        </ul>
+      </section>
+      <section id="index"></section>`;
+
+    /** @type {HTMLElement} */
+    let index;
+    beforeAll(async () => {
+      const ops = makeStandardOps({ xref: "web-platform" }, body);
+      const doc = await makeRSDoc(ops);
+      index = doc.getElementById("index-defined-elsewhere");
+    });
+
+    it("doesn't list local terms", () => {
+      const terms = index.querySelectorAll("ul li li");
+      const localTerm = [...terms].find(li => li.textContent === "hello");
+      expect(localTerm).toBeUndefined();
+    });
+
+    it("lists terms grouped by specs", () => {
+      const bySpecs = index.querySelectorAll("ul.index > li");
+      expect(bySpecs.length).toBe(6);
+      expect(bySpecs[0].textContent.trim()).toMatch(
+        /\[DOM\] defines the following:/
+      );
+
+      const specNames = [...bySpecs].map(
+        el => el.querySelector("a.bibref").textContent
+      );
+      expect(specNames).toEqual([
+        "DOM",
+        "ECMASCRIPT",
+        "HTML",
+        "INFRA",
+        "RFC6454",
+        "WEBIDL",
+      ]);
+
+      expect(index.querySelectorAll("ul.index .index-term").length).toBe(21);
+      const termsInDom = [...bySpecs[0].querySelectorAll("li")];
+      expect(termsInDom.length).toBe(4);
+    });
+
+    it("lists terms in a spec in sorted order", () => {
+      const termsInDom = index.querySelectorAll("[data-spec='DOM'] li");
+      expect(termsInDom.length).toBe(4);
+      const terms = [...termsInDom].map(el => el.textContent.trim());
+      expect(terms[0]).toMatch(/^creating an event/);
+      expect(terms[1]).toMatch(/^Event/);
+      expect(terms[2]).toMatch(/^EventInit/);
+      expect(terms[3]).toMatch(/^type/);
+    });
+
+    it("highlights IDL terms", () => {
+      const termsInDom = index.querySelectorAll("[data-spec='DOM'] li span");
+      expect(termsInDom[0].textContent).toBe("creating an event");
+      expect(termsInDom[0].querySelector("code")).toBeFalsy();
+
+      expect(termsInDom[1].textContent).toMatch(/^Event/);
+      expect(termsInDom[1].querySelector("code").textContent).toBe("Event");
+    });
+
+    it("suffixes terms with type information", () => {
+      const [
+        iframeAllowAttribute,
+        eventHandlerDict,
+        fullyActive,
+        iframeElement,
+      ] = [...index.querySelectorAll("[data-spec='HTML'] li")].map(el =>
+        el.textContent.trim()
+      );
+      expect(iframeAllowAttribute).toMatch(/^allow attribute \(for/);
+      expect(eventHandlerDict).toBe("EventHandler");
+      expect(fullyActive).toMatch(/^fully active \(for/);
+      expect(iframeElement).toBe("iframe element");
+    });
+
+    it("suffixes term with a 'for' context", async () => {
+      const termsInHTML = index.querySelectorAll("[data-spec='HTML'] li");
+
+      const iframeAllowAttribute = termsInHTML[0];
+      expect(iframeAllowAttribute.textContent.trim()).toMatch(/^allow/);
+      expect(iframeAllowAttribute.textContent.trim()).toMatch(
+        /\(for iframe element\)$/
+      );
+      expect(iframeAllowAttribute.querySelectorAll("code").length).toBe(2);
+      const [allow, iframe] = iframeAllowAttribute.querySelectorAll("code");
+      expect(allow.textContent).toBe("allow");
+      expect(iframe.textContent).toBe("iframe");
+
+      const fullyActive = termsInHTML[2];
+      expect(fullyActive.textContent.trim()).toMatch(/^fully active/);
+      expect(fullyActive.textContent.trim()).toMatch(/\(for Document\)$/);
+      expect(fullyActive.querySelectorAll("code").length).toBe(1);
+      expect(fullyActive.querySelector("code").textContent).toBe("Document");
+
+      const responsibleDocument = termsInHTML[4];
+      expect(responsibleDocument.textContent.trim()).toMatch(
+        /^responsible document/
+      );
+      expect(responsibleDocument.textContent.trim()).toMatch(
+        /\(for environment settings object\)$/
+      );
+      expect(responsibleDocument.querySelectorAll("code").length).toBe(0);
+    });
+
+    it("opens dfnPanel on term click", async () => {
+      const body = `<section data-cite="DOM">
+          <h2>TEST</h2>
+          <p>{{ Event }} {{ Event/type }}</p>
+        </section>
+        <section id="index"></section>`;
+      const ops = makeStandardOps(null, body);
+      const doc = await makeRSDoc(ops);
+      const index = doc.getElementById("index-defined-elsewhere");
+
+      expect(index.querySelectorAll(".index-term").length).toBe(2);
+      const term = index.querySelector(".index-term");
+      expect(term.textContent).toBe("Event interface");
+      expect(term.id).toBe("index-term-event-interface");
+
+      expect(doc.getElementById("dfn-panel")).toBeFalsy();
+      term.click();
+      const panel = doc.getElementById("dfn-panel");
+      expect(panel).toBeTruthy();
+      expect(panel.querySelector("a.self-link").href).toBe(
+        "https://dom.spec.whatwg.org/#event"
+      );
+      expect(panel.querySelectorAll("ul li").length).toBe(1);
+      const reference = panel.querySelector("ul li a");
+      expect(reference.textContent).toBe("1. TEST");
+      expect(reference.hash).toBe("#ref-for-index-term-event-interface-1");
+    });
+  });
+});

--- a/tests/spec/core/dfn-index-spec.js
+++ b/tests/spec/core/dfn-index-spec.js
@@ -6,7 +6,7 @@ describe("Core — dfn-index", () => {
 
   it("adds default heading to section#index", async () => {
     const body = `<section id="index">
-      <p>PASS</p>
+      <p id="pass">PASS</p>
     </section>`;
     const ops = makeStandardOps(null, body);
     const doc = await makeRSDoc(ops);
@@ -17,6 +17,9 @@ describe("Core — dfn-index", () => {
     expect(index.querySelectorAll("h2").length).toBe(1);
     expect(index.querySelector("h2").textContent).toBe("A. Index");
     expect(index.firstElementChild).toBe(index.querySelector("h2"));
+    expect(index.querySelector("h2").nextElementSibling).toEqual(
+      document.getElementById("pass")
+    );
   });
 
   it("doesn't override existing content in section#index", async () => {

--- a/tests/spec/core/dfn-index-spec.js
+++ b/tests/spec/core/dfn-index-spec.js
@@ -4,7 +4,7 @@ import { flushIframes, makeRSDoc, makeStandardOps } from "../SpecHelper.js";
 describe("Core — dfn-index", () => {
   afterAll(flushIframes);
 
-  xit("adds default heading to section#index", async () => {
+  it("adds default heading to section#index", async () => {
     const body = `<section id="index">
       <p>PASS</p>
     </section>`;
@@ -19,7 +19,7 @@ describe("Core — dfn-index", () => {
     expect(index.firstElementChild).toBe(index.querySelector("h2"));
   });
 
-  xit("doesn't override existing content in section#index", async () => {
+  it("doesn't override existing content in section#index", async () => {
     const body = `<section id="index">
       <h2 id="custom-heading">el índex</h2>
       <p id="custom-paragraph">PASS</p>

--- a/tests/spec/core/dfn-index-spec.js
+++ b/tests/spec/core/dfn-index-spec.js
@@ -18,7 +18,7 @@ describe("Core — dfn-index", () => {
     expect(index.querySelector("h2").textContent).toBe("A. Index");
     expect(index.firstElementChild).toBe(index.querySelector("h2"));
     expect(index.querySelector("h2").nextElementSibling).toEqual(
-      document.getElementById("pass")
+      doc.getElementById("pass")
     );
   });
 


### PR DESCRIPTION
Closes https://github.com/w3c/respec/issues/2560
[Demo with [payment-request]](https://respec-preview.netlify.com/?spec=https%3A%2F%2Fw3c.github.io%2Fpayment-request%2F&version=https%3A%2F%2Fdeploy-preview-2810--respec-pr.netlify.com%2Frespec-w3c.js&respecConfig=setTimeout%28%28%29+%3D%3E+document.body.insertAdjacentHTML%28%27beforeend%27%2C+%27%3Csection+id%3D%22index%22%3E%3C%2Fsection%3E%27%29%2C+0%29%3B)