### PR TITLE
chore(package.json): use funding option

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "arrowParens": "avoid"
   },
   "snyk": true,
-  "collective": {
+  "funding": {
     "type": "opencollective",
     "url": "https://opencollective.com/respec"
   }


### PR DESCRIPTION
Use `funding` as per [npm docs](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#funding). The `collective` one was used when we had `opencollective-postinstall` enabled.
Pretty sure it's not effective at all (does anyone even run `npm fund` to find projects in funding need!), but lets take our chances.