### PR TITLE
fix(core/webidl): update outdated xref terms

### DIFF
--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -157,7 +157,7 @@ function defineIdlName(escaped, data, parent) {
     data.name === "toJSON" &&
     data.extAttrs.some(({ name }) => name === "Default");
   if (isDefaultJSON) {
-    return html`<a data-link-type="dfn" data-lt="default toJSON operation"
+    return html`<a data-link-type="dfn" data-lt="default toJSON steps"
       >${escaped}</a
     >`;
   }

--- a/tests/spec/core/dfn-index-spec.js
+++ b/tests/spec/core/dfn-index-spec.js
@@ -211,10 +211,34 @@ describe("Core — dfn-index", () => {
       index = doc.getElementById("index-defined-elsewhere");
     });
 
-    it("doesn't list local terms", () => {
-      const terms = index.querySelectorAll(".index-term");
-      const localTerm = [...terms].find(li => li.textContent === "hello");
-      expect(localTerm).toBeUndefined();
+    it("lists only external terms", () => {
+      const getTermAndType = el => el.textContent.trim().split(/\s\(/)[0];
+      const terms = [...index.querySelectorAll(".index-term")].map(
+        getTermAndType
+      );
+      expect(terms).toEqual([
+        "creating an event",
+        "Event interface",
+        "EventInit",
+        "type attribute",
+        "JSON.stringify",
+        "allow attribute",
+        "EventHandler",
+        "fully active",
+        "iframe element",
+        "responsible document",
+        "Window interface",
+        "ASCII uppercase",
+        "origin",
+        "AbortError exception",
+        "boolean type",
+        "[Default] extended attribute",
+        "DOMString interface",
+        "[Exposed] extended attribute",
+        "[NewObject] extended attribute",
+        "object type",
+        "Promise interface",
+      ]);
     });
 
     it("lists terms grouped by specs", () => {

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -1165,7 +1165,7 @@ callback CallBack = Z? (X x, optional Y y, /*trivia*/ optional Z z);
     ).map(elem => new URL(elem.href));
     expect(defaultLink.hash).toBe("#Default");
     expect(objectLink.hash).toBe("#idl-object");
-    expect(toJSONLink.hash).toBe("#default-tojson-operation");
+    expect(toJSONLink.hash).toBe("#default-tojson-steps");
   });
   it("allows toJSON() to be defined in spec", () => {
     const elem = doc.getElementById("DefinedToJson");

--- a/tests/spec/core/webidl-spec.js
+++ b/tests/spec/core/webidl-spec.js
@@ -1337,7 +1337,7 @@ callback CallBack = Z? (X x, optional Y y, /*trivia*/ optional Z z);
         <h2>Test</h2>
         <pre class="idl" id="link-test">
           interface mixin InnerHTMLMixin {
-            [TreatNullAs=EmptyString] attribute DOMString innerHTML;
+            [PutForwards=html] readonly attribute DOMString innerHTML;
           };
         </pre>
       </section>

--- a/tests/spec/core/webidl.html
+++ b/tests/spec/core/webidl.html
@@ -735,7 +735,7 @@
       </pre>
       <section>
       <h2><dfn>toJSON()</dfn> method</h2>
-      <p>When <a>toJSON()</a> is called, run [[!WEBIDL]]'s <a data-cite="WEBIDL#default-tojson-operation">default toJSON operation</a>.</p>
+      <p>When <a>toJSON()</a> is called, run [[!WEBIDL]]'s <a data-cite="WEBIDL#default-tojson-steps">default toJSON steps</a>.</p>
       </section>
     </section>
     <section>


### PR DESCRIPTION
This is cherry-pick of a4d3b2680aa8ac0e8ad84b50de5406aa856b5689 and 42cc58e6ac0e661755352fa9cbbfdf37d0d83367
Without these, tests in w3c-common branch will keep failing.