### PR TITLE
refactor(core/base-runner): remove redundant canMeasure checks

### DIFF
--- a/src/core/base-runner.js
+++ b/src/core/base-runner.js
@@ -10,7 +10,6 @@ import { pub } from "./pubsubhub.js";
 import { removeReSpec } from "./utils.js";
 
 export const name = "core/base-runner";
-const canMeasure = performance.mark && performance.measure;
 
 function toRunnable(plug) {
   const name = plug.name || "";
@@ -25,9 +24,7 @@ function toRunnable(plug) {
         console.error(msg, plug);
         reject(new Error(msg));
       }, 15000);
-      if (canMeasure) {
-        performance.mark(`${name}-start`);
-      }
+      performance.mark(`${name}-start`);
       try {
         if (plug.Plugin) {
           await new plug.Plugin(config).run();
@@ -46,10 +43,8 @@ function toRunnable(plug) {
       } finally {
         clearTimeout(timerId);
       }
-      if (canMeasure) {
-        performance.mark(`${name}-end`);
-        performance.measure(name, `${name}-start`, `${name}-end`);
-      }
+      performance.mark(`${name}-end`);
+      performance.measure(name, `${name}-start`, `${name}-end`);
     });
   };
 }
@@ -60,9 +55,7 @@ function isRunnableModule(plug) {
 
 export async function runAll(plugs) {
   pub("start-all", respecConfig);
-  if (canMeasure) {
-    performance.mark(`${name}-start`);
-  }
+  performance.mark(`${name}-start`);
   await preProcessDone;
   const runnables = plugs.filter(isRunnableModule).map(toRunnable);
   for (const task of runnables) {
@@ -76,8 +69,6 @@ export async function runAll(plugs) {
   await postProcessDone;
   pub("end-all", respecConfig);
   removeReSpec(document);
-  if (canMeasure) {
-    performance.mark(`${name}-end`);
-    performance.measure(name, `${name}-start`, `${name}-end`);
-  }
+  performance.mark(`${name}-end`);
+  performance.measure(name, `${name}-start`, `${name}-end`);
 }


### PR DESCRIPTION
As browser support is good enough for us, and Spectre/Meltdown mitigation is to limit the time resolution, I think we can remove these checks. 
Any reason where it might be safe to keep these checks?