### PR TITLE
chore(ci/changelog): update create-pull-request to v3

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -18,7 +18,7 @@ jobs:
       - run: github_changelog_generator -u w3c -p respec --no-unreleased
         env:
           CHANGELOG_GITHUB_TOKEN: ${{ secrets.CHANGELOG_GITHUB_TOKEN }}
-      - uses: peter-evans/create-pull-request@v2
+      - uses: peter-evans/create-pull-request@v3
         with:
           commit-message: "chore(CHANGELOG): regenerate"
           title: "chore(CHANGELOG): regenerate"


### PR DESCRIPTION
This will get rid of `set-env` and `add-path` deprecation errors in GitHub pages (example: https://github.com/w3c/respec/actions/runs/378730123)