### PR TITLE
fix(core/xref): do not throw in error reporting without spec context

### DIFF
--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -413,7 +413,7 @@ function showErrors({ ambiguous, notFound }) {
   };
 
   for (const { query, elems } of notFound.values()) {
-    const specs = [...new Set(query.specs.flat())].sort();
+    const specs = query.specs ? [...new Set(query.specs.flat())].sort() : [];
     const originalTerm = getTermFromElement(elems[0]);
     const formUrl = getPrefilledFormURL(originalTerm, query);
     const specsString = specs.map(spec => `\`${spec}\``).join(", ");


### PR DESCRIPTION
As seen in https://github.com/w3c/respec/issues/2432#issuecomment-610114149, this was causing irrelevant error messages on linking failure. And as it threw, it showed unrelated error even with `data-no-xref`.
Demo:
- [with this fix](https://respec-preview.netlify.com/?spec=https%3A%2F%2Frawcdn.githack.com%2FMaps4HTML%2FHTML-Map-Element-UseCases-Requirements%2Ffa0ed305b36dafbb76814d6fc49d3eb6e6049e40%2Findex.html&version=https%3A%2F%2Fdeploy-preview-2821--respec-pr.netlify.com%2Frespec-w3c-common.js&respecConfig=delete+respecConfig.xref%3B)
- [without this fix](https://respec-preview.netlify.com/?spec=https%3A%2F%2Frawcdn.githack.com%2FMaps4HTML%2FHTML-Map-Element-UseCases-Requirements%2Ffa0ed305b36dafbb76814d6fc49d3eb6e6049e40%2Findex.html&version=https%3A%2F%2Fwww.w3.org%2FTools%2Frespec%2Frespec-w3c-common&respecConfig=delete+respecConfig.xref%3B)