### PR TITLE
fix(core/dfn-finder): Properly handle optional arguments in data-lt

### DIFF
--- a/src/core/dfn-finder.js
+++ b/src/core/dfn-finder.js
@@ -96,11 +96,7 @@ function generateMethodNamesWithArgs(operationName, argsAst) {
   const requiredOperation = `${operationName}(${requiredArgs})`;
   operationNames.push(requiredOperation);
   const optionalOps = optional.map((_, index) => {
-    const optionalArgs = optional.slice(0, index + 1).join(", ");
-    const args =
-      requiredArgs && optionalArgs
-        ? `${requiredArgs}, ${optionalArgs}`
-        : requiredArgs || optionalArgs || "";
+    const args = [...required, ...optional.slice(0, index + 1)].join(", ");
     const result = `${operationName}(${args})`;
     return result;
   });

--- a/src/core/dfn-finder.js
+++ b/src/core/dfn-finder.js
@@ -97,9 +97,11 @@ function generateMethodNamesWithArgs(operationName, argsAst) {
   operationNames.push(requiredOperation);
   const optionalOps = optional.map((_, index) => {
     const optionalArgs = optional.slice(0, index + 1).join(", ");
-    const result = `${operationName}(${requiredArgs}${
-      optionalArgs ? `, ${optionalArgs}` : ""
-    })`;
+    const args =
+      requiredArgs && optionalArgs
+        ? `${requiredArgs}, ${optionalArgs}`
+        : requiredArgs || optionalArgs || "";
+    const result = `${operationName}(${args})`;
     return result;
   });
   operationNames.push(...optionalOps);

--- a/tests/spec/core/dfn-finder-spec.js
+++ b/tests/spec/core/dfn-finder-spec.js
@@ -63,4 +63,31 @@ describe("Core — Definition finder", () => {
     expect(baz.dataset.localLt).toBe("Foo.baz|Foo.baz()|baz");
     expect(baz.dataset.lt).toBe("baz()");
   });
+
+  it("should include optional arguments for operations", async () => {
+    const bodyText = `
+      <section data-dfn-for="Foo">
+        <h2>Test section</h2>
+        <pre class="idl">
+          [Exposed=Window]
+          interface Foo {
+            undefined bar(DOMString arg, optional DOMString opt);
+            undefined baz(optional DOMString opt);
+          };
+        </pre>
+        <dfn id="bar">bar</dfn>
+        <dfn id="baz">baz()</dfn>
+      </section>`;
+    const ops = {
+      config: makeBasicConfig(),
+      body: makeDefaultBody() + bodyText,
+    };
+    const doc = await makeRSDoc(ops);
+    const bar = doc.getElementById("bar");
+    expect(bar.dataset.localLt).toBe("Foo.bar|Foo.bar()|bar");
+    expect(bar.dataset.lt).toBe("bar()|bar(arg)|bar(arg, opt)");
+    const baz = doc.getElementById("baz");
+    expect(baz.dataset.localLt).toBe("Foo.baz|Foo.baz()|baz");
+    expect(baz.dataset.lt).toBe("baz()|baz(opt)");
+  });
 });

--- a/tests/spec/core/dfn-finder-spec.js
+++ b/tests/spec/core/dfn-finder-spec.js
@@ -2,8 +2,7 @@
 
 import {
   flushIframes,
-  makeBasicConfig,
-  makeDefaultBody,
+  makeStandardOps,
   makeRSDoc,
 } from "../SpecHelper.js";
 
@@ -23,10 +22,7 @@ describe("Core — Definition finder", () => {
         <dfn data-dfn-for="Foo" data-lt="bar()">bar</dfn>
         <dfn>Foo</dfn>
       </section>`;
-    const ops = {
-      config: makeBasicConfig(),
-      body: makeDefaultBody() + bodyText,
-    };
+    const ops = makeStandardOps(null, bodyText);
     const doc = await makeRSDoc(ops);
     const [barDfn, fooDfn] = doc.getElementsByTagName("dfn");
     expect(barDfn.dataset.lt).toBe("bar()");
@@ -51,10 +47,7 @@ describe("Core — Definition finder", () => {
         <dfn id="bar">bar</dfn>
         <dfn id="baz">baz()</dfn>
       </section>`;
-    const ops = {
-      config: makeBasicConfig(),
-      body: makeDefaultBody() + bodyText,
-    };
+    const ops = makeStandardOps(null, bodyText);
     const doc = await makeRSDoc(ops);
     const bar = doc.getElementById("bar");
     expect(bar.dataset.localLt).toBe("Foo.bar|Foo.bar()|bar");
@@ -78,10 +71,7 @@ describe("Core — Definition finder", () => {
         <dfn id="bar">bar</dfn>
         <dfn id="baz">baz()</dfn>
       </section>`;
-    const ops = {
-      config: makeBasicConfig(),
-      body: makeDefaultBody() + bodyText,
-    };
+    const ops = makeStandardOps(null, bodyText);
     const doc = await makeRSDoc(ops);
     const bar = doc.getElementById("bar");
     expect(bar.dataset.localLt).toBe("Foo.bar|Foo.bar()|bar");

--- a/tests/spec/core/dfn-finder-spec.js
+++ b/tests/spec/core/dfn-finder-spec.js
@@ -1,10 +1,6 @@
 "use strict";
 
-import {
-  flushIframes,
-  makeStandardOps,
-  makeRSDoc,
-} from "../SpecHelper.js";
+import { flushIframes, makeRSDoc, makeStandardOps } from "../SpecHelper.js";
 
 describe("Core — Definition finder", () => {
   afterAll(flushIframes);


### PR DESCRIPTION
This update fixes the generation of the `data-lt` attribute when an operation only has optional arguments.

The code added a `, ` prefix before the list of optional arguments, regardless of whether the operation had mandatory arguments as well, leading to names such as `methodName(, options)` instead of `methodName(options)` (see issue #3200).