### PR TITLE
(w3c/group): improve error messages, support group type, deprecate legacy options

### DIFF
--- a/src/w3c/group.js
+++ b/src/w3c/group.js
@@ -78,13 +78,13 @@ async function getGroupDetails(group) {
     return { wg, wgId, wgURI, wgPatentURI, wgPatentPolicy };
   }
 
-  let message = `Failed to fetch group details (HTTP: ${res.status})`;
+  const text = await res.text();
+  let message = `Failed to fetch group details (HTTP: ${res.status}). ${text}`;
   if (res.status === 404) {
-    const msg = `No group with name \`"${group}"\` found.`;
     const hint =
       "See [supported group names](https://respec.org/w3c/groups/) to use with the " +
-      "[`group`](https://github.com/w3c/respec/wiki/group) configuration option.";
-    message = `${msg} ${hint}`;
+      "[`group`](https://respec.org/docs/#group) configuration option.";
+    message += ` ${hint}`;
   }
   pub("error", message);
 }

--- a/src/w3c/group.js
+++ b/src/w3c/group.js
@@ -63,8 +63,13 @@ async function getMultipleGroupDetails(groups) {
  * @returns {Promise<GroupDetails|undefined>}
  */
 async function getGroupDetails(group) {
-  const url = new URL(group, W3C_GROUPS_API).href;
-  const res = await fetchAndCache(url);
+  let type = "";
+  let shortname = group;
+  if (group.includes("/")) {
+    [type, shortname] = group.split("/", 2);
+  }
+  const url = new URL(`${shortname}/${type}`, W3C_GROUPS_API);
+  const res = await fetchAndCache(url.href);
 
   if (res.ok) {
     const json = await res.json();

--- a/src/w3c/group.js
+++ b/src/w3c/group.js
@@ -12,20 +12,23 @@ import { pub } from "../core/pubsubhub.js";
 export const name = "w3c/group";
 
 const W3C_GROUPS_API = "https://respec.org/w3c/groups/";
+const LEGACY_OPTIONS = ["wg", "wgURI", "wgId", "wgPatentURI", "wgPatentPolicy"];
 
 export async function run(conf) {
-  if (!conf.group) return;
+  const usedLegacyOptions = LEGACY_OPTIONS.filter(opt => conf[opt]);
 
-  const supersededOptions = [
-    "wg",
-    "wgURI",
-    "wgId",
-    "wgPatentURI",
-    "wgPatentPolicy",
-  ];
-  const usedSupersededOptions = supersededOptions.filter(opt => conf[opt]);
-  if (usedSupersededOptions.length) {
-    const outdatedOptionsStr = joinAnd(usedSupersededOptions, s => `\`${s}\``);
+  if (!conf.group) {
+    if (usedLegacyOptions.length) {
+      const outdatedOptionsStr = joinAnd(LEGACY_OPTIONS, s => `\`${s}\``);
+      const msg = `Configuration options ${outdatedOptionsStr} are deprecated.`;
+      const hint = `Please use the [\`group\`](https://respec.org/docs/#group) option instead.`;
+      pub("warn", `${msg} ${hint}`);
+    }
+    return;
+  }
+
+  if (usedLegacyOptions.length) {
+    const outdatedOptionsStr = joinAnd(usedLegacyOptions, s => `\`${s}\``);
     const msg = `Configuration options ${outdatedOptionsStr} are superseded by \`group\` and will be overridden by ReSpec.`;
     const hint = "Please remove them from `respecConfig`.";
     pub("warn", `${msg} ${hint}`);

--- a/tests/spec/w3c/group-spec.js
+++ b/tests/spec/w3c/group-spec.js
@@ -57,4 +57,14 @@ describe("W3C — Group", () => {
     ]);
     expect(conf.wgURI).toEqual(["https://www.w3.org/2019/webapps/"]);
   });
+
+  it("fails if multiple groups exist with same shortname", async () => {
+    const conf = await getGroupConf({ group: "wot" });
+    expect(conf.wg).toBeFalsy();
+  });
+
+  it("allows specifying group type to disambiguate", async () => {
+    const conf = await getGroupConf({ group: "wg/wot" });
+    expect(conf.wg).toBe("Web of Things Working Group");
+  });
 });


### PR DESCRIPTION
1. Improves error messages by using error response from the server.
2. Allow specifying group type to disambiguate groups with same shortname and different type. See https://github.com/marcoscaceres/respec.org/issues/114  (**Note**: Tests will fail until server is updated). Closes https://github.com/w3c/respec/issues/3120.
3. Show deprecation warning if `wg`, `wgURI`, `wgId`, `wgPatentURI`, and `wgPatentPolicy` are used instead of `group`.

Note to reviewer: Review each commit separately. Also, lets merge this as 3 separate commits.