### PR TITLE
feat(package): better Node.js support

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,10 @@
     "npm": ">=5"
   },
   "bin": {
+    "respec": "./tools/respec2html.js",
     "respec2html": "./tools/respec2html.js"
   },
+  "main": "./tools/respecDocWriter.js",
   "repository": {
     "type": "git",
     "url": "git://github.com/w3c/respec.git"


### PR DESCRIPTION
This will allow us to use respec as:
``` bash
npx respec -s src.html -o out.html
# instead of
npx -p respec respec2html -s src -o out.html
```

and:
``` js
const { fetchAndWrite } = require("respec");
// instead of
const { fetchAndWrite } = require("respec/tools/respecDocWriter");
```