### PR TITLE
chore(ci): use npm ci instead of npm i

### DIFF
--- a/.github/workflows/pr-push.yml
+++ b/.github/workflows/pr-push.yml
@@ -25,7 +25,7 @@ jobs:
           path: ./node_modules
           key: ${{ runner.os }}-node-12-${{ hashFiles('**/package-lock.json') }}
       - if: "!contains(steps.log.outputs.message, 'ci skip')"
-        run: npm install
+        run: npm ci
       - if: "!contains(steps.log.outputs.message, 'ci skip')"
         run: npm run lint
 
@@ -50,7 +50,7 @@ jobs:
       - if: "!contains(steps.log.outputs.message, 'ci skip')"
         name: install & build
         run: |
-          npm install
+          npm ci
           npm run build:w3c
       - if: "!contains(steps.log.outputs.message, 'ci skip')"
         run: npm run test:headless
@@ -79,7 +79,7 @@ jobs:
       - if: "!contains(steps.log.outputs.message, 'ci skip')"
         name: install & build
         run: |
-          npm install
+          npm ci
           npm run build:w3c & npm run build:geonovum
       - if: "!contains(steps.log.outputs.message, 'ci skip')"
         run: npm run test:karma


### PR DESCRIPTION
As we have a package-lock, we can use it, and it's faster than `npm install`.