### PR TITLE
chore(ci): skip puppeteer install

### DIFF
--- a/.github/workflows/pr-push.yml
+++ b/.github/workflows/pr-push.yml
@@ -6,6 +6,10 @@ on:
       - gh-pages
   pull_request: {}
 
+env:
+  PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 1
+  PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome
+
 jobs:
   lint:
     name: Check linting issues


### PR DESCRIPTION
GitHub actions [already have](https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md) Chrome and Firefox installed, so we can skip our own install..

Cons: A rare risk of puppeteer API getting out of sync with installed Chrome/Firefox version.
Pros: Much faster CI (4m 26s to 3m 15s), smaller cache (157MB compressed to 35MB) (need cache purging to see - will be automatic in future, I checked with temporary manual cache purges)

What's next?
- We can now use `npm ci` :tada: 
- We can also remove `actions/setup-node`, as Node v12 is also installed.
