### PR TITLE
chore(bundle): mangle object properties to get smaller bundle

### DIFF
--- a/tools/builder.js
+++ b/tools/builder.js
@@ -6,6 +6,7 @@ const { promises: fsp } = require("fs");
 const path = require("path");
 const { rollup } = require("rollup");
 const alias = require("rollup-plugin-alias");
+const { terser } = require("rollup-plugin-terser");
 const CleanCSS = require("clean-css");
 const commandLineArgs = require("command-line-args");
 const getUsage = require("command-line-usage");
@@ -127,7 +128,7 @@ const Builder = {
     const inputOptions = {
       input: require.resolve(`../profiles/${name}.js`),
       plugins: [
-        !debug && require("rollup-plugin-terser").terser(),
+        !debug && terser({ mangle: { properties: true } }),
         alias({
           resolve: [".css", ".svg", ".js"],
           entries: [

--- a/tools/builder.js
+++ b/tools/builder.js
@@ -128,7 +128,7 @@ const Builder = {
     const inputOptions = {
       input: require.resolve(`../profiles/${name}.js`),
       plugins: [
-        !debug && terser({ mangle: { properties: true } }),
+        !debug && terser({ mangle: { properties: { undeclared: true } } }),
         alias({
           resolve: [".css", ".svg", ".js"],
           entries: [


### PR DESCRIPTION
Mangles long keys names in objects to get smaller bundle. Keys like [`no_issues_in_spec`](https://github.com/w3c/respec/blob/33532d9f29b5188614ca16d75098eaa9df86875a/src/core/issues-notes.js#L21-L29) get renamed to have smaller names.


|              | Before |  After | Difference |
| ------------ | -----: | -----: | ---------: |
| Uncompressed | 306548 | 282476 |      24072 |
| Brotli       |  84039 |  81095 |       2944 |
| Gzip         |  97392 |  94140 |       3252 |
