### PR TITLE
refactor(core/data-cite): simplify linking

### DIFF
--- a/src/core/dfn-map.js
+++ b/src/core/dfn-map.js
@@ -1,5 +1,7 @@
 // @ts-check
 import { CaseInsensitiveMap } from "./utils.js";
+
+/** @type {CaseInsensitiveMap<Set<HTMLElement>>} */
 export const definitionMap = new CaseInsensitiveMap();
 
 /**

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -56,11 +56,11 @@ export async function run(conf) {
   /** @type {HTMLAnchorElement[]} */
   const badLinks = [];
 
-  const localLinkSelector =
-    "a[data-cite=''], a:not([href]):not([data-cite]):not(.logo):not(.externalDFN)";
-  document.querySelectorAll(localLinkSelector).forEach((
-    /** @type {HTMLAnchorElement} */ anchor
-  ) => {
+  /** @type {NodeListOf<HTMLAnchorElement>} */
+  const localAnchors = document.querySelectorAll(
+    "a[data-cite=''], a:not([href]):not([data-cite]):not(.logo):not(.externalDFN)"
+  );
+  for (const anchor of localAnchors) {
     const linkTargets = getLinkTargets(anchor);
     const linkTarget = linkTargets.find(
       target =>
@@ -76,7 +76,7 @@ export async function run(conf) {
         possibleExternalLinks.push(anchor);
       }
     }
-  });
+  }
 
   showLinkingError(badLinks);
 

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -68,8 +68,8 @@ export async function run(conf) {
         titleToDfns.get(target.title).has(target.for)
     );
     if (linkTarget) {
-      const localMatchFound = processAnchor(anchor, linkTarget, titleToDfns);
-      if (!localMatchFound) {
+      const foundLocalMatch = processAnchor(anchor, linkTarget, titleToDfns);
+      if (!foundLocalMatch) {
         possibleExternalLinks.push(anchor);
       }
     } else {
@@ -141,14 +141,14 @@ function collectDfns(title) {
  * @param {ReturnType<typeof mapTitleToDfns>} titleToDfns
  */
 function processAnchor(anchor, target, titleToDfns) {
-  let localMatchFound = false;
+  let foundLocalMatch = false;
   const { linkFor } = anchor.dataset;
   const dfn = titleToDfns.get(target.title).get(target.for);
   if (dfn.dataset.cite) {
     anchor.dataset.cite = dfn.dataset.cite;
-    localMatchFound = true;
+    foundLocalMatch = true;
   } else if (linkFor && !titleToDfns.get(linkFor)) {
-    localMatchFound = false;
+    foundLocalMatch = false;
   } else if (dfn.classList.contains("externalDFN")) {
     // data-lt[0] serves as unique id for the dfn which this element references
     const lt = dfn.dataset.lt ? dfn.dataset.lt.split("|") : [];
@@ -156,7 +156,7 @@ function processAnchor(anchor, target, titleToDfns) {
   } else if (anchor.dataset.idl !== "partial") {
     anchor.href = `#${dfn.id}`;
     anchor.classList.add("internalDFN");
-    localMatchFound = true;
+    foundLocalMatch = true;
   }
   if (!anchor.hasAttribute("data-link-type")) {
     anchor.dataset.linkType = "idl" in dfn.dataset ? "idl" : "dfn";
@@ -164,7 +164,7 @@ function processAnchor(anchor, target, titleToDfns) {
   if (isCode(dfn)) {
     wrapAsCode(anchor, dfn);
   }
-  return localMatchFound;
+  return foundLocalMatch;
 }
 
 /**

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -62,10 +62,14 @@ export async function run(conf) {
     /** @type {HTMLAnchorElement} */ anchor
   ) => {
     const linkTargets = getLinkTargets(anchor);
-    const foundDfn = linkTargets.some(target => {
-      return findLinkTarget(target, anchor, titleToDfns);
-    });
-    if (!foundDfn && linkTargets.length !== 0) {
+    const linkTarget = linkTargets.find(
+      target =>
+        titleToDfns.has(target.title) &&
+        titleToDfns.get(target.title).has(target.for)
+    );
+    if (linkTarget) {
+      useLinkTarget(linkTarget, anchor, titleToDfns);
+    } else if (linkTargets.length !== 0) {
       if (anchor.dataset.cite === "") {
         badLinks.push(anchor);
       } else {
@@ -132,14 +136,8 @@ function collectDfns(title) {
  * @param {HTMLAnchorElement} anchor
  * @param {CaseInsensitiveMap} titleToDfns
  */
-function findLinkTarget(target, anchor, titleToDfns) {
+function useLinkTarget(target, anchor, titleToDfns) {
   const { linkFor } = anchor.dataset;
-  if (
-    !titleToDfns.has(target.title) ||
-    !titleToDfns.get(target.title).get(target.for)
-  ) {
-    return false;
-  }
   const dfn = titleToDfns.get(target.title).get(target.for);
   if (dfn.dataset.cite) {
     anchor.dataset.cite = dfn.dataset.cite;
@@ -164,7 +162,6 @@ function findLinkTarget(target, anchor, titleToDfns) {
   if (isCode(dfn)) {
     wrapAsCode(anchor, dfn);
   }
-  return true;
 }
 
 /**

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -69,7 +69,7 @@ export async function run(conf) {
     );
     if (linkTarget) {
       useLinkTarget(linkTarget, anchor, titleToDfns);
-    } else if (linkTargets.length !== 0) {
+    } else {
       if (anchor.dataset.cite === "") {
         badLinks.push(anchor);
       } else {

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -93,6 +93,7 @@ export async function run(conf) {
 }
 
 function mapTitleToDfns() {
+  /** @type {CaseInsensitiveMap<Map<string, HTMLElement>>} */
   const titleToDfns = new CaseInsensitiveMap();
   for (const key of definitionMap.keys()) {
     const { result, duplicates } = collectDfns(key);
@@ -137,7 +138,7 @@ function collectDfns(title) {
 /**
  * @param {HTMLAnchorElement} anchor
  * @param {import("./utils.js").LinkTarget} target
- * @param {CaseInsensitiveMap} titleToDfns
+ * @param {ReturnType<typeof mapTitleToDfns>} titleToDfns
  */
 function processAnchor(anchor, target, titleToDfns) {
   let localMatchFound = false;

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -141,22 +141,23 @@ function collectDfns(title) {
  * @param {ReturnType<typeof mapTitleToDfns>} titleToDfns
  */
 function processAnchor(anchor, target, titleToDfns) {
-  let foundLocalMatch = false;
+  let noLocalMatch = false;
   const { linkFor } = anchor.dataset;
   const dfn = titleToDfns.get(target.title).get(target.for);
   if (dfn.dataset.cite) {
     anchor.dataset.cite = dfn.dataset.cite;
-    foundLocalMatch = true;
   } else if (linkFor && !titleToDfns.get(linkFor)) {
-    foundLocalMatch = false;
+    noLocalMatch = true;
   } else if (dfn.classList.contains("externalDFN")) {
     // data-lt[0] serves as unique id for the dfn which this element references
     const lt = dfn.dataset.lt ? dfn.dataset.lt.split("|") : [];
     anchor.dataset.lt = lt[0] || dfn.textContent;
+    noLocalMatch = true;
   } else if (anchor.dataset.idl !== "partial") {
     anchor.href = `#${dfn.id}`;
     anchor.classList.add("internalDFN");
-    foundLocalMatch = true;
+  } else {
+    noLocalMatch = true;
   }
   if (!anchor.hasAttribute("data-link-type")) {
     anchor.dataset.linkType = "idl" in dfn.dataset ? "idl" : "dfn";
@@ -164,7 +165,7 @@ function processAnchor(anchor, target, titleToDfns) {
   if (isCode(dfn)) {
     wrapAsCode(anchor, dfn);
   }
-  return foundLocalMatch;
+  return !noLocalMatch;
 }
 
 /**

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -920,7 +920,7 @@ export class CaseInsensitiveMap extends Map {
   }
   /**
    * @param {String} key
-   * @param {*} value
+   * @param {ValueType} value
    */
   set(key, value) {
     super.set(key.toLowerCase(), value);

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -903,9 +903,13 @@ function* walkTree(walker) {
   }
 }
 
+/**
+ * @template ValueType
+ * @extends {Map<string, ValueType>}
+ */
 export class CaseInsensitiveMap extends Map {
   /**
-   * @param {Array<[String, HTMLElement]>} [entries]
+   * @param {Array<[string, ValueType]>} [entries]
    */
   constructor(entries = []) {
     super();


### PR DESCRIPTION
Part of https://github.com/w3c/respec/issues/2830
`findLinkTarget` was misleading as it mutated its `anchor` parameter.
Although `useLinkTarget` isn't a great name either - it's very much overloaded. Suggestions welcome.