### PR TITLE
feat(tools/respecDocWriter): add improved toHTML() method

### DIFF
--- a/tests/headless.js
+++ b/tests/headless.js
@@ -40,10 +40,8 @@ async function runRespec2html() {
   const errors = new Set();
   // Incrementally spawn processes and add them to process counter.
   const executables = testURLs.map(url => {
-    const nullDevice =
-      process.platform === "win32" ? "\\\\.\\NUL" : "/dev/null";
     const disableSandbox = process.env.TRAVIS ? " --disable-sandbox" : "";
-    const cmd = `node ./tools/respec2html.js -e${disableSandbox} --timeout 30 --src ${url} --out ${nullDevice}`;
+    const cmd = `node ./tools/respec2html.js -e${disableSandbox} --timeout 30 --src ${url}`;
     return toExecutable(cmd);
   });
   let testCount = 1;

--- a/tools/respec2html.js
+++ b/tools/respec2html.js
@@ -13,9 +13,7 @@ colors.setTheme({
   verbose: "cyan",
   warn: "yellow",
 });
-const convertToHTML = require("./respecDocWriter");
-const { writeFile } = require("fs").promises;
-const path = require("path");
+const { convertToHTML, write } = require("./respecDocWriter");
 
 const commandLineArgs = require("command-line-args");
 const getUsage = require("command-line-usage");
@@ -170,25 +168,3 @@ const usageSections = [
   }
   process.exit(0);
 })();
-
-/**
- * @param {string | "stdout" | null | "" | undefined} destination
- * @param {string} html
- */
-async function write(destination, html) {
-  switch (destination) {
-    case "":
-    case null:
-    case undefined:
-      break;
-    case "stdout":
-      process.stdout.write(html);
-      break;
-    default: {
-      const newFilePath = path.isAbsolute(destination)
-        ? destination
-        : path.resolve(process.cwd(), destination);
-      await writeFile(newFilePath, html, "utf-8");
-    }
-  }
-}

--- a/tools/respec2html.js
+++ b/tools/respec2html.js
@@ -13,7 +13,7 @@ colors.setTheme({
   verbose: "cyan",
   warn: "yellow",
 });
-const { convertToHTML, write } = require("./respecDocWriter");
+const { toHTML, write } = require("./respecDocWriter");
 
 const commandLineArgs = require("command-line-args");
 const getUsage = require("command-line-usage");
@@ -134,7 +134,7 @@ const usageSections = [
   const out = parsedArgs.out;
 
   try {
-    const { html, errors, warnings } = await convertToHTML(src, {
+    const { html, errors, warnings } = await toHTML(src, {
       timeout: parsedArgs.timeout * 1000,
       onError(error) {
         console.error(

--- a/tools/respec2html.js
+++ b/tools/respec2html.js
@@ -154,11 +154,9 @@ const usageSections = [
     const exitOnError = errors.length && parsedArgs.haltonerror;
     const exitOnWarning = warnings.length && parsedArgs.haltonwarn;
     if (exitOnError || exitOnWarning) {
-      const msg = `\n${
-        exitOnError ? "Errors" : "Warnings"
-      } found during processing.`;
-      console.error(colors.error(msg));
-      process.exit(2);
+      throw new Error(
+        `\n${exitOnError ? "Errors" : "Warnings"} found during processing.`
+      );
     }
 
     await write(out, html);

--- a/tools/respec2html.js
+++ b/tools/respec2html.js
@@ -155,7 +155,7 @@ const usageSections = [
     const exitOnWarning = warnings.length && parsedArgs.haltonwarn;
     if (exitOnError || exitOnWarning) {
       throw new Error(
-        `\n${exitOnError ? "Errors" : "Warnings"} found during processing.`
+        `${exitOnError ? "Errors" : "Warnings"} found during processing.`
       );
     }
 

--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -112,22 +112,19 @@ async function fetchAndWrite(src, out, whenToHalt = {}, options = {}) {
   const colors = require("colors");
   colors.setTheme({ debug: "cyan", error: "red", warn: "yellow" });
 
-  console.warn(
-    colors.warn(
-      "DEPRECATION WARNING: `fetchAndWrite` is deprecated and will be removed in a future version. Please use `convertToHTML` instead."
-    )
+  const showError = error => console.error(colors.error(error));
+  const showWarning = warning => console.warn(colors.warn(warning));
+
+  showWarning(
+    "DEPRECATION WARNING: `fetchAndWrite` is deprecated and will be removed in a future version. Please use `convertToHTML` instead."
   );
 
   const opts = {
     onError(error) {
-      console.error(
-        colors.error(`💥 ReSpec error: ${colors.debug(error.message)}`)
-      );
+      showError(`💥 ReSpec error: ${colors.debug(error.message)}`);
     },
     onWarning(warning) {
-      console.warn(
-        colors.warn(`⚠️ ReSpec warning: ${colors.debug(warning.message)}`)
-      );
+      showWarning(`⚠️ ReSpec warning: ${colors.debug(warning.message)}`);
     },
     ...options,
     devtools: options.debug,

--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -1,110 +1,96 @@
 /**
- * Exports fetchAndWrite() method, allowing programmatic control of the
+ * Exports convertToHTML() method, allowing programmatic control of the
  * spec generator.
- *
- * For usage, see example a https://github.com/w3c/respec/pull/692
  */
-/* jshint node: true, browser: false */
-"use strict";
-const os = require("os");
 const puppeteer = require("puppeteer");
-const colors = require("colors");
-const { mkdtemp, writeFile } = require("fs").promises;
-const path = require("path");
-colors.setTheme({
-  debug: "cyan",
-  error: "red",
-  warn: "yellow",
-  info: "blue",
-});
+const { mkdtemp } = require("fs").promises;
+const { tmpdir } = require("os");
 
 /**
  * Fetches a ReSpec "src" URL, and writes the processed static HTML to an "out" path.
  * @param {string} src A URL or filepath that is the ReSpec source.
- * @param {string | null | ""} out A path to write to. If null, goes to stdout. If "", then don't write, just return value.
- * @param {object} [whenToHalt] Allowing execution to stop without writing.
- * @param {boolean} [whenToHalt.haltOnError] Do not write if a ReSpec processing has an error.
- * @param {boolean} [whenToHalt.haltOnWarn] Do not write if a ReSpec processing has a warning.
  * @param {object} [options]
  * @param {number} [options.timeout] Milliseconds before processing should timeout.
- * @param {boolean} [options.disableSandbox] See https://peter.sh/experiments/chromium-command-line-switches/#no-sandbox
- * @param {boolean} [options.debug] Show the Chromium window with devtools open for debugging.
+ * @param {(error: RsError) => void} [options.onError] What to do if a ReSpec processing has an error. Does nothing by default.
+ * @param {(warning: RsError) => void} [options.onWarning] What to do if a ReSpec processing has a warning. Does nothing by default.
  * @param {boolean} [options.verbose] Log processing status to stdout.
- * @param {(error: RsError) => void} [options.onError] What to do if a ReSpec processing has an error. Logs to stderr by default.
- * @param {(warning: RsError) => void} [options.onWarning] What to do if a ReSpec processing has a warning. Logs to stderr by default.
- * @return {Promise<string>} Resolves with HTML when done writing. Rejects on errors.
+ * @param {boolean} [options.disableSandbox] See https://peter.sh/experiments/chromium-command-line-switches/#no-sandbox
+ * @param {boolean} [options.devtools] Show the Chromium window with devtools open for debugging.
+ * @return {Promise<{ html: string, errors: RsError[], warnings: RsError[] }>}
+ * @throws {Error} If failed to process.
  */
-async function fetchAndWrite(
-  src,
-  out,
-  whenToHalt = {},
-  {
+async function convertToHTML(src, options = {}) {
+  const {
     timeout = 300000,
-    disableSandbox = false,
     verbose = false,
-    debug = false,
-    onError = error =>
-      console.error(
-        colors.error(`💥 ReSpec error: ${colors.debug(error.message)}`)
-      ),
-    onWarning = warning =>
-      console.warn(
-        colors.warn(`⚠️ ReSpec warning: ${colors.debug(warning.message)}`)
-      ),
-  } = {}
-) {
+    disableSandbox = false,
+    devtools = false,
+  } = options;
+  if (typeof options.onError !== "function") {
+    options.onError = () => {};
+  }
+  if (typeof options.onWarning !== "function") {
+    options.onWarning = () => {};
+  }
+
   const timer = createTimer(timeout);
 
-  const log =
-    verbose && out !== null
-      ? msg => console.log(`[Timeout: ${timer.remaining}ms] ${msg}`)
-      : () => {};
+  const log = verbose
+    ? msg => console.log(`[Timeout: ${timer.remaining}ms] ${msg}`)
+    : () => {};
 
-  const userDataDir = await mkdtemp(`${os.tmpdir()}/respec2html-`);
-  const args = disableSandbox ? ["--no-sandbox"] : undefined;
+  /** @type {RsError[]} */
+  const errors = [];
+  /** @type {RsError[]} */
+  const warnings = [];
+  const onError = error => {
+    errors.push(error);
+    options.onError(error);
+  };
+  const onWarning = warning => {
+    warnings.push(warning);
+    options.onWarning(warning);
+  };
+
+  const userDataDir = await mkdtemp(`${tmpdir()}/respec2html-`);
+  const args = [];
+  if (disableSandbox) args.push("--no-sandbox");
+
   log("Launching browser");
-  const browser = await puppeteer.launch({
-    userDataDir,
-    args,
-    devtools: debug,
-  });
+  const browser = await puppeteer.launch({ userDataDir, args, devtools });
+
   try {
     const page = await browser.newPage();
-
-    const haltFlags = { error: false, warn: false };
-    handleConsoleMessages(page, haltFlags, onError, onWarning);
+    handleConsoleMessages(page, onError, onWarning);
 
     const url = new URL(src);
     log(`Navigating to ${url}`);
-    const response = await page.goto(url, { timeout });
+    const response = await page.goto(url.href, { timeout: timer.remaining });
     if (
       !response.ok() &&
       response.status() /* workaround: 0 means ok for local files */
     ) {
-      const warn = colors.warn(`📡 HTTP Error ${response.status()}:`);
       // don't show params, as they can contain the API key!
       const debugURL = `${url.origin}${url.pathname}`;
-      const msg = `${warn} ${colors.debug(debugURL)}`;
+      const msg = `📡 HTTP Error ${response.status()}: ${debugURL}`;
       throw new Error(msg);
     }
     log(`Navigation complete.`);
+
     await checkIfReSpec(page);
+    const version = await getVersion(page);
+    log(`Using ReSpec v${version.join(".")}`);
+
     log("Processing ReSpec document...");
-    const html = await generateHTML(page, url, timer);
+    const html = await generateHTML(page, timer, version, url);
     log("Processed document.");
-    const abortOnWarning = whenToHalt.haltOnWarn && haltFlags.warn;
-    const abortOnError = whenToHalt.haltOnError && haltFlags.error;
-    if (abortOnError || abortOnWarning) {
-      throw new Error(
-        `${abortOnError ? "Errors" : "Warnings"} found during processing.`
-      );
-    }
-    await write(out, html);
+
     // Race condition: Wait before page close for all console messages to be logged
     await new Promise(resolve => setTimeout(resolve, 1000));
     await page.close();
     log("Done.");
-    return html;
+
+    return { html, errors, warnings };
   } finally {
     await browser.close();
   }
@@ -112,24 +98,17 @@ async function fetchAndWrite(
 
 /**
  * @param {import("puppeteer").Page} page
- * @param {string} url
- * @param {ReturnType<typeof createTimer>} timer
+ * @typedef {[major: number, minor: number, patch: number]} ReSpecVersion
+ * @returns {Promise<ReSpecVersion>}
  */
-async function generateHTML(page, url, timer) {
+async function getVersion(page) {
   await page.waitForFunction(() => window.hasOwnProperty("respecVersion"));
-  const version = await page.evaluate(getVersion);
-  try {
-    return await page.evaluate(evaluateHTML, version, timer);
-  } catch (err) {
-    const msg = `\n😭  Sorry, there was an error generating the HTML. Please report this issue!\n${colors.debug(
-      `${
-        `Specification: ${url}\n` +
-        `ReSpec version: ${version.join(".")}\n` +
-        "File a bug: https://github.com/w3c/respec/\n"
-      }${err ? `Error: ${err.stack}\n` : ""}`
-    )}`;
-    throw new Error(msg);
-  }
+  return await page.evaluate(() => {
+    if (/^\D/.test(window.respecVersion)) {
+      return [123456789, 0, 0];
+    }
+    return window.respecVersion.split(".").map(str => parseInt(str, 10));
+  });
 }
 
 /**
@@ -138,35 +117,50 @@ async function generateHTML(page, url, timer) {
 async function checkIfReSpec(page) {
   const isRespecDoc = await page.evaluate(isRespec);
   if (!isRespecDoc) {
-    const msg = `${colors.warn(
-      "🕵️‍♀️  That doesn't seem to be a ReSpec document. Please check manually:"
-    )} ${colors.debug(page.url)}`;
+    const msg = `🕵️‍♀️  That doesn't seem to be a ReSpec document. Please check manually: ${page.url}`;
     throw new Error(msg);
   }
   return isRespecDoc;
-}
 
-async function isRespec() {
-  const query = "script[data-main*='profile-'], script[src*='respec']";
-  if (document.head.querySelector(query)) {
-    return true;
+  async function isRespec() {
+    const query = "script[data-main*='profile-'], script[src*='respec']";
+    if (document.head.querySelector(query)) {
+      return true;
+    }
+    await new Promise(resolve => {
+      document.onreadystatechange = () => {
+        if (document.readyState === "complete") resolve();
+      };
+      document.onreadystatechange();
+    });
+    await new Promise(resolve => {
+      setTimeout(resolve, 2000);
+    });
+    return Boolean(document.getElementById("respec-ui"));
   }
-  await new Promise(resolve => {
-    document.onreadystatechange = () => {
-      if (document.readyState === "complete") {
-        resolve();
-      }
-    };
-    document.onreadystatechange();
-  });
-  await new Promise(resolve => {
-    setTimeout(resolve, 2000);
-  });
-  return Boolean(document.getElementById("respec-ui"));
 }
 
 /**
- * @param {number[]} version
+ * @param {import("puppeteer").Page} page
+ * @param {ReturnType<typeof createTimer>} timer
+ * @param {ReSpecVersion} version
+ * @param {URL} url
+ */
+async function generateHTML(page, timer, version, url) {
+  try {
+    return await page.evaluate(evaluateHTML, version, timer);
+  } catch (err) {
+    const msg = `\n😭  Sorry, there was an error generating the HTML. Please report this issue!\n${`${
+      `Specification: ${url}\n` +
+      `ReSpec version: ${version.join(".")}\n` +
+      "File a bug: https://github.com/w3c/respec/\n"
+    }${err ? `Error: ${err.stack}\n` : ""}`}`;
+    throw new Error(msg);
+  }
+}
+
+/**
+ * @param {ReSpecVersion} version
  * @param {ReturnType<typeof createTimer>} timer
  */
 async function evaluateHTML(version, timer) {
@@ -205,13 +199,6 @@ async function evaluateHTML(version, timer) {
       setTimeout(() => reject(msg), ms);
     });
   }
-}
-
-function getVersion() {
-  if (window.respecVersion === "Developer Edition") {
-    return [123456789, 0, 0];
-  }
-  return window.respecVersion.split(".").map(str => parseInt(str, 10));
 }
 
 /**
@@ -273,24 +260,5 @@ function createTimer(duration) {
   };
 }
 
-/**
- * @param {string | null | ""} destination
- * @param {string} html
- */
-async function write(destination, html) {
-  switch (destination) {
-    case "":
-      break;
-    case null:
-      process.stdout.write(html);
-      break;
-    default: {
-      const newFilePath = path.isAbsolute(destination)
-        ? destination
-        : path.resolve(process.cwd(), destination);
-      await writeFile(newFilePath, html, "utf-8");
-    }
-  }
-}
-
-exports.fetchAndWrite = fetchAndWrite;
+module.exports = convertToHTML;
+exports.convertToHTML = convertToHTML;

--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -338,7 +338,6 @@ async function write(destination, html) {
   }
 }
 
-module.exports = convertToHTML;
 exports.convertToHTML = convertToHTML;
 exports.fetchAndWrite = fetchAndWrite;
 exports.write = write;

--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -20,19 +20,13 @@ const { tmpdir } = require("os");
  * @return {Promise<{ html: string, errors: RsError[], warnings: RsError[] }>}
  * @throws {Error} If failed to process.
  */
-async function convertToHTML(src, options = {}) {
+async function convertToHTML(src, options = { onError() {}, onWarning() {} }) {
   const {
     timeout = 300000,
     verbose = false,
     disableSandbox = false,
     devtools = false,
   } = options;
-  if (typeof options.onError !== "function") {
-    options.onError = () => {};
-  }
-  if (typeof options.onWarning !== "function") {
-    options.onWarning = () => {};
-  }
 
   const timer = createTimer(timeout);
 

--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -1,6 +1,5 @@
 /**
- * Exports convertToHTML() method, allowing programmatic control of the
- * spec generator.
+ * Exports toHTML() method, allowing programmatic control of the spec generator.
  */
 const puppeteer = require("puppeteer");
 const path = require("path");
@@ -20,7 +19,7 @@ const { tmpdir } = require("os");
  * @return {Promise<{ html: string, errors: RsError[], warnings: RsError[] }>}
  * @throws {Error} If failed to process.
  */
-async function convertToHTML(src, options = { onError() {}, onWarning() {} }) {
+async function toHTML(src, options = { onError() {}, onWarning() {} }) {
   const {
     timeout = 300000,
     verbose = false,
@@ -93,7 +92,7 @@ async function convertToHTML(src, options = { onError() {}, onWarning() {} }) {
 
 /**
  * Fetches a ReSpec "src" URL, and writes the processed static HTML to an "out" path.
- * @deprecated Please use `convertToHTML` instead.
+ * @deprecated Please use `toHTML` instead.
  * @param {string} src A URL or filepath that is the ReSpec source.
  * @param {string | null | ""} out A path to write to. If null, goes to stdout. If "", then don't write, just return value.
  * @param {object} [whenToHalt] Allowing execution to stop without writing.
@@ -116,7 +115,7 @@ async function fetchAndWrite(src, out, whenToHalt = {}, options = {}) {
   const showWarning = warning => console.warn(colors.warn(warning));
 
   showWarning(
-    "DEPRECATION WARNING: `fetchAndWrite` is deprecated and will be removed in a future version. Please use `convertToHTML` instead."
+    "DEPRECATION WARNING: `fetchAndWrite` is deprecated and will be removed in a future version. Please use `toHTML` instead."
   );
 
   const opts = {
@@ -129,7 +128,7 @@ async function fetchAndWrite(src, out, whenToHalt = {}, options = {}) {
     ...options,
     devtools: options.debug,
   };
-  const { html, errors, warnings } = await convertToHTML(src, opts);
+  const { html, errors, warnings } = await toHTML(src, opts);
 
   const abortOnWarning = whenToHalt.haltOnWarn && warnings.length;
   const abortOnError = whenToHalt.haltOnError && errors.length;
@@ -333,6 +332,6 @@ async function write(destination, html) {
   }
 }
 
-exports.convertToHTML = convertToHTML;
+exports.toHTML = toHTML;
 exports.fetchAndWrite = fetchAndWrite;
 exports.write = write;

--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -6,6 +6,8 @@ const path = require("path");
 const { mkdtemp, writeFile } = require("fs").promises;
 const { tmpdir } = require("os");
 
+const noop = () => {};
+
 /**
  * Fetches a ReSpec "src" URL, and writes the processed static HTML to an "out" path.
  * @param {string} src A URL or filepath that is the ReSpec source.
@@ -19,19 +21,25 @@ const { tmpdir } = require("os");
  * @return {Promise<{ html: string, errors: RsError[], warnings: RsError[] }>}
  * @throws {Error} If failed to process.
  */
-async function toHTML(src, options = { onError() {}, onWarning() {} }) {
+async function toHTML(src, options = {}) {
   const {
     timeout = 300000,
     verbose = false,
     disableSandbox = false,
     devtools = false,
   } = options;
+  if (typeof options.onError !== "function") {
+    options.onError = noop;
+  }
+  if (typeof options.onWarning !== "function") {
+    options.onWarning = noop;
+  }
 
   const timer = createTimer(timeout);
 
   const log = verbose
     ? msg => console.log(`[Timeout: ${timer.remaining}ms] ${msg}`)
-    : () => {};
+    : noop;
 
   /** @type {RsError[]} */
   const errors = [];

--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -115,11 +115,15 @@ async function convertToHTML(src, options = {}) {
  * @return {Promise<string>} Resolves with HTML when done writing. Rejects on errors.
  */
 async function fetchAndWrite(src, out, whenToHalt = {}, options = {}) {
-  console.warn(
-    "`fetchAndWrite` is deprecated and will be removed in a future version. Please use `convertToHTML` instead."
-  );
   const colors = require("colors");
   colors.setTheme({ debug: "cyan", error: "red", warn: "yellow" });
+
+  console.warn(
+    colors.warn(
+      "DEPRECATION WARNING: `fetchAndWrite` is deprecated and will be removed in a future version. Please use `convertToHTML` instead."
+    )
+  );
+
   const opts = {
     onError(error) {
       console.error(


### PR DESCRIPTION
## DEPRECATED:

- `fetchAndWrite` is deprecated (will be removed in future).

## BREAKING CHANGES:

- `--out=""` CLI option no longer writes to stdout.

## Node.js API Changes:

- `toHTML` is more structured and requires fewer arguments:
  - `toHTML` does not write output unlike `fetchAndWrite`.
  - `toHTML` returns processed HTML as well as errors & warnings.
  - `toHTML` does not have `haltOnError` and `haltOnWarning` object parameter.
  - `options.debug` in `toHTML` is renamed to `options.devtools`.
- Removed colors from errors and warnings returned from `toHTML` to make them easier to parse.
- ReSpec version being used is printed during processing.

### Example usage:

```js
const { toHTML } = require('respec');
try {
  const { html, errors, warnings } = await toHTML(src, options);
} catch (fatalError) {
  console.error(fatalError);
}
```

## CLI Improvements:

- Use `--out stdout` to write to stdout.
- Ignore `--out` option to ignore output. No need to pass `/dev/null` anymore.

## Internal:

- lots of refactoring and cleanup.
- functions are defined where used, and follow more consistent order.