### PR TITLE
fix(core/dfn-panel): do not generate panels for dfn without id

### DIFF
--- a/src/core/dfn-panel.js
+++ b/src/core/dfn-panel.js
@@ -19,7 +19,7 @@ export async function run() {
 
   /** @type {NodeListOf<HTMLElement>} */
   const elems = document.querySelectorAll(
-    "dfn, #index-defined-elsewhere .index-term"
+    "dfn[id], #index-defined-elsewhere .index-term"
   );
   const panels = document.createDocumentFragment();
   for (const el of elems) {


### PR DESCRIPTION
There were some `dfn` inside IDL index, which didn't have an id, causing broken local reference.