### PR TITLE
refactor(templates/sotd): remove redundant array

### DIFF
--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -238,7 +238,7 @@ function renderDeliverer(conf) {
             ? html` W3C maintains ${wgPatentHTML} `
             : html`
                 W3C maintains a
-                <a href="${[wgPatentURI]}" rel="disclosure"
+                <a href="${wgPatentURI}" rel="disclosure"
                   >public list of any patent disclosures</a
                 >
               `}

--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -1,6 +1,7 @@
 // @ts-check
 import { getIntlData } from "../../core/utils.js";
 import { html } from "../../core/import-maps.js";
+import { pub } from "../../core/pubsubhub.js";
 
 const localizationStrings = {
   en: {
@@ -230,9 +231,18 @@ function renderDeliverer(conf) {
   const wontBeRec = recNotExpected
     ? "The group does not expect this document to become a W3C Recommendation."
     : "";
+  if (!charterDisclosureURI && !wgPatentURI) {
+    pub(
+      "error",
+      "Document is missing patent disclosure information. Please associate this document " +
+        "with a W3C group by using the [`group`](https://respec.org/docs/#group) " +
+        "configuration option."
+    );
+    return;
+  }
   return html`<p data-deliverer="${isNote || isIGNote ? wgId : null}">
     ${producers} ${wontBeRec}
-    ${!isNote && !isIGNote
+    ${!isNote && !isIGNote && !charterDisclosureURI
       ? html`
           ${multipleWGs
             ? html` W3C maintains ${wgPatentHTML} `
@@ -257,7 +267,7 @@ function renderDeliverer(conf) {
           >.
         `
       : ""}
-    ${isIGNote
+    ${isIGNote || charterDisclosureURI
       ? html`
           The disclosure obligations of the Participants of this group are
           described in the


### PR DESCRIPTION
Closes #2638

Using the `group` option ensures the right patent policy URI. 