### PR TITLE
refactor(core/data-cite): split into smaller functions

### DIFF
--- a/src/core/biblio.js
+++ b/src/core/biblio.js
@@ -26,6 +26,8 @@ const link = createResourceHint({
 });
 document.head.appendChild(link);
 let doneResolver;
+
+/** @type {Promise<Conf['biblio']>} */
 const done = new Promise(resolve => {
   doneResolver = resolve;
 });
@@ -49,6 +51,7 @@ export async function updateFromNetwork(
   if ((!options.forceUpdate && !response.ok) || response.status !== 200) {
     return null;
   }
+  /** @type {Conf['biblio']} */
   const data = await response.json();
   try {
     await biblioDB.addAll(data);
@@ -60,6 +63,7 @@ export async function updateFromNetwork(
 
 /**
  * @param {string} key
+ * @returns {Promise<BiblioData>}
  */
 export async function resolveRef(key) {
   const biblio = await done;

--- a/src/core/data-cite.js
+++ b/src/core/data-cite.js
@@ -159,6 +159,7 @@ export function toCiteDetails(elem) {
   return details;
 }
 
+/** @param {Conf} conf */
 export async function run(conf) {
   const shortNameRegex = new RegExp(
     String.raw`\b${conf.shortName.toLowerCase()}\b`,
@@ -208,7 +209,7 @@ export async function linkInlineCitations() {
 }
 
 /**
- * fetch and update biblio entries corresponding to given elements
+ * Fetch and update `biblio` with entries corresponding to given elements
  * @param {HTMLElement[]} elems
  */
 async function updateBiblio(elems) {
@@ -228,6 +229,7 @@ async function updateBiblio(elems) {
   }
 }
 
+/** @param {Document} doc */
 function cleanup(doc) {
   const attrToRemove = ["data-cite", "data-cite-frag", "data-cite-path"];
   const elems = doc.querySelectorAll("a[data-cite], dfn[data-cite]");

--- a/src/type-helper.d.ts
+++ b/src/type-helper.d.ts
@@ -115,6 +115,7 @@ interface Conf {
   normativeReferences: Set<string>;
   localBiblio?: Record<string, BiblioData>;
   biblio: Record<string, BiblioData>;
+  shortName: string;
 }
 
 module "core/xref" {


### PR DESCRIPTION
Making code further easier to understand. `data-cite` already does too much, and does a lot of unrelated work.

Note to reviewer: Review commit by commit. Split view with whitespace hidden recommended.