### PR TITLE
fix(assets/dfn-panel.css): fix caret position across browsers

### DIFF
--- a/assets/dfn-panel.css
+++ b/assets/dfn-panel.css
@@ -23,8 +23,8 @@ dfn {
 }
 /* Triangle/caret */
 .dfn-panel:not(.docked) > .caret {
-  position: relative;
-  top: -0.25em;
+  position: absolute;
+  top: -9px;
 }
 .dfn-panel:not(.docked) > .caret::before,
 .dfn-panel:not(.docked) > .caret::after {
@@ -36,7 +36,7 @@ dfn {
   top: 0;
 }
 .dfn-panel:not(.docked) > .caret::before {
-  border-bottom: 10px solid #a2a9b1;
+  border-bottom: 9px solid #a2a9b1;
 }
 
 .dfn-panel * {


### PR DESCRIPTION
Firefox and Chrome treated `display: inline` with `position: relative` differently. 

I'll write a minimal case and see if it's a web-compat bug or I did something wrong.
Update: Minimal reproduction: https://codepen.io/sidvishnoi/pen/bGEGaeW?editors=1100

| Firefox | Chrome |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/8426945/83633497-afcc6a00-a5be-11ea-941a-c55491af6797.png) | ![image](https://user-images.githubusercontent.com/8426945/83633471-a2af7b00-a5be-11ea-8604-6ebf8083fce9.png) | 
