### PR TITLE
fix(core/dfn-panel): do not generate panels in local dfn index

### DIFF
--- a/src/core/dfn-panel.js
+++ b/src/core/dfn-panel.js
@@ -15,7 +15,9 @@ export async function run() {
   );
 
   /** @type {HTMLElement} */
-  const elems = document.querySelectorAll("dfn, .index-term");
+  const elems = document.querySelectorAll(
+    "dfn, #index-defined-elsewhere .index-term"
+  );
   const panels = document.createDocumentFragment();
   for (const el of elems) {
     panels.append(createPanel(el));


### PR DESCRIPTION
Missed this in https://github.com/w3c/respec/pull/2901
linter/local-refs-exist started complaining rightly.

It was generating dfn panels for all `.index-term` which included the following links:
![image](https://user-images.githubusercontent.com/8426945/83528964-5c4b1500-a507-11ea-90ed-323faa363ba8.png)
