### PR TITLE
fix(w3c/headers): allow skipping latest published version in ED

### DIFF
--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -317,16 +317,15 @@ export function run(conf) {
       conf.maturity
     }-${conf.shortName}-${concatDate(conf.publishDate)}/`;
   if (conf.specStatus === "ED") conf.thisVersion = conf.edDraftURI;
-  if (conf.isRegular)
+  const skipLatestVersion =
+    conf.specStatus === "ED" && conf.latestVersion === null;
+  if (conf.isRegular && !skipLatestVersion)
     conf.latestVersion = `https://www.w3.org/${publishSpace}/${conf.shortName}/`;
   if (conf.isTagFinding) {
     conf.latestVersion = `https://www.w3.org/2001/tag/doc/${conf.shortName}`;
     conf.thisVersion = `${conf.latestVersion}-${ISODate.format(
       conf.publishDate
     )}`;
-  }
-  if (conf.publishedURI === null && conf.specStatus === "ED") {
-    conf.latestVersion = null;
   }
 
   if (conf.previousPublishDate) {

--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -325,6 +325,10 @@ export function run(conf) {
       conf.publishDate
     )}`;
   }
+  if (conf.publishedURI === null && conf.specStatus === "ED") {
+    conf.latestVersion = null;
+  }
+
   if (conf.previousPublishDate) {
     if (!conf.previousMaturity && !conf.isTagFinding) {
       pub("error", "`previousPublishDate` is set, but not `previousMaturity`.");

--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -327,7 +327,6 @@ export function run(conf) {
       conf.publishDate
     )}`;
   }
-
   if (conf.previousPublishDate) {
     if (!conf.previousMaturity && !conf.isTagFinding) {
       pub("error", "`previousPublishDate` is set, but not `previousMaturity`.");

--- a/src/w3c/templates/headers.js
+++ b/src/w3c/templates/headers.js
@@ -129,14 +129,12 @@ export default (conf, options) => {
                 >${conf.thisVersion}</a
               >
             </dd>
-            <dt>${l10n.latest_published_version}</dt>
-            <dd>
-              ${conf.latestVersion
-                ? html`<a href="${conf.latestVersion}"
-                    >${conf.latestVersion}</a
-                  >`
-                : "none"}
-            </dd>
+            ${conf.latestVersion
+              ? html`<dt>${l10n.latest_published_version}</dt>
+                  <dd>
+                    <a href="${conf.latestVersion}">${conf.latestVersion}</a>
+                  </dd>`
+              : ""}
           `
         : ""}
       ${conf.edDraftURI

--- a/src/w3c/templates/headers.js
+++ b/src/w3c/templates/headers.js
@@ -129,12 +129,14 @@ export default (conf, options) => {
                 >${conf.thisVersion}</a
               >
             </dd>
-            ${conf.latestVersion
-              ? html`<dt>${l10n.latest_published_version}</dt>
-                  <dd>
-                    <a href="${conf.latestVersion}">${conf.latestVersion}</a>
-                  </dd>`
-              : ""}
+            <dt>${l10n.latest_published_version}</dt>
+            <dd>
+              ${conf.latestVersion
+                ? html`<a href="${conf.latestVersion}"
+                    >${conf.latestVersion}</a
+                  >`
+                : "none"}
+            </dd>
           `
         : ""}
       ${conf.edDraftURI

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -1147,7 +1147,7 @@ describe("W3C — Headers", () => {
     });
 
     it("allows skipping latest published version link in initial ED", async () => {
-      const ops = makeStandardOps({ specStatus: "ED", publishedURI: null });
+      const ops = makeStandardOps({ specStatus: "ED", latestVersion: null });
       const doc = await makeRSDoc(ops);
 
       const terms = [...doc.querySelectorAll("dt")];

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -1129,6 +1129,35 @@ describe("W3C — Headers", () => {
     });
   });
 
+  describe("latestVersion", () => {
+    it("adds a latest published version link", async () => {
+      const ops = makeStandardOps({ shortName: "foo", specStatus: "ED" });
+      const doc = await makeRSDoc(ops);
+
+      const terms = [...doc.querySelectorAll("dt")];
+      const latestVersion = terms.find(
+        el => el.textContent.trim() === "Latest published version:"
+      );
+      expect(latestVersion).toBeTruthy();
+      const latestVersionEl = latestVersion.nextElementSibling;
+      expect(latestVersionEl.localName).toBe("dd");
+      const latestVersionLink = latestVersionEl.querySelector("a");
+      expect(latestVersionLink.href).toBe("https://www.w3.org/TR/foo/");
+      expect(latestVersionLink.textContent).toBe("https://www.w3.org/TR/foo/");
+    });
+
+    it("allows skipping latest published version link in initial ED", async () => {
+      const ops = makeStandardOps({ specStatus: "ED", publishedURI: null });
+      const doc = await makeRSDoc(ops);
+
+      const terms = [...doc.querySelectorAll("dt")];
+      const latestVersion = terms.find(
+        el => el.textContent.trim() === "Latest published version:"
+      );
+      expect(latestVersion).toBeUndefined();
+    });
+  });
+
   describe("prevED", () => {
     it("takes prevED into account", async () => {
       const ops = makeStandardOps();

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -1154,7 +1154,12 @@ describe("W3C — Headers", () => {
       const latestVersion = terms.find(
         el => el.textContent.trim() === "Latest published version:"
       );
-      expect(latestVersion).toBeUndefined();
+      expect(latestVersion).toBeTruthy();
+      const latestVersionEl = latestVersion.nextElementSibling;
+      expect(latestVersionEl.localName).toBe("dd");
+      const latestVersionLink = latestVersionEl.querySelector("a");
+      expect(latestVersionLink).toBeNull();
+      expect(latestVersionEl.textContent.trim()).toBe("none");
     });
   });
 


### PR DESCRIPTION
Fixes https://github.com/w3c/respec/issues/1562

To skip adding a "Latest published version" link:
``` js
var respecConfig = {
  specStatus: "ED",
  latestVersion: null,
};
```