### PR TITLE
fix(w3c/sotd): require data-deliverer for IG Notes

### DIFF
--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -230,7 +230,7 @@ function renderDeliverer(conf) {
   const wontBeRec = recNotExpected
     ? "The group does not expect this document to become a W3C Recommendation."
     : "";
-  return html`<p data-deliverer="${isNote ? wgId : null}">
+  return html`<p data-deliverer="${(isNote || isIGNote) ? wgId : null}">
     ${producers} ${wontBeRec}
     ${!isNote && !isIGNote
       ? html`

--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -230,7 +230,7 @@ function renderDeliverer(conf) {
   const wontBeRec = recNotExpected
     ? "The group does not expect this document to become a W3C Recommendation."
     : "";
-  return html`<p data-deliverer="${(isNote || isIGNote) ? wgId : null}">
+  return html`<p data-deliverer="${isNote || isIGNote ? wgId : null}">
     ${producers} ${wontBeRec}
     ${!isNote && !isIGNote
       ? html`


### PR DESCRIPTION
About [2 months ago ](https://github.com/w3c/specberus/issues/880), we noticed pubrules wasn't strictly checking the disclosure link for IG Notes and we fixed that issue.
Because of that bug, people were confused and they often used the `wgPatentURI` link which contains the deliverer id. This is no longer the case and we now need to rely on the `data-deliverer` attribute for IG Notes. I created a PR for specberus to look for that
attribute: https://github.com/w3c/specberus/pull/919