### PR TITLE
fix(anchor-expander): trailing ws when expanding headers

### DIFF
--- a/src/core/anchor-expander.js
+++ b/src/core/anchor-expander.js
@@ -114,6 +114,10 @@ function processHeading(heading, a) {
   a.append(...children);
   if (hadSelfLink) a.prepend("§\u00A0");
   a.classList.add("sec-ref");
+  // Trim stray whitespace of the last text node (see bug #3265).
+  if (a.lastChild.nodeType === Node.TEXT_NODE) {
+    a.lastChild.textContent = a.lastChild.textContent.trimEnd();
+  }
 }
 
 function localize(matchingElement, newElement) {

--- a/tests/spec/core/anchor-expander-spec.js
+++ b/tests/spec/core/anchor-expander-spec.js
@@ -91,7 +91,7 @@ describe("Core - anchor-expander", () => {
       </section>
       <section>
         <h2>Some other section</section>
-        <p id="expansion">[[[#myid]]]</a></p>
+        <p id="expansion">[[[#myid]]]</p>
         <p id="expansion2"><a href="#myid" dir="ltr" lang=""></a></p>
       </section>
     `;
@@ -103,5 +103,34 @@ describe("Core - anchor-expander", () => {
     const secondExpansion = doc.querySelector("#expansion2 a");
     expect(secondExpansion.dir).toBe("ltr");
     expect(secondExpansion.lang).toBe("");
+  });
+
+  it("it removes trailing whitespace when expanding headers", async () => {
+    const body = `
+      <section lang="ar" class="introductory">
+        <h2 id="someid">
+          This
+          <code>is</code>
+          a test
+        </h2>
+      </section>
+      <section>
+        <h2>Some other section</section>
+        <p id="expansion1">[[[#someid]]].</p>
+        <p id="expansion2"><a href="#someid"></a>!</p>
+      </section>
+    `;
+    const ops = makeStandardOps({}, body);
+    const doc = await makeRSDoc(ops);
+
+    const p1 = doc.getElementById("expansion1");
+    const { textContent: text1 } = p1.querySelector("a").lastChild;
+    expect(text1.endsWith("a test")).toBeTrue();
+    expect(p1.textContent.endsWith("a test.")).toBeTrue();
+
+    const p2 = doc.getElementById("expansion2");
+    const { textContent: text2 } = p2.querySelector("a").lastChild;
+    expect(text2.endsWith("a test")).toBeTrue();
+    expect(p2.textContent.endsWith("a test!")).toBeTrue();
   });
 });


### PR DESCRIPTION
closes #3265 