### PR TITLE
fix(core/mdn-annotation): inject CSS in exported docs

### DIFF
--- a/src/core/mdn-annotation.js
+++ b/src/core/mdn-annotation.js
@@ -139,7 +139,6 @@ export async function run(conf) {
 
   const style = document.createElement("style");
   style.textContent = await loadStyle();
-  style.classList.add("removeOnSave");
   document.head.append(style);
 
   for (const elem of findElements(mdnSpecJson)) {


### PR DESCRIPTION
We already inject the panels in exported doc, styles were missing,