### PR TITLE
chore(ci): split into PR and push workflows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,69 @@
+name: Node CI (PR)
+on:
+  pull_request: {}
+
+env:
+  PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 1
+  PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome
+
+jobs:
+  lint:
+    name: Check linting issues
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Cache node modules
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-12-${{ hashFiles('**/package-lock.json') }}
+      - run: npm ci
+      - run: npm run lint
+
+  test-headless:
+    name: Headless Tests
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Cache node modules
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-12-${{ hashFiles('**/package-lock.json') }}
+      - name: install & build
+        run: |
+          npm ci
+          npm run build:w3c
+      - run: npm run test:headless
+
+  test-karma:
+    name: Karma Unit Tests (${{ matrix.browser }})
+    strategy:
+      matrix:
+        browser: [ChromeHeadless, FirefoxHeadless]
+    runs-on: ubuntu-latest
+    needs: lint
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Cache node modules
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-12-${{ hashFiles('**/package-lock.json') }}
+      - name: install & build
+        run: |
+          npm ci
+          npm run build:w3c & npm run build:geonovum
+      - run: npm run test:karma
+        env:
+          BROWSERS: ${{ matrix.browser }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,32 +1,11 @@
-name: Node CI
+name: Node CI (push)
 on:
   push:
     branches:
       - develop
       - gh-pages
-  pull_request: {}
-
-env:
-  PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: 1
-  PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome
 
 jobs:
-  lint:
-    name: Check linting issues
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12
-      - name: Cache node modules
-        uses: actions/cache@v1
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-12-${{ hashFiles('**/package-lock.json') }}
-      - run: npm ci
-      - run: npm run lint
-
   test-headless:
     name: Headless Tests
     runs-on: ubuntu-latest
@@ -48,12 +27,8 @@ jobs:
       - run: npm run test:headless
 
   test-karma:
-    name: Karma Unit Tests (${{ matrix.browser }})
-    strategy:
-      matrix:
-        browser: [ChromeHeadless, FirefoxHeadless]
+    name: Karma Unit Tests (Chrome)
     runs-on: ubuntu-latest
-    needs: lint
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
@@ -70,4 +45,4 @@ jobs:
           npm run build:w3c & npm run build:geonovum
       - run: npm run test:karma
         env:
-          BROWSERS: ${{ matrix.browser }}
+          BROWSERS: ChromeHeadless


### PR DESCRIPTION
Idea is:
- We run all tests for PRs (pr.yml). Good work.
- When merge the PR, all tests have already passed. Plus, we always sync with develop before merge, so things are unlikely to have changed.
- But to be sure, we still run fast tests when PR is merged, or when we release (push: gh-pages). To not waste CPU cycles, we:
  - ignore lint -> not high priority.
  - run karma only in Chrome, as Firefox is slower and there is unlikely any change since PR tests. We can also do the opposite: test more browsers on merge.
- We can run other jobs on merge, like https://github.com/w3c/respec/pull/2895/ or regression tests (See https://github.com/w3c/respec/issues/2874). These need not run on every PR synchronize event.
