### PR TITLE
test(core/webidl): remove legacy TreatNullAs

### DIFF
--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -1337,7 +1337,7 @@ callback CallBack = Z? (X x, optional Y y, /*trivia*/ optional Z z);
         <h2>Test</h2>
         <pre class="idl" id="link-test">
           interface mixin InnerHTMLMixin {
-            [TreatNullAs=EmptyString] attribute DOMString innerHTML;
+            [PutForwards=html] readonly attribute DOMString innerHTML;
           };
         </pre>
       </section>


### PR DESCRIPTION
This attribute was removed in https://github.com/heycam/webidl/pull/870 and one of our test was using it ([see failing test](https://github.com/w3c/respec/runs/608111600)).