### PR TITLE
fix(core/webidl): default toJSON operation is now toJSON steps

### DIFF
--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -157,7 +157,7 @@ function defineIdlName(escaped, data, parent) {
     data.name === "toJSON" &&
     data.extAttrs.some(({ name }) => name === "Default");
   if (isDefaultJSON) {
-    return html`<a data-link-type="dfn" data-lt="default toJSON operation"
+    return html`<a data-link-type="dfn" data-lt="default toJSON steps"
       >${escaped}</a
     >`;
   }

--- a/tests/spec/core/dfn-index-spec.js
+++ b/tests/spec/core/dfn-index-spec.js
@@ -233,7 +233,7 @@ describe("Core — dfn-index", () => {
         "AbortError exception",
         "boolean type",
         "[Default] extended attribute",
-        "default toJSON operation",
+        "default toJSON steps",
         "DOMString interface",
         "[Exposed] extended attribute",
         "[NewObject] extended attribute",

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -1165,7 +1165,7 @@ callback CallBack = Z? (X x, optional Y y, /*trivia*/ optional Z z);
     ).map(elem => new URL(elem.href));
     expect(defaultLink.hash).toBe("#Default");
     expect(objectLink.hash).toBe("#idl-object");
-    expect(toJSONLink.hash).toBe("#default-tojson-operation");
+    expect(toJSONLink.hash).toBe("#default-tojson-steps");
   });
   it("links `[Default] object toJSON();` with data-link-for automatically to IDL spec", () => {
     const elem = doc.getElementById("AutoLinkToIDLSpecLinkFor");
@@ -1174,7 +1174,7 @@ callback CallBack = Z? (X x, optional Y y, /*trivia*/ optional Z z);
     ).map(elem => new URL(elem.href));
     expect(defaultLink.hash).toBe("#Default");
     expect(objectLink.hash).toBe("#idl-object");
-    expect(toJSONLink.hash).toBe("#default-tojson-operation");
+    expect(toJSONLink.hash).toBe("#default-tojson-steps");
   });
   it("allows toJSON() to be defined in spec", () => {
     const elem = doc.getElementById("DefinedToJson");

--- a/tests/spec/core/webidl.html
+++ b/tests/spec/core/webidl.html
@@ -743,7 +743,7 @@
       </pre>
       <section>
       <h2><dfn>toJSON()</dfn> method</h2>
-      <p>When <a>toJSON()</a> is called, run [[!WEBIDL]]'s <a data-cite="WEBIDL#default-tojson-operation">default toJSON operation</a>.</p>
+      <p>When <a>toJSON()</a> is called, run [[!WEBIDL]]'s <a data-cite="WEBIDL#default-tojson-steps">default toJSON steps</a>.</p>
       </section>
     </section>
     <section>


### PR DESCRIPTION
Note for anyone coming to search for this issue as a linker error:
Replace all occurrences of `default toJSON operation` with `default toJSON steps`.

See https://github.com/heycam/webidl/pull/882,
or in particular: https://github.com/heycam/webidl/commit/ea3af2cfb2a8204ac17da27c347d760ae12b4d0a#diff-ec9cfa5f3f35ec1f84feb2e59686c34dL11840


