### PR TITLE
fix(core/link-to-dfn): link local dfn with foreign forContext

### DIFF
--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -154,9 +154,10 @@ function findMatchingDfn(anchor, titleToDfns) {
 function processAnchor(anchor, dfn, titleToDfns) {
   let noLocalMatch = false;
   const { linkFor } = anchor.dataset;
+  const { dfnFor } = dfn.dataset;
   if (dfn.dataset.cite) {
     anchor.dataset.cite = dfn.dataset.cite;
-  } else if (linkFor && !titleToDfns.get(linkFor)) {
+  } else if (linkFor && !titleToDfns.get(linkFor) && linkFor !== dfnFor) {
     noLocalMatch = true;
   } else if (dfn.classList.contains("externalDFN")) {
     // data-lt[0] serves as unique id for the dfn which this element references

--- a/tests/spec/core/link-to-dfn-spec.js
+++ b/tests/spec/core/link-to-dfn-spec.js
@@ -130,6 +130,34 @@ describe("Core — Link to definitions", () => {
     expect(dfnEnumValue.dataset.dfnFor).toBe("Planet");
   });
 
+  it("links local dfn with external forContext", async () => {
+    const body = `
+      <div id="test">
+        <dfn id="vis-state">Visibility State</dfn> and
+        <dfn id="vis-state-hidden" data-dfn-for="visibility state">hidden</dfn>
+        are defined entirely locally. [= Visibility state =] [= visibility
+        state/hidden =].
+        <dfn id="document-hidden" data-dfn-for="Document">hidden</dfn> is
+        defined here, but Document is external. [= Document/hidden =]
+      </div>
+    `;
+    const config = { xref: ["DOM"] };
+    const ops = makeStandardOps(config, body);
+    const doc = await makeRSDoc(ops);
+
+    const [
+      visibilityState,
+      visibilityStateHidden,
+      documentHidden,
+    ] = doc.querySelectorAll("#test a");
+
+    expect(visibilityState.hash).toBe("#vis-state");
+    expect(visibilityStateHidden.hash).toBe("#vis-state-hidden");
+
+    expect(documentHidden.hash).toBe("#document-hidden");
+    expect(documentHidden.classList).not.toContain("respec-offending-element");
+  });
+
   it("should get ID from the first match", async () => {
     const bodyText = `
       <section>


### PR DESCRIPTION
Compare the effect [with this PR](https://respec-preview.netlify.app/?spec=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fpage-visibility%2F62320d1091941e13862ed3d4e469e82afbb1f214%2Findex.html&version=https%3A%2F%2Fdeploy-preview-2868--respec-pr.netlify.app%2Frespec-w3c.js) to [without this PR](https://respec-preview.netlify.app/?spec=https%3A%2F%2Frawcdn.githack.com%2Fw3c%2Fpage-visibility%2F62320d1091941e13862ed3d4e469e82afbb1f214%2Findex.html&version=https://unpkg.com/respec@25.7.0/builds/respec-w3c.js) on [page-visibility]

Part of #2271