### PR TITLE
fix(w3c/headers): show CR type in <h2>

### DIFF
--- a/src/w3c/templates/headers.js
+++ b/src/w3c/templates/headers.js
@@ -128,7 +128,7 @@ export default (conf, options) => {
     ${conf.logos.map(showLogo)} ${document.querySelector("h1#title")}
     ${getSpecSubTitleElem(conf)}
     <h2>
-      ${conf.prependW3C ? "W3C " : ""}${conf.textStatus}
+      ${conf.prependW3C ? "W3C " : ""}${conf.isCR ? ${conf.longStatus} : ${conf.textStatus}}
       <time class="dt-published" datetime="${conf.dashDate}"
         >${conf.publishHumanDate}</time
       >${conf.modificationDate
@@ -136,7 +136,6 @@ export default (conf, options) => {
           ${inPlaceModificationDate(conf.modificationDate)}`
         : ""}
     </h2>
-    ${conf.isCR ? html`<h3>${conf.isCRDraft ? "Draft" : "Snapshot"}</h3>` : ""}
     <dl>
       ${!conf.isNoTrack
         ? html`

--- a/src/w3c/templates/headers.js
+++ b/src/w3c/templates/headers.js
@@ -128,7 +128,7 @@ export default (conf, options) => {
     ${conf.logos.map(showLogo)} ${document.querySelector("h1#title")}
     ${getSpecSubTitleElem(conf)}
     <h2>
-      ${conf.prependW3C ? "W3C " : ""}${conf.isCR ? ${conf.longStatus} : ${conf.textStatus}}
+      ${conf.prependW3C ? "W3C " : ""}${conf.isCR ? `${conf.longStatus}` : `${conf.textStatus}`}
       <time class="dt-published" datetime="${conf.dashDate}"
         >${conf.publishHumanDate}</time
       >${conf.modificationDate

--- a/src/w3c/templates/headers.js
+++ b/src/w3c/templates/headers.js
@@ -128,7 +128,9 @@ export default (conf, options) => {
     ${conf.logos.map(showLogo)} ${document.querySelector("h1#title")}
     ${getSpecSubTitleElem(conf)}
     <h2>
-      ${conf.prependW3C ? "W3C " : ""}${conf.isCR ? `${conf.longStatus}` : `${conf.textStatus}`}
+      ${conf.prependW3C ? "W3C " : ""}${conf.isCR
+        ? `${conf.longStatus}`
+        : `${conf.textStatus}`}
       <time class="dt-published" datetime="${conf.dashDate}"
         >${conf.publishHumanDate}</time
       >${conf.modificationDate


### PR DESCRIPTION
With the release of process 2020, we asked to specify the type of CR (Snapshot/Draft) in a `<h3>` following the `<h2>` in the headers. We've been asked to integrate this in a single header (https://github.com/w3c/specberus/issues/1006) instead.
We are going to [update pubrules to only check the `h2`](https://github.com/w3c/specberus/pull/1018) early next week so that PR is to prepare respec for that change.

/cc @fantasai @plehegar @jennyliang220 