### PR TITLE
chore: gitignore vscode settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,4 @@ js/deps/builds
 !js/profile-geonovum.js
 !js/profile-w3c.js
 .vscode/*
-!.vscode/settings.json
 !.vscode/tasks.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-  "editor.formatOnSave": true,
-  "files.insertFinalNewline": true,
-  "prettier.trailingComma": "es5",
-  "editor.tabSize": 2
-}


### PR DESCRIPTION
Everything is already in `.editorconfig` and `package.json`. Ignoring vscode setting respects people's preferences.