### PR TITLE
chore(ci/changelog): automate changelog generation

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,23 @@
+name: Changelog
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - refs/tags/*
+
+jobs:
+  changelog:
+    name: Update Changelog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+      - run: gem install github_changelog_generator
+      - run: github_changelog_generator -u w3c -p respec --no-unreleased
+        env:
+          CHANGELOG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: peter-evans/create-pull-request@v2
+        with:
+          commit-message: "chore(CHANGELOG): regenerate"
+          title: "chore(CHANGELOG): regenerate"
+          branch: regenerate-changelog


### PR DESCRIPTION
It'll run automatically when we "release". We can also run it [manually](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/).
Takes around 15min to finish.
Changelog generation didn't fail in 5 attempts.
A sample run is available at: https://github.com/sidvishnoi/respec-xref-route/runs/855276492

May close https://github.com/w3c/respec/issues/2782 if we want to go this way.