### PR TITLE
fix(core/dfn-panel): fix heading markup due to pubrules id rule

### DIFF
--- a/assets/dfn-panel.css
+++ b/assets/dfn-panel.css
@@ -43,10 +43,9 @@ dfn {
   margin: 0;
 }
 
-.dfn-panel h2 {
+.dfn-panel b {
+  display: block;
   color: #000;
-  font-weight: bold;
-  font-size: inherit;
   margin-top: 0.25em;
 }
 

--- a/src/core/dfn-panel.js
+++ b/src/core/dfn-panel.js
@@ -49,7 +49,7 @@ function createPanel(dfn) {
         <a class="self-link" href="${href}">Permalink</a>
         ${dfnExportedMarker(dfn)}
       </div>
-      <h2>Referenced in:</h2>
+      <b>Referenced in:</b>
       ${referencesToHTML(id, links)}
     </aside>
   `;

--- a/tests/spec/core/dfn-panel-spec.js
+++ b/tests/spec/core/dfn-panel-spec.js
@@ -132,7 +132,7 @@ describe("Core — dfnPanel", () => {
     const selfLink = panel.querySelector("a.self-link");
     expect(selfLink.hash).toBe("#dfn-one");
 
-    const referenceHeading = panel.querySelector("h2");
+    const referenceHeading = panel.querySelector("b");
     expect(referenceHeading.textContent).toBe("Referenced in:");
 
     const referenceListItems = panel.querySelectorAll("ul li");
@@ -154,7 +154,7 @@ describe("Core — dfnPanel", () => {
     const selfLink = panel.querySelector("a.self-link");
     expect(selfLink.hash).toBe("#dfn-many");
 
-    const referenceHeading = panel.querySelector("h2");
+    const referenceHeading = panel.querySelector("b");
     expect(referenceHeading.textContent).toBe("Referenced in:");
 
     const referenceListItems = panel.querySelectorAll("ul li");
@@ -210,7 +210,7 @@ describe("Core — dfnPanel", () => {
     const selfLink = panel.querySelector("a.self-link");
     expect(selfLink.hash).toBe("#dfn-one");
 
-    const referenceHeading = panel.querySelector("h2");
+    const referenceHeading = panel.querySelector("b");
     expect(referenceHeading.textContent).toBe("Referenced in:");
 
     const referenceListItems = panel.querySelectorAll("ul li");


### PR DESCRIPTION
[Pubrules wanted](https://github.com/w3c/web-share/runs/738231021#step:3:53) an ID on each for `<h2>Referenced in:</h2>`. Falling back to less semantic `<b>` as generating ID on these headings doesn't make sense.

Need to prioritize on https://github.com/w3c/respec/issues/792 / https://github.com/w3c/respec/issues/639 now.