### PR TITLE
feat(tools/respec2html): add verbose flag

### DIFF
--- a/tools/respec2html.js
+++ b/tools/respec2html.js
@@ -77,6 +77,12 @@ const optionList = [
     name: "debug",
     type: Boolean,
   },
+  {
+    default: false,
+    description: "Enable debugging and show Chrome's DevTools.",
+    name: "verbose",
+    type: Boolean,
+  },
 ];
 
 const usageSections = [
@@ -137,6 +143,7 @@ const usageSections = [
       timeout: parsedArgs.timeout * 1000,
       disableSandbox: parsedArgs["disable-sandbox"],
       debug: parsedArgs.debug,
+      verbose: parsedArgs.verbose,
     });
   } catch (err) {
     console.error(colors.error(err.stack));

--- a/tools/respec2html.js
+++ b/tools/respec2html.js
@@ -79,7 +79,7 @@ const optionList = [
   },
   {
     default: false,
-    description: "Enable debugging and show Chrome's DevTools.",
+    description: "Log processing status to stdout.",
     name: "verbose",
     type: Boolean,
   },


### PR DESCRIPTION
Facing too many timeout errors in CI ([example](https://user-images.githubusercontent.com/8426945/95108149-82542080-0758-11eb-95b6-4f5fda1ab0cf.png)). This PR adds a `--verbose` flag to the ReSpec CLI to show processing status and understand what step is actually taking time.

<details>
<summary>Sample run</summary>


```bash
$ ./tools/respec2html.js -s examples/basic.built.html -o /tmp/out.html --timeout 10 --verbose
[Timeout: 9999ms] Launching browser
[Timeout: 9886ms] Navigating to file:///path/to/examples/basic.built.html
[Timeout: 8259ms] Navigation complete.
[Timeout: 8257ms] Processing ReSpec document...
[Timeout: 6534ms] Processed document.
[Timeout: 5525ms] Done.
```

</details>