### PR TITLE
fix(core/inlines): allow escaping forward-slash in terms

### DIFF
--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -80,7 +80,7 @@ function inlineElementMatches(matched) {
   const [element, attribute] = splitBySlash(value, 2);
   const [xrefType, xrefFor, textContent] = attribute
     ? ["element-attr", element, attribute]
-    : ["element|element-attr", null, element];
+    : ["element", null, element];
   const code = html`<code
     ><a data-xref-type="${xrefType}" data-xref-for="${xrefFor}"
       >${textContent}</a

--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -81,11 +81,17 @@ function inlineElementMatches(matched) {
     .replace("\\/", "%%")
     .split("/", 2)
     .map(s => s && s.trim().replace("%%", "/"));
-  const [xrefType, xrefFor, textContent] = attribute
-    ? ["element-attr", element, attribute]
-    : ["element|element-attr", null, element];
+  const [xrefFor, textContent] = attribute
+    ? [element, attribute]
+    : [null, element];
+  const xrefType = [];
+  if (attribute || value.includes("\\/")) {
+    xrefType.push("element-attr");
+  } else if (!attribute) {
+    xrefType.push("element");
+  }
   const code = html`<code
-    ><a data-xref-type="${xrefType}" data-xref-for="${xrefFor}"
+    ><a data-xref-type="${xrefType.join("|")}" data-xref-for="${xrefFor}"
       >${textContent}</a
     ></code
   >`;

--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -77,10 +77,13 @@ const inlineElement = /(?:\[\^[^^]+\^\])/; // Inline [^element^]
  */
 function inlineElementMatches(matched) {
   const value = matched.slice(2, -2).trim();
-  const [element, attribute] = value.split("/", 2).map(s => s && s.trim());
+  const [element, attribute] = value
+    .replace("\\/", "%%")
+    .split("/", 2)
+    .map(s => s && s.trim().replace("%%", "/"));
   const [xrefType, xrefFor, textContent] = attribute
     ? ["element-attr", element, attribute]
-    : ["element", null, element];
+    : ["element|element-attr", null, element];
   const code = html`<code
     ><a data-xref-type="${xrefType}" data-xref-for="${xrefFor}"
       >${textContent}</a
@@ -200,7 +203,10 @@ function inlineVariableMatches(matched) {
  */
 function inlineAnchorMatches(matched) {
   matched = matched.slice(2, -2); // Chop [= =]
-  const parts = matched.split("/", 2).map(s => s.trim());
+  const parts = matched
+    .replace("\\/", "%%")
+    .split("/", 2)
+    .map(s => s.trim().replace("%%", "/"));
   const [isFor, content] = parts.length === 2 ? parts : [null, parts[0]];
   const [linkingText, text] = content.includes("|")
     ? content.split("|", 2).map(s => s.trim())

--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -78,17 +78,11 @@ const inlineElement = /(?:\[\^[^^]+\^\])/; // Inline [^element^]
 function inlineElementMatches(matched) {
   const value = matched.slice(2, -2).trim();
   const [element, attribute] = splitBySlash(value, 2);
-  const [xrefFor, textContent] = attribute
-    ? [element, attribute]
-    : [null, element];
-  const xrefType = [];
-  if (attribute || value.includes("\\/")) {
-    xrefType.push("element-attr");
-  } else if (!attribute) {
-    xrefType.push("element");
-  }
+  const [xrefType, xrefFor, textContent] = attribute
+    ? ["element-attr", element, attribute]
+    : ["element|element-attr", null, element];
   const code = html`<code
-    ><a data-xref-type="${xrefType.join("|")}" data-xref-for="${xrefFor}"
+    ><a data-xref-type="${xrefType}" data-xref-for="${xrefFor}"
       >${textContent}</a
     ></code
   >`;

--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -77,7 +77,7 @@ const inlineElement = /(?:\[\^[^^]+\^\])/; // Inline [^element^]
  */
 function inlineElementMatches(matched) {
   const value = matched.slice(2, -2).trim();
-  const [element, attribute] = splitBySlash(value, 2);
+  const [element, attribute] = value.split("/", 2).map(s => s && s.trim());
   const [xrefType, xrefFor, textContent] = attribute
     ? ["element-attr", element, attribute]
     : ["element", null, element];

--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -77,10 +77,7 @@ const inlineElement = /(?:\[\^[^^]+\^\])/; // Inline [^element^]
  */
 function inlineElementMatches(matched) {
   const value = matched.slice(2, -2).trim();
-  const [element, attribute] = value
-    .replace("\\/", "%%")
-    .split("/", 2)
-    .map(s => s && s.trim().replace("%%", "/"));
+  const [element, attribute] = splitBySlash(value, 2);
   const [xrefFor, textContent] = attribute
     ? [element, attribute]
     : [null, element];
@@ -209,10 +206,7 @@ function inlineVariableMatches(matched) {
  */
 function inlineAnchorMatches(matched) {
   matched = matched.slice(2, -2); // Chop [= =]
-  const parts = matched
-    .replace("\\/", "%%")
-    .split("/", 2)
-    .map(s => s.trim().replace("%%", "/"));
+  const parts = splitBySlash(matched, 2);
   const [isFor, content] = parts.length === 2 ? parts : [null, parts[0]];
   const [linkingText, text] = content.includes("|")
     ? content.split("|", 2).map(s => s.trim())
@@ -331,4 +325,18 @@ export function run(conf) {
     }
     txt.replaceWith(df);
   }
+}
+
+/**
+ * Split a string by slash (`/`) unless it's escaped by a backslash (`\`)
+ * @param {string} str
+ *
+ * TODO: Use negative lookbehind (`str.split(/(?<!\\)\//)`) when supported.
+ * https://github.com/w3c/respec/issues/2869
+ */
+function splitBySlash(str, limit = Infinity) {
+  return str
+    .replace("\\/", "%%")
+    .split("/", limit)
+    .map(s => s && s.trim().replace("%%", "/"));
 }

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -391,8 +391,9 @@ function addDataCite(elem, query, result, conf) {
   const { term } = query;
   const { uri, shortname: cite, normative, type, for: forContext } = result;
 
-  const path = uri.includes("/") ? uri.split("/", 1)[1] : uri;
-  const [citePath, citeFrag] = path.split("#");
+  const url = new URL(uri, "https://example.org");
+  const { pathname: citePath } = url;
+  const citeFrag = url.hash.slice(1);
   const dataset = { cite, citePath, citeFrag, type };
   if (forContext) dataset.linkFor = forContext[0];
   Object.assign(elem.dataset, dataset);

--- a/tests/spec/core/inlines-spec.js
+++ b/tests/spec/core/inlines-spec.js
@@ -420,6 +420,21 @@ describe("Core - Inlines", () => {
     expect(iterationBreak.hash).toBe("#iteration-break");
   });
 
+  it("allows escaping `/` in [= concept =] and [^ element-attr ^] links", async () => {
+    const body = `<section id="test">
+      <dfn>foo/bar</dfn> [= foo\\/bar =]
+      [=multipart\\/form-data encoding algorithm=]
+      [^application\\/x-www-form-urlencoded^]
+    </section>`;
+    const ops = makeStandardOps({ xref: ["HTML"] }, body);
+    const doc = await makeRSDoc(ops);
+
+    const [localLink, conceptLink, attrLink] = doc.querySelectorAll("#test a");
+    expect(localLink.hash).toBe("#dfn-foo-bar");
+    expect(conceptLink.hash).toBe("#multipart/form-data-encoding-algorithm");
+    expect(attrLink.hash).toBe("#attr-fs-enctype-urlencoded");
+  });
+
   it("processes {{ forContext/term }} IDL", async () => {
     const body = `
       <section>

--- a/tests/spec/core/inlines-spec.js
+++ b/tests/spec/core/inlines-spec.js
@@ -420,19 +420,17 @@ describe("Core - Inlines", () => {
     expect(iterationBreak.hash).toBe("#iteration-break");
   });
 
-  it("allows escaping `/` in [= concept =] and [^ element-attr ^] links", async () => {
+  it("allows escaping `/` in [= concept =] links", async () => {
     const body = `<section id="test">
       <dfn>foo/bar</dfn> [= foo\\/bar =]
       [=multipart\\/form-data encoding algorithm=]
-      [^application\\/x-www-form-urlencoded^]
     </section>`;
     const ops = makeStandardOps({ xref: ["HTML"] }, body);
     const doc = await makeRSDoc(ops);
 
-    const [localLink, conceptLink, attrLink] = doc.querySelectorAll("#test a");
+    const [localLink, conceptLink] = doc.querySelectorAll("#test a");
     expect(localLink.hash).toBe("#dfn-foo-bar");
     expect(conceptLink.hash).toBe("#multipart/form-data-encoding-algorithm");
-    expect(attrLink.hash).toBe("#attr-fs-enctype-urlencoded");
   });
 
   it("processes {{ forContext/term }} IDL", async () => {


### PR DESCRIPTION
Closes https://github.com/w3c/respec/issues/2914 as backticks are already supported but `/` is not