### PR TITLE
refactor(core/data-cite): do not require conf in citeDetailsConverer

### DIFF
--- a/src/core/data-cite.js
+++ b/src/core/data-cite.js
@@ -26,9 +26,6 @@ export const name = "core/data-cite";
 
 const THIS_SPEC = "__SPEC__";
 
-/**
- * @param {HTMLElement} elem
- */
 async function toLookupRequest(elem) {
   const originalKey = elem.dataset.cite;
   const { key, frag, path } = toCiteDetails(elem);

--- a/src/core/data-cite.js
+++ b/src/core/data-cite.js
@@ -33,10 +33,6 @@ async function toLookupRequest(elem) {
   let title = "";
   // This is just referring to this document
   if (key === THIS_SPEC) {
-    console.log(
-      elem,
-      `The reference "${key}" is resolved into the current document per \`conf.shortName\`.`
-    );
     href = document.location.href;
   } else {
     // Let's go look it up in spec ref...

--- a/src/core/data-cite.js
+++ b/src/core/data-cite.js
@@ -183,10 +183,9 @@ export async function run(conf) {
 
 /**
  * @param {Document} doc
- * @param {*} conf
  */
-export async function linkInlineCitations(doc, conf = respecConfig) {
-  const toLookupRequest = requestLookup(conf);
+export async function linkInlineCitations(doc) {
+  const toLookupRequest = requestLookup();
   const elems = [
     ...doc.querySelectorAll(
       "dfn[data-cite]:not([data-cite='']), a[data-cite]:not([data-cite=''])"

--- a/src/core/data-cite.js
+++ b/src/core/data-cite.js
@@ -179,13 +179,10 @@ export async function run(conf) {
   sub("beforesave", cleanup);
 }
 
-/**
- * @param {Document} doc
- */
-export async function linkInlineCitations(doc) {
+export async function linkInlineCitations() {
   const toLookupRequest = requestLookup();
   const elems = [
-    ...doc.querySelectorAll(
+    ...document.querySelectorAll(
       "dfn[data-cite]:not([data-cite='']), a[data-cite]:not([data-cite=''])"
     ),
   ];

--- a/src/core/dfn-index.js
+++ b/src/core/dfn-index.js
@@ -46,7 +46,7 @@ const CODE_TYPES = new Set([
  * @typedef {{ term: string, type: string, linkFor: string, elem: HTMLAnchorElement }} Entry
  */
 
-export async function run(conf) {
+export async function run() {
   const index = document.querySelector("section#index");
   if (!index) {
     return;
@@ -61,7 +61,7 @@ export async function run(conf) {
     index.prepend(html`<h2>${l10n.heading}</h2>`);
   }
 
-  const toCiteDetails = citeDetailsConverter(conf);
+  const toCiteDetails = citeDetailsConverter();
 
   const localTermIndex = html`<section id="index-defined-here">
     <h3>${l10n.headlingLocal}</h3>

--- a/src/core/dfn-index.js
+++ b/src/core/dfn-index.js
@@ -6,12 +6,12 @@
  */
 
 import { addId, getIntlData, norm } from "./utils.js";
-import { citeDetailsConverter } from "./data-cite.js";
 import { fetchAsset } from "./text-loader.js";
 import { getTermFromElement } from "./xref.js";
 import { html } from "./import-maps.js";
 import { renderInlineCitation } from "./render-biblio.js";
 import { sub } from "./pubsubhub.js";
+import { toCiteDetails } from "./data-cite.js";
 
 export const name = "core/dfn-index";
 
@@ -61,8 +61,6 @@ export async function run() {
     index.prepend(html`<h2>${l10n.heading}</h2>`);
   }
 
-  const toCiteDetails = citeDetailsConverter();
-
   const localTermIndex = html`<section id="index-defined-here">
     <h3>${l10n.headlingLocal}</h3>
     ${createLocalTermIndex()}
@@ -71,7 +69,7 @@ export async function run() {
 
   const externalTermIndex = html`<section id="index-defined-elsewhere">
     <h3>${l10n.headingExternal}</h3>
-    ${createExternalTermIndex(toCiteDetails)}
+    ${createExternalTermIndex()}
   </section>`;
   index.append(externalTermIndex);
 
@@ -231,11 +229,8 @@ function appendSectionNumbers() {
   elems.forEach(el => el.append(getSectionNumber(el.dataset.id)));
 }
 
-/**
- * @param {ReturnType<typeof citeDetailsConverter>} toCiteDetails
- */
-function createExternalTermIndex(toCiteDetails) {
-  const data = collectExternalTerms(toCiteDetails);
+function createExternalTermIndex() {
+  const data = collectExternalTerms();
   const dataSortedBySpec = [...data.entries()].sort(([specA], [specB]) =>
     specA.localeCompare(specB)
   );
@@ -253,10 +248,7 @@ function createExternalTermIndex(toCiteDetails) {
   </ul>`;
 }
 
-/**
- * @param {ReturnType<typeof citeDetailsConverter>} toCiteDetails
- */
-function collectExternalTerms(toCiteDetails) {
+function collectExternalTerms() {
   /** @type {Set<string>} */
   const uniqueReferences = new Set();
   /** @type {Map<string, Entry[]>} spec => entry[] */

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -88,7 +88,7 @@ export async function run(conf) {
     showLinkingError(possibleExternalLinks);
   }
 
-  await linkInlineCitations(document, conf);
+  await linkInlineCitations(document);
   // Added message for legacy compat with Aria specs
   // See https://github.com/w3c/respec/issues/793
   pub("end", "core/link-to-dfn");

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -88,7 +88,7 @@ export async function run(conf) {
     showLinkingError(possibleExternalLinks);
   }
 
-  await linkInlineCitations(document);
+  await linkInlineCitations();
   // Added message for legacy compat with Aria specs
   // See https://github.com/w3c/respec/issues/793
   pub("end", "core/link-to-dfn");


### PR DESCRIPTION
We can avoid passing conf to citeDetailsConverter, and have a unique instance which we can reuse. Simplifies code a bit.

Note to reviewer: Review commit by commit and ignore whitespace changes.