### PR TITLE
feat(core/markdown): treat markdown code snippets as 'example'

### DIFF
--- a/src/core/markdown.js
+++ b/src/core/markdown.js
@@ -62,8 +62,10 @@ class Renderer extends marked.Renderer {
     }
 
     const html = super.code(code, language, isEscaped);
+
     const { example, illegalExample } = metaData;
     if (!example && !illegalExample) return html;
+
     const title = example || illegalExample;
     const className = `${language} ${example ? "example" : "illegal-example"}`;
     return html.replace(

--- a/src/core/markdown.js
+++ b/src/core/markdown.js
@@ -68,10 +68,7 @@ class Renderer extends marked.Renderer {
 
     const title = example || illegalExample;
     const className = `${language} ${example ? "example" : "illegal-example"}`;
-    return html.replace(
-      /^<pre[^>]*>/,
-      `<pre title="${title}" class="${className}">`
-    );
+    return html.replace("<pre>", `<pre title="${title}" class="${className}">`);
   }
 
   /**

--- a/src/core/markdown.js
+++ b/src/core/markdown.js
@@ -54,7 +54,7 @@ const ampEntity = /&amp;/gm;
 
 class Renderer extends marked.Renderer {
   code(code, infoString, isEscaped) {
-    const { language, example } = Renderer.parseInfoString(infoString);
+    const { language, ...metaData } = Renderer.parseInfoString(infoString);
 
     // regex to check whether the language is webidl
     if (/(^webidl$)/i.test(language)) {
@@ -62,10 +62,13 @@ class Renderer extends marked.Renderer {
     }
 
     const html = super.code(code, language, isEscaped);
-    if (!example) return html;
+    const { example, illegalExample } = metaData;
+    if (!example && !illegalExample) return html;
+    const title = example || illegalExample;
+    const className = `${language} ${example ? "example" : "illegal-example"}`;
     return html.replace(
       /^<pre[^>]*>/,
-      `<pre title="${example}" class="${language} example">`
+      `<pre title="${title}" class="${className}">`
     );
   }
 

--- a/src/core/markdown.js
+++ b/src/core/markdown.js
@@ -58,6 +58,29 @@ class Renderer extends marked.Renderer {
     if (/(^webidl$)/i.test(language)) {
       return `<pre class="idl">${code}</pre>`;
     }
+
+    // Extract the first comment containing "@example" as title, and treat this
+    // code block as an "example" if such comment exists.
+    const firstNonEmptyLine = code.split("\n", 3).find(s => s.trim());
+    const commentRegex = /^(\/\/|\/\*|<!--|#)\s*@example:?/;
+    if (firstNonEmptyLine && commentRegex.test(firstNonEmptyLine)) {
+      code = code.replace(`${firstNonEmptyLine}\n`, "");
+
+      const titleValue = firstNonEmptyLine
+        .replace(commentRegex, "")
+        .replace(/(\*\/|-->)$/, "")
+        .trim();
+      const title = `title="${titleValue}"`;
+
+      const html = super.code(code, language, isEscaped);
+      const htmlWithoutPre = html
+        .replace(/^<pre[^>]*>/, "")
+        .replace(/<\/pre>\n$/, "");
+
+      const className = `example ${language}`;
+      return `<pre ${title} class="${className}">${htmlWithoutPre}</pre>`;
+    }
+
     return super.code(code, language, isEscaped);
   }
 

--- a/tests/spec/core/markdown-spec.js
+++ b/tests/spec/core/markdown-spec.js
@@ -530,7 +530,7 @@ function getAnswer() {
       const title = example.querySelector(".example-title");
       expect(title).toBeTruthy();
       expect(title.textContent).toContain("the title");
-      expect(example.querySelector("pre").classList).toContain("js");
+      expect(example.querySelector("pre").classList).toContain("html");
       expect(example.querySelector("pre > code.hljs")).toBeTruthy();
     });
   });

--- a/tests/spec/core/markdown-spec.js
+++ b/tests/spec/core/markdown-spec.js
@@ -517,8 +517,8 @@ function getAnswer() {
     it("treats as example if example metadata exists", async () => {
       const body = `
         <section data-format="markdown" id="test">
-        \`\`\`js "example": "the title"
-        console.log("hey!!");
+        \`\`\`html "example": "the title"
+        <div>&lt;soup</div>
         \`\`\`
         </section>
       `;

--- a/tests/spec/core/markdown-spec.js
+++ b/tests/spec/core/markdown-spec.js
@@ -514,76 +514,24 @@ function getAnswer() {
       expect(example).toBeFalsy();
     });
 
-    it("adds example class if code contains @example comment", async () => {
+    it("treats as example if example metadata exists", async () => {
       const body = `
         <section data-format="markdown" id="test">
-        \`\`\`js
-        // @example
+        \`\`\`js "example": "the title"
         console.log("hey!!");
         \`\`\`
         </section>
       `;
       const ops = makeStandardOps(null, body);
       const doc = await makeRSDoc(ops);
-      const pre = doc.querySelector("#test pre");
 
-      const example = pre.closest(".example");
+      const example = doc.querySelector("#test .example");
       expect(example).toBeTruthy();
-      expect(example.textContent).not.toContain("@example");
-    });
-
-    it("adds example title if @example comment with title exists", async () => {
-      const body = `
-        <section data-format="markdown" id="test">
-        \`\`\`js
-        // @example: JS like comments
-        console.log("hey!!");
-        \`\`\`
-
-        \`\`\`html
-        <!-- @example: HTML like comments -->
-        <div></div>
-        \`\`\`
-
-        \`\`\`css
-        /* @example: CSS like comments */
-        .body { color: black }
-        \`\`\`
-
-        \`\`\`bash
-        # @example: Bash like comments
-        echo hey
-        \`\`\`
-        </section>
-      `;
-      const ops = makeStandardOps(null, body);
-      const doc = await makeRSDoc(ops);
-
-      const examples = doc.querySelectorAll("#test .example");
-      // expect(examples.length).toBe(4);
-      const [js, html, css, bash] = examples;
-
-      expect(js.querySelector(".example-title").textContent).toContain(
-        "JS like comments"
-      );
-      expect(js.querySelector("pre > code.hljs .hljs-comment")).toBeFalsy();
-
-      expect(html.querySelector(".example-title").textContent).toContain(
-        "HTML like comments"
-      );
-      expect(js.querySelector("pre > code.hljs .hljs-comment")).toBeFalsy();
-
-      expect(css.querySelector(".example-title").textContent).toContain(
-        "CSS like comments"
-      );
-      expect(js.querySelector("pre > code.hljs .hljs-comment")).toBeFalsy();
-
-      expect(bash.querySelector(".example-title").textContent).toContain(
-        "Bash like comments"
-      );
-      expect(js.querySelector("pre > code.hljs .hljs-comment")).toBeFalsy();
-
-      expect(doc.getElementById("test").textContent).not.toContain("@example");
+      const title = example.querySelector(".example-title");
+      expect(title).toBeTruthy();
+      expect(title.textContent).toContain("the title");
+      expect(example.querySelector("pre").classList).toContain("js");
+      expect(example.querySelector("pre > code.hljs")).toBeTruthy();
     });
   });
 


### PR DESCRIPTION
``` markdown
    ``` js
    console.log("hey!!");
    ```
```
becomes:
``` html
<pre class="example js">
console.log("hey!!");
</pre>
```


This might be a breaking change (nested `.example` if people already added their own `pre.example`).
A safer way might be to use DOM manipulation to convert `<pre><code class="lang">` to `<pre class="example lang"><code>`