### PR TITLE
feat(core/dfn-index): list local definitions

### DIFF
--- a/assets/dfn-index.css
+++ b/assets/dfn-index.css
@@ -23,5 +23,14 @@ ul.index li span {
 
 ul.index code {
   color: inherit;
-  font-size: 0.95em;
+}
+
+#index-defined-here .print-only {
+  display: none;
+}
+
+@media print {
+  #index-defined-here .print-only {
+    display: initial;
+  }
 }

--- a/assets/dfn-index.css
+++ b/assets/dfn-index.css
@@ -17,6 +17,10 @@ ul.index li span {
   white-space: normal;
 }
 
+#index-defined-here ul.index li {
+  font-size: 0.9rem;
+}
+
 ul.index code {
   color: inherit;
   font-size: 0.95em;

--- a/src/core/dfn-index.js
+++ b/src/core/dfn-index.js
@@ -381,4 +381,8 @@ function cleanup(doc) {
   doc
     .querySelectorAll("#index-defined-elsewhere li[data-spec]")
     .forEach(el => el.removeAttribute("data-spec"));
+
+  doc
+    .querySelectorAll("#index-defined-here li[data-id]")
+    .forEach(el => el.removeAttribute("data-id"));
 }

--- a/src/core/dfn-index.js
+++ b/src/core/dfn-index.js
@@ -125,8 +125,9 @@ function renderLocalTerm(term, dfns) {
   const renderItem = (dfn, text, suffix) => {
     const href = `#${dfn.id}`;
     return html`<li>
-      <a class="index-term" href="${href}">${{ html: text }}</a>
-      ${suffix ? { html: suffix } : ""}
+      <a class="index-term" href="${href}">${{ html: text }}</a> ${suffix
+        ? { html: suffix }
+        : ""}
     </li>`;
   };
 

--- a/src/core/dfn-index.js
+++ b/src/core/dfn-index.js
@@ -4,7 +4,7 @@
  * reference (external terms).
  */
 
-import { addId, getIntlData } from "./utils.js";
+import { addId, getIntlData, norm } from "./utils.js";
 import { citeDetailsConverter } from "./data-cite.js";
 import { fetchAsset } from "./text-loader.js";
 import { getTermFromElement } from "./xref.js";
@@ -18,9 +18,27 @@ const localizationStrings = {
   en: {
     heading: "Index",
     headingExternal: "Terms defined by reference",
+    headlingLocal: "Terms defined by this specification",
   },
 };
 const l10n = getIntlData(localizationStrings);
+
+// Terms of these _types_ are wrapped in `<code>`.
+const CODE_TYPES = new Set([
+  "attribute",
+  "callback",
+  "dict-member",
+  "dictionary",
+  "element-attr",
+  "element",
+  "enum-value",
+  "enum",
+  "exception",
+  "extended-attribute",
+  "interface",
+  "method",
+  "typedef",
+]);
 
 /**
  * @typedef {{ term: string, type: string, linkFor: string, elem: HTMLAnchorElement }} Entry
@@ -43,6 +61,12 @@ export async function run(conf) {
 
   const toCiteDetails = citeDetailsConverter(conf);
 
+  const localTermIndex = html`<section id="index-defined-here">
+    <h3>${l10n.headlingLocal}</h3>
+    ${createLocalTermIndex()}
+  </section>`;
+  index.append(localTermIndex);
+
   const externalTermIndex = html`<section id="index-defined-elsewhere">
     <h3>${l10n.headingExternal}</h3>
     ${createExternalTermIndex(toCiteDetails)}
@@ -50,6 +74,149 @@ export async function run(conf) {
   index.append(externalTermIndex);
 
   sub("beforesave", cleanup);
+}
+
+function createLocalTermIndex() {
+  const dataSortedByTerm = collectLocalTerms();
+  return html`<ul class="index">
+    ${dataSortedByTerm.map(([term, dfns]) => renderLocalTerm(term, dfns))}
+  </ul>`;
+}
+
+function collectLocalTerms() {
+  /** @type {Map<string, HTMLElement[]>} */
+  const data = new Map();
+  /** @type {NodeListOf<HTMLElement>} */
+  const elems = document.querySelectorAll("dfn:not([data-cite])");
+  for (const elem of elems) {
+    if (!elem.id) continue;
+    const text = norm(elem.textContent);
+    const elemsByTerm = data.get(text) || data.set(text, []).get(text);
+    elemsByTerm.push(elem);
+  }
+
+  /** @param {string} a @param {string} b */
+  const sortByTerm = (a, b) => {
+    a = a.slice(a.search(/\w/));
+    b = b.slice(b.search(/\w/));
+    return a.localeCompare(b);
+  };
+  const dataSortedByTerm = [...data].sort(([termA], [termB]) =>
+    sortByTerm(termA, termB)
+  );
+
+  return dataSortedByTerm;
+}
+
+/**
+ * @param {string} term
+ * @param {HTMLElement[]} dfns
+ * @returns {HTMLLIElement}
+ */
+function renderLocalTerm(term, dfns) {
+  // /** @param {HTMLElement`} dfn */
+  // const getSectionNumber = dfn => {
+  //   const sectionNumberEl = dfn.closest("section").querySelector(".secno");
+  //   const sectionNumber = sectionNumberEl.textContent.trim();
+  //   return `<span class="print-only">§${sectionNumber}</span>`;
+  // };
+
+  const renderItem = (dfn, text, suffix) => {
+    const href = `#${dfn.id}`;
+    return html`<li>
+      <a class="index-term" href="${href}">${{ html: text }}</a>
+      ${suffix ? { html: suffix } : ""}
+    </li>`;
+  };
+
+  if (dfns.length === 1) {
+    const dfn = dfns[0];
+    const type = getLocalTermType(dfn);
+    const text = getLocalTermText(dfn, type, term);
+    const suffix = getLocalTermSuffix(dfn, type, term);
+    return renderItem(dfn, text, suffix);
+  }
+  return html`<li>
+    ${term}
+    <ul>
+      ${dfns.map(dfn => {
+        const type = getLocalTermType(dfn);
+        const text = getLocalTermSuffix(dfn, type, term);
+        return renderItem(dfn, text);
+      })}
+    </ul>
+  </li>`;
+}
+
+/** @param {HTMLElement} dfn */
+function getLocalTermType(dfn) {
+  const ds = dfn.dataset;
+  const type = ds.dfnType || ds.idl || ds.linkType || "";
+  switch (type) {
+    case "":
+    case "dfn":
+      return "";
+    default:
+      return type;
+  }
+}
+
+/** @param {HTMLElement} dfn */
+function getLocalTermParentContext(dfn) {
+  /** @type {HTMLElement} */
+  const dfnFor = dfn.closest("[data-dfn-for]:not([data-dfn-for=''])");
+  return dfnFor ? dfnFor.dataset.dfnFor : "";
+}
+
+/**
+ * @param {HTMLElement} dfn
+ * @param {string} type
+ * @param {string} term
+ */
+function getLocalTermText(dfn, type, term) {
+  let text = term;
+  if (type === "enum-value") {
+    text = `"${text}"`;
+  }
+  if (CODE_TYPES.has(type) || dfn.dataset.idl || dfn.closest("code")) {
+    text = `<code>${text}</code>`;
+  }
+  return text;
+}
+
+/**
+ * @param {HTMLElement} dfn
+ * @param {string} type
+ * @param {string} [term=""]
+ */
+function getLocalTermSuffix(dfn, type, term = "") {
+  if (term.startsWith("[[")) {
+    const parent = getLocalTermParentContext(dfn);
+    return `internal slot for <code>${parent}</code>`;
+  }
+
+  switch (type) {
+    case "dict-member":
+    case "method":
+    case "attribute":
+    case "enum-value": {
+      const typeText =
+        type === "dict-member" ? "member" : type.replace("-", " ");
+      const parent = getLocalTermParentContext(dfn);
+      return `${typeText} for <code>${parent}</code>`;
+    }
+    case "interface":
+    case "dictionary":
+    case "enum": {
+      return type;
+    }
+    case "constructor": {
+      const parent = getLocalTermParentContext(dfn);
+      return `for <code>${parent}</code>`;
+    }
+    default:
+      return "";
+  }
 }
 
 /**
@@ -122,23 +289,6 @@ function renderExternalTermEntry(entry) {
   addId(el.querySelector("span"), "index-term");
   return el;
 }
-
-// Terms of these _types_ are wrapped in `<code>`.
-const CODE_TYPES = new Set([
-  "attribute",
-  "callback",
-  "dict-member",
-  "dictionary",
-  "element-attr",
-  "element",
-  "enum-value",
-  "enum",
-  "exception",
-  "extended-attribute",
-  "interface",
-  "method",
-  "typedef",
-]);
 
 // Terms of these _types_ are suffixed with their type info.
 const TYPED_TYPES = new Map([

--- a/src/core/dfn-index.js
+++ b/src/core/dfn-index.js
@@ -98,14 +98,8 @@ function collectLocalTerms() {
     elemsByTerm.push(elem);
   }
 
-  /** @param {string} a @param {string} b */
-  const sortByTerm = (a, b) => {
-    a = a.slice(a.search(/\w/));
-    b = b.slice(b.search(/\w/));
-    return a.localeCompare(b);
-  };
-  const dataSortedByTerm = [...data].sort(([termA], [termB]) =>
-    sortByTerm(termA, termB)
+  const dataSortedByTerm = [...data].sort(([a], [b]) =>
+    a.slice(a.search(/\w/)).localeCompare(b.slice(b.search(/\w/)))
   );
 
   return dataSortedByTerm;

--- a/src/core/dfn-index.js
+++ b/src/core/dfn-index.js
@@ -143,7 +143,7 @@ function renderLocalTerm(term, dfns) {
     <ul>
       ${dfns.map(dfn => {
         const type = getLocalTermType(dfn);
-        const text = getLocalTermSuffix(dfn, type, term);
+        const text = getLocalTermSuffix(dfn, type, term) || "definition of";
         return renderItem(dfn, text);
       })}
     </ul>

--- a/src/core/dfn-index.js
+++ b/src/core/dfn-index.js
@@ -68,13 +68,21 @@ export async function run(conf) {
     ${createLocalTermIndex()}
   </section>`;
   index.append(localTermIndex);
-  sub("toc", appendSectionNumbers, { once: true });
 
   const externalTermIndex = html`<section id="index-defined-elsewhere">
     <h3>${l10n.headingExternal}</h3>
     ${createExternalTermIndex(toCiteDetails)}
   </section>`;
   index.append(externalTermIndex);
+
+  // XXX: This event is used to overcome an edge case with core/structure,
+  // related to a circular dependency in plugin run order. We want
+  // core/structure to run after dfn-index so the #index can be listed in the
+  // TOC, but we also want section numbers in dfn-index. So, we "split"
+  // core/dfn-index in two parts, one that runs before core/structure (using
+  // plugin order in profile) and the other (following) after section numbers
+  // are generated in core/structure (this event).
+  sub("toc", appendSectionNumbers, { once: true });
 
   sub("beforesave", cleanup);
 }

--- a/src/core/dfn-index.js
+++ b/src/core/dfn-index.js
@@ -115,13 +115,6 @@ function collectLocalTerms() {
  * @returns {HTMLLIElement}
  */
 function renderLocalTerm(term, dfns) {
-  // /** @param {HTMLElement`} dfn */
-  // const getSectionNumber = dfn => {
-  //   const sectionNumberEl = dfn.closest("section").querySelector(".secno");
-  //   const sectionNumber = sectionNumberEl.textContent.trim();
-  //   return `<span class="print-only">§${sectionNumber}</span>`;
-  // };
-
   const renderItem = (dfn, text, suffix) => {
     const href = `#${dfn.id}`;
     return html`<li>

--- a/src/core/dfn-index.js
+++ b/src/core/dfn-index.js
@@ -1,7 +1,8 @@
 // @ts-check
 /**
- * If a `<section id="index">` exists, it is filled by a list terms defined by
- * reference (external terms).
+ * If a `<section id="index">` exists, it is filled by a list of terms defined
+ * (locally) by current document and a list of terms referenced (external) by
+ * current document.
  */
 
 import { addId, getIntlData, norm } from "./utils.js";

--- a/src/core/dfn-index.js
+++ b/src/core/dfn-index.js
@@ -20,6 +20,7 @@ const localizationStrings = {
     heading: "Index",
     headingExternal: "Terms defined by reference",
     headlingLocal: "Terms defined by this specification",
+    dfnOf: "definition of",
   },
 };
 const l10n = getIntlData(localizationStrings);
@@ -137,7 +138,7 @@ function renderLocalTerm(term, dfns) {
     <ul>
       ${dfns.map(dfn => {
         const type = getLocalTermType(dfn);
-        const text = getLocalTermSuffix(dfn, type, term) || "definition of";
+        const text = getLocalTermSuffix(dfn, type, term) || l10n.dfnOf;
         return renderItem(dfn, text);
       })}
     </ul>

--- a/src/core/dfn-index.js
+++ b/src/core/dfn-index.js
@@ -67,6 +67,7 @@ export async function run(conf) {
     ${createLocalTermIndex()}
   </section>`;
   index.append(localTermIndex);
+  sub("toc", appendSectionNumbers, { once: true });
 
   const externalTermIndex = html`<section id="index-defined-elsewhere">
     <h3>${l10n.headingExternal}</h3>
@@ -117,7 +118,7 @@ function collectLocalTerms() {
 function renderLocalTerm(term, dfns) {
   const renderItem = (dfn, text, suffix) => {
     const href = `#${dfn.id}`;
-    return html`<li>
+    return html`<li data-id=${dfn.id}>
       <a class="index-term" href="${href}">${{ html: text }}</a> ${suffix
         ? { html: suffix }
         : ""}
@@ -212,6 +213,19 @@ function getLocalTermSuffix(dfn, type, term = "") {
     default:
       return "";
   }
+}
+
+function appendSectionNumbers() {
+  const getSectionNumber = id => {
+    const dfn = document.getElementById(id);
+    const sectionNumberEl = dfn.closest("section").querySelector(".secno");
+    const secNum = `§${sectionNumberEl.textContent.trim()}`;
+    return html`<span class="print-only">${secNum}</span>`;
+  };
+
+  /** @type {NodeListOf<HTMLElement>} */
+  const elems = document.querySelectorAll("#index-defined-here li[data-id]");
+  elems.forEach(el => el.append(getSectionNumber(el.dataset.id)));
 }
 
 /**

--- a/src/core/dfn-panel.js
+++ b/src/core/dfn-panel.js
@@ -65,7 +65,7 @@ function deriveAction(clickTarget) {
 function createPanel(dfn) {
   const { id } = dfn;
   const href = dfn.dataset.href || `#${id}`;
-  const links = document.querySelectorAll(`a[href="${href}"]`);
+  const links = document.querySelectorAll(`a[href="${href}"]:not(.index-term)`);
 
   /** @type {HTMLElement} */
   const panel = hyperHTML`

--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -195,6 +195,8 @@ export function run(conf) {
       createTableOfContents(result);
     }
   }
+
+  // See core/dfn-index
   pub("toc");
 }
 

--- a/src/core/structure.js
+++ b/src/core/structure.js
@@ -12,6 +12,7 @@
 
 import { addId, getIntlData, parents, renameElement } from "./utils.js";
 import { html } from "./import-maps.js";
+import { pub } from "./pubsubhub.js";
 
 const lowerHeaderTags = ["h2", "h3", "h4", "h5", "h6"];
 const headerTags = ["h1", ...lowerHeaderTags];
@@ -194,6 +195,7 @@ export function run(conf) {
       createTableOfContents(result);
     }
   }
+  pub("toc");
 }
 
 function renameSectionHeaders() {

--- a/tests/spec/core/dfn-index-spec.js
+++ b/tests/spec/core/dfn-index-spec.js
@@ -87,6 +87,7 @@ describe("Core — dfn-index", () => {
       const ops = makeStandardOps(null, body);
       const doc = await makeRSDoc(ops);
       index = doc.getElementById("index-defined-here");
+      index.querySelectorAll(".print-only").forEach(el => el.remove());
     });
 
     it("doesn't list external terms", () => {
@@ -139,6 +140,17 @@ describe("Core — dfn-index", () => {
       expect(iface).toBe("Foo interface");
       expect(slot).toBe("[[haha]] internal slot for Foo");
       expect(concept).toBe("hello");
+    });
+
+    it("contains section number for print media", async () => {
+      const ops = makeStandardOps(null, body);
+      const doc = await makeRSDoc(ops);
+      const index = doc.getElementById("index-defined-here");
+
+      const item = index.querySelector("ul.index > li:nth-child(2)");
+      const secNum = item.querySelector(".print-only");
+      expect(secNum.textContent).toBe("§1.");
+      expect(item.textContent.endsWith("§1.")).toBeTrue();
     });
   });
 

--- a/tests/spec/core/dfn-index-spec.js
+++ b/tests/spec/core/dfn-index-spec.js
@@ -39,8 +39,14 @@ describe("Core — dfn-index", () => {
     expect(index.querySelector("p#custom-paragraph").textContent).toBe("PASS");
 
     const subsections = index.querySelectorAll("section");
-    expect(subsections.length).toBe(1);
-    const [externalIndex] = subsections;
+    expect(subsections.length).toBe(2);
+    const [localIndex, externalIndex] = subsections;
+
+    const localIndexHeading = localIndex.querySelector("h3");
+    expect(localIndexHeading.textContent).toContain(
+      "Terms defined by this specification"
+    );
+    expect(localIndexHeading.nextElementSibling.matches("ul.index")).toBeTrue();
 
     const externalIndexHeading = externalIndex.querySelector("h3");
     expect(externalIndexHeading.textContent).toContain(


### PR DESCRIPTION
Closes https://github.com/w3c/respec/issues/2817

[Demo with [payment-request]](https://respec-preview.netlify.com/?spec=https%3A%2F%2Fw3c.github.io%2Fpayment-request%2F&version=https%3A%2F%2Fdeploy-preview-2819--respec-pr.netlify.com%2Frespec-w3c.js&respecConfig=setTimeout%28%28%29+%3D%3E+document.body.insertAdjacentHTML%28%27beforeend%27%2C+%27%3Csection+id%3D%22index%22%3E%3C%2Fsection%3E%27%29%2C+0%29%3B)
[Demo with [manifest]](https://respec-preview.netlify.com/?spec=https%3A%2F%2Fw3c.github.io%2Fmanifest%2F&version=https%3A%2F%2Fdeploy-preview-2819--respec-pr.netlify.com%2Frespec-w3c.js#index)

TODO:
- [x] ~figure out a way to show section numbers when `core/structure` runs after `core/dfn-index`~ update tests for this