### PR TITLE
fix(core/xref): add data-cite as authored in spec context

### DIFF
--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -389,8 +389,12 @@ function addDataCiteToTerms(elems, queryKeys, data, conf) {
  */
 function addDataCite(elem, query, result, conf) {
   const { term } = query;
-  const { uri, shortname: cite, normative, type, for: forContext } = result;
-
+  const { uri, shortname, spec, normative, type, for: forContext } = result;
+  let cite = shortname;
+  // if authored spec context had `result.spec`, use it instead of shortname
+  if (query.specs && query.specs.some(specs => specs.includes(spec))) {
+    cite = spec;
+  }
   const path = uri.includes("/") ? uri.split("/", 1)[1] : uri;
   const [citePath, citeFrag] = path.split("#");
   const dataset = { cite, citePath, citeFrag, type };

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -390,11 +390,8 @@ function addDataCiteToTerms(elems, queryKeys, data, conf) {
 function addDataCite(elem, query, result, conf) {
   const { term, specs = [] } = query;
   const { uri, shortname, spec, normative, type, for: forContext } = result;
-  let cite = shortname;
   // if authored spec context had `result.spec`, use it instead of shortname
-  if (specs.flat().includes(spec)) {
-    cite = spec;
-  }
+  const cite = specs.flat().includes(spec) ? spec : shortname;
   const path = uri.includes("/") ? uri.split("/", 1)[1] : uri;
   const [citePath, citeFrag] = path.split("#");
   const dataset = { cite, citePath, citeFrag, type };

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -388,11 +388,11 @@ function addDataCiteToTerms(elems, queryKeys, data, conf) {
  * @param {any} conf
  */
 function addDataCite(elem, query, result, conf) {
-  const { term } = query;
+  const { term, specs = [] } = query;
   const { uri, shortname, spec, normative, type, for: forContext } = result;
   let cite = shortname;
   // if authored spec context had `result.spec`, use it instead of shortname
-  if (query.specs && query.specs.flat().includes(spec)) {
+  if (specs.flat().includes(spec)) {
     cite = spec;
   }
   const path = uri.includes("/") ? uri.split("/", 1)[1] : uri;

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -392,7 +392,7 @@ function addDataCite(elem, query, result, conf) {
   const { uri, shortname, spec, normative, type, for: forContext } = result;
   let cite = shortname;
   // if authored spec context had `result.spec`, use it instead of shortname
-  if (query.specs && query.specs.some(specs => specs.includes(spec))) {
+  if (query.specs && query.specs.flat().includes(spec)) {
     cite = spec;
   }
   const path = uri.includes("/") ? uri.split("/", 1)[1] : uri;

--- a/tests/spec/core/xref-spec.js
+++ b/tests/spec/core/xref-spec.js
@@ -319,6 +319,22 @@ describe("Core — xref", () => {
     expect(linkLocal2.classList).toContain("respec-offending-element");
   });
 
+  it("uses data-cite as authored in spec context", async () => {
+    const body = `<section id="test">
+      <p data-cite="css-syntax-3">[=CSS/parsing=]</p>
+      <p data-cite="css-color">[=sRGB=]</p>
+    </section>`;
+    const localBiblio = { "css-color": { aliasOf: "css-color-3" } };
+    const ops = makeStandardOps({ localBiblio }, body);
+    const doc = await makeRSDoc(ops);
+
+    const [specLink, shortnameLink] = doc.querySelectorAll("#test a");
+    expect(specLink.hash).toBe(
+      "#css-parse-something-according-to-a-css-grammar"
+    );
+    expect(shortnameLink.hash).toBe("#sRGB");
+  });
+
   it("treats terms as local if empty data-cite on parent", async () => {
     const body = `
       <section data-cite="" id="test">


### PR DESCRIPTION
This avoids the need to add `aliasOf` entries in `localBiblio`
It allows ReSpec to search and link using the same authored `data-cite`. Earlier, we could search using authored data-cite, but link was always based on `shortname`.
See: https://github.com/w3c/manifest/pull/878#discussion_r432331678
