### PR TITLE
fix(core/dfn-index): prevent id collision

### DIFF
--- a/src/core/dfn-index.js
+++ b/src/core/dfn-index.js
@@ -72,9 +72,6 @@ export async function run() {
     ${createExternalTermIndex()}
   </section>`;
   index.append(externalTermIndex);
-  for (const el of externalTermIndex.querySelectorAll(".index-term")) {
-    addId(el, "index-term");
-  }
 
   // XXX: This event is used to overcome an edge case with core/structure,
   // related to a circular dependency in plugin run order. We want
@@ -293,6 +290,7 @@ function renderExternalTermEntry(entry) {
   const el = html`<li>
     <span class="index-term" data-href="${elem.href}">${{ html: text }}</span>
   </li>`;
+  addId(el.querySelector("span"), "index-term");
   return el;
 }
 

--- a/src/core/dfn-index.js
+++ b/src/core/dfn-index.js
@@ -72,6 +72,9 @@ export async function run() {
     ${createExternalTermIndex()}
   </section>`;
   index.append(externalTermIndex);
+  for (const el of externalTermIndex.querySelectorAll(".index-term")) {
+    addId(el, "index-term");
+  }
 
   // XXX: This event is used to overcome an edge case with core/structure,
   // related to a circular dependency in plugin run order. We want
@@ -290,7 +293,6 @@ function renderExternalTermEntry(entry) {
   const el = html`<li>
     <span class="index-term" data-href="${elem.href}">${{ html: text }}</span>
   </li>`;
-  addId(el.querySelector("span"), "index-term");
   return el;
 }
 

--- a/tests/spec/core/dfn-index-spec.js
+++ b/tests/spec/core/dfn-index-spec.js
@@ -378,11 +378,11 @@ describe("Core — dfn-index", () => {
     });
 
     it("associates different id to each term", async () => {
-      const termsInDom = index.querySelectorAll(
+      const termsInEcma = index.querySelectorAll(
         "[data-spec='ECMASCRIPT'] li span"
       );
-      expect(termsInDom.length).toBe(3);
-      const [, parsing1, parsing2] = termsInDom;
+      expect(termsInEcma.length).toBe(3);
+      const [, parsing1, parsing2] = termsInEcma;
       expect(parsing1.id).toBe("index-term-parsing");
       expect(parsing2.id).toBe("index-term-parsing-0");
     });

--- a/tests/spec/core/dfn-index-spec.js
+++ b/tests/spec/core/dfn-index-spec.js
@@ -200,6 +200,10 @@ describe("Core — dfn-index", () => {
           </li>
           <li><a>JSON.stringify</a></li>
         </ul>
+        <ul class="test" data-testid="possible-duplicate-id">
+        <li><a data-cite="ECMASCRIPT#sec-json.parse">parsing</a></li>
+        <li><a data-cite="ECMASCRIPT#sec-15.12.2">parsing</a></li>
+        </ul>
       </section>
       <section id="index"></section>`;
 
@@ -222,6 +226,8 @@ describe("Core — dfn-index", () => {
         "EventInit",
         "type attribute",
         "JSON.stringify",
+        "parsing",
+        "parsing",
         "allow attribute",
         "EventHandler",
         "fully active",
@@ -369,6 +375,16 @@ describe("Core — dfn-index", () => {
       const reference = panel.querySelector("ul li a");
       expect(reference.textContent).toBe("1. TEST");
       expect(reference.hash).toBe("#ref-for-index-term-event-interface-1");
+    });
+
+    it("associates different id to each term", async () => {
+      const termsInDom = index.querySelectorAll(
+        "[data-spec='ECMASCRIPT'] li span"
+      );
+      expect(termsInDom.length).toBe(3);
+      const [, parsing1, parsing2] = termsInDom;
+      expect(parsing1.id).toBe("index-term-parsing");
+      expect(parsing2.id).toBe("index-term-parsing-0");
     });
   });
 });


### PR DESCRIPTION
`addId` relies on checking IDs for collision in `ownerDocument`, but these `.index-term` are not in any document yet.

Demo with an old version of manifest spec:
![image](https://user-images.githubusercontent.com/8426945/82788244-b6076b80-9e85-11ea-8901-cd487da3a5d0.png)
