### PR TITLE
fix(core/link-to-dfn): make current-spec regex more conservative

### DIFF
--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -278,7 +278,7 @@ function showLinkingError(elems) {
  */
 function updateReferences(conf) {
   const shortName = new RegExp(
-    String.raw`\b${(conf.shortName || "").toLowerCase()}\b`,
+    String.raw`\b${(conf.shortName || "").toLowerCase()}([^-])\b`,
     "i"
   );
 
@@ -287,7 +287,7 @@ function updateReferences(conf) {
     "dfn[data-cite]:not([data-cite='']), a[data-cite]:not([data-cite=''])"
   );
   for (const elem of elems) {
-    elem.dataset.cite = elem.dataset.cite.replace(shortName, THIS_SPEC);
+    elem.dataset.cite = elem.dataset.cite.replace(shortName, `${THIS_SPEC}$1`);
     const { key, isNormative } = toCiteDetails(elem);
     if (key === THIS_SPEC) continue;
 

--- a/tests/spec/core/link-to-dfn-spec.js
+++ b/tests/spec/core/link-to-dfn-spec.js
@@ -253,7 +253,7 @@ describe("Core — Link to definitions", () => {
 
   it("links to external spec with current spec as prefix", async () => {
     const body = `
-      <a id="test" data-cite="tomato-sauce#dfn-stats-object">PASS</a>
+      <a id="test" data-cite="tomato-sauce#is-red">PASS</a>
     `;
     const conf = {
       shortName: "tomato",

--- a/tests/spec/core/link-to-dfn-spec.js
+++ b/tests/spec/core/link-to-dfn-spec.js
@@ -269,5 +269,6 @@ describe("Core — Link to definitions", () => {
 
     const testLink = doc.getElementById("test");
     expect(testLink.classList).not.toContain("respec-offending-element");
+    expect(testLink.href).toBe("https://example.com/#is-red");
   });
 });

--- a/tests/spec/core/link-to-dfn-spec.js
+++ b/tests/spec/core/link-to-dfn-spec.js
@@ -250,4 +250,24 @@ describe("Core — Link to definitions", () => {
       doc.querySelectorAll("#links a[href='#dfn-test-string']").length
     ).toBe(3);
   });
+
+  it("links to external spec with current spec as prefix", async () => {
+    const body = `
+      <a id="test" data-cite="tomato-sauce#dfn-stats-object">PASS</a>
+    `;
+    const conf = {
+      shortName: "tomato",
+      localBiblio: {
+        "tomato-sauce": {
+          title: "A spec to ketchup",
+          href: "https://example.com",
+        },
+      },
+    };
+    const ops = makeStandardOps(conf, body);
+    const doc = await makeRSDoc(ops);
+
+    const testLink = doc.getElementById("test");
+    expect(testLink.classList).not.toContain("respec-offending-element");
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/w3c/respec/issues/2984
Regex test: https://regex101.com/r/HcHnzO/3

- [ ] TODO: Backport this to w3c-common.