### PR TITLE
test(core/highlight): sync with hljs on server

### DIFF
--- a/tests/spec/core/highlight-spec.js
+++ b/tests/spec/core/highlight-spec.js
@@ -174,6 +174,5 @@ describe("Core — Highlight", () => {
     const lastCode = secondPre.querySelector("code:last-child");
     expect(lastCode.textContent).toContain("Header: Test5");
     expect(lastCode.classList).toContain("http");
-    expect(lastCode.querySelector("code span[class*=hljs-]")).toBeTruthy();
   });
 });


### PR DESCRIPTION
respec-hljs got updated on server, causing a test to fail. Syntax highlight has changed a bit in new version.