### PR TITLE
fix(core/exporter): don't add new line on head, body

### DIFF
--- a/src/core/exporter.js
+++ b/src/core/exporter.js
@@ -101,9 +101,6 @@ function prettify(cloneDoc) {
   cloneDoc.querySelectorAll("head > *").forEach(el => {
     el.outerHTML = `\n${el.outerHTML}`;
   });
-  cloneDoc.querySelectorAll(":root > *").forEach(el => {
-    el.outerHTML = `\n${el.outerHTML}\n`;
-  });
 }
 
 expose("core/exporter", { rsDocToDataURL });


### PR DESCRIPTION
It produced invalid HTML as such :man_facepalming: :
```html
<link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2016/W3C-ED"></head>
<body></body>
<head></head><body class="h-entry" data-cite="WebIDL HTML INFRA URL WEBIDL DOM FETCH"><div class="head">
```