### PR TITLE
fix(w3c): improve license + unofficial status support

### DIFF
--- a/src/core/ui.js
+++ b/src/core/ui.js
@@ -275,7 +275,7 @@ function rsErrorToHTML(err) {
   }
 
   const plugin = err.plugin ? `(${err.plugin}): ` : "";
-  const hint = err.hint ? ` ${err.hint}.` : "";
+  const hint = err.hint ? ` ${err.hint}` : "";
   const elements = Array.isArray(err.elements)
     ? ` Occurred at: ${joinAnd(err.elements.map(generateMarkdownLink))}.`
     : "";

--- a/src/w3c/defaults.js
+++ b/src/w3c/defaults.js
@@ -24,7 +24,6 @@ const w3cDefaults = {
     "wpt-tests-exist": false,
   },
   doJsonLd: false,
-  license: "w3c-software-doc",
   logos: [],
   xref: true,
 };
@@ -42,7 +41,11 @@ export function run(conf) {
 
   if (conf.specStatus && conf.specStatus.toLowerCase() !== "unofficial") {
     w3cDefaults.logos.push(w3cLogo);
+    if (!conf.hasOwnProperty("license")) {
+      w3cDefaults.license = "w3c-software-doc";
+    }
   }
+
   Object.assign(conf, {
     ...coreDefaults,
     ...w3cDefaults,

--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -262,7 +262,7 @@ export function run(conf) {
       const licensesKeys = [...licenses.keys()]
         .map(key => `\`${key}\``)
         .join(", ");
-      const hint = `Please explicitly set \`license\` to one of: ${licensesKeys}`;
+      const hint = `Please explicitly set \`license\` to one of: ${licensesKeys}.`;
       showError(msg, name, { hint });
       conf.license = "cc-by";
     }
@@ -275,7 +275,7 @@ export function run(conf) {
   conf.isW3CSoftAndDocLicense = conf.license === "w3c-software-doc";
   if (!conf.isUnofficial && ["cc-by"].includes(conf.license)) {
     const msg = `You cannot use license "\`${conf.license}\`" with W3C Specs.`;
-    const hint = `Please set \`license\` to "w3c-software-doc" instead`;
+    const hint = `Please set \`license\` to "w3c-software-doc" instead.`;
     showError(msg, name, { hint });
   }
   conf.licenseInfo = licenses.get(conf.license);
@@ -413,9 +413,10 @@ export function run(conf) {
       !conf.isNoTrack &&
       !conf.isSubmission
     ) {
-      const msg = "Document on track but no previous version";
+      const msg = "Document on track but no previous version.";
       const hint =
-        "Add `previousMaturity`, and `previousPublishDate` to ReSpec's config.";
+        "Add [`previousMaturity`](https://respec.org/docs/#previousMaturity) " +
+        "and [`previousPublishDate`](https://respec.org/docs/#previousPublishDate) to ReSpec's config.";
       showError(msg, name, { hint });
     }
     if (!conf.prevVersion) conf.prevVersion = "";
@@ -424,8 +425,11 @@ export function run(conf) {
     conf.prevRecURI = `https://www.w3.org/TR/${conf.prevRecShortname}`;
   const peopCheck = function (it) {
     if (!it.name) {
-      const msg = "All authors and editors must have a name.";
-      showError(msg, name);
+      const msg = "All authors and editors must have a `name` property.";
+      const hint =
+        "See [Person](https://respec.org/docs/#person) configuration for available options.";
+
+      showError(msg, name, { hint });
     }
     if (it.orcid) {
       try {
@@ -492,7 +496,9 @@ export function run(conf) {
   conf.isRec = conf.isRecTrack && conf.specStatus === "REC";
   if (conf.isRec && !conf.errata) {
     const msg = "Recommendations must have an errata link.";
-    showError(msg, name);
+    const hint =
+      "Add an [`errata`](https://respec.org/docs/#errata) URL to your respecConfig.";
+    showError(msg, name, { hint });
   }
   conf.prependW3C = !conf.isUnofficial;
   conf.isED = conf.specStatus === "ED";
@@ -510,8 +516,10 @@ export function run(conf) {
     conf.wgPatentPolicy &&
     !["PP2017", "PP2020"].includes(conf.wgPatentPolicy)
   ) {
-    const msg = `\`wgPatentPolicy\` config option must be either 'PP2017' or 'PP2020'.`;
-    showError(msg, name);
+    const msg =
+      "Invalid [`wgPatentPolicy`](https://respec.org/docs#wgPatentPolicy) value.";
+    const hint = 'Please use `"PP2017"` or `"PP2020"`.';
+    showError(msg, name, { hint });
   }
   if (conf.hasOwnProperty("wgPatentURI") && !Array.isArray(conf.wgPatentURI)) {
     Object.defineProperty(conf, "wgId", {

--- a/src/w3c/templates/headers.js
+++ b/src/w3c/templates/headers.js
@@ -290,11 +290,7 @@ function renderCopyright(conf) {
   if (conf.isUnofficial && conf.licenseInfo) {
     return html`<p class="copyright">
       This document is licensed under a
-      ${linkLicense(
-        conf.licenseInfo.name,
-        conf.licenseInfo.url,
-        "subfoot"
-      )}
+      ${linkLicense(conf.licenseInfo.name, conf.licenseInfo.url, "subfoot")}
       (${conf.licenseInfo.short}).
     </p>`;
   }

--- a/src/w3c/templates/headers.js
+++ b/src/w3c/templates/headers.js
@@ -7,7 +7,7 @@ import showPeople from "../../core/templates/show-people.js";
 
 const name = "w3c/templates/headers";
 
-const ccLicense = "https://creativecommons.org/licenses/by/4.0/";
+const ccLicense = "https://creativecommons.org/licenses/by/4.0/legalcode";
 const w3cLicense = "https://www.w3.org/Consortium/Legal/copyright-documents";
 const legalDisclaimer =
   "https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer";
@@ -282,25 +282,23 @@ function renderCopyright(conf) {
   }
   if (conf.hasOwnProperty("overrideCopyright")) {
     const msg = "The `overrideCopyright` configuration option is deprecated.";
-    const hint = 'Please use `<p class="copyright">` instead.';
+    const hint =
+      'Please add a `<p class="copyright">` element directly to your document instead';
     showWarning(msg, name, { hint });
+    return html`${[conf.overrideCopyright]}`;
   }
-  return conf.isUnofficial
-    ? conf.additionalCopyrightHolders
-      ? html`<p class="copyright">${[conf.additionalCopyrightHolders]}</p>`
-      : conf.overrideCopyright
-      ? [conf.overrideCopyright]
-      : html`<p class="copyright">
-          This document is licensed under a
-          ${linkLicense(
-            "Creative Commons Attribution 4.0 License",
-            ccLicense,
-            "subfoot"
-          )}.
-        </p>`
-    : conf.overrideCopyright
-    ? [conf.overrideCopyright]
-    : renderOfficialCopyright(conf);
+  if (conf.isUnofficial && conf.licenseInfo) {
+    return html`<p class="copyright">
+      This document is licensed under a
+      ${linkLicense(
+        `${conf.licenseInfo.name}`,
+        conf.licenseInfo.url,
+        "subfoot"
+      )}
+      (${conf.licenseInfo.short}).
+    </p>`;
+  }
+  return renderOfficialCopyright(conf);
 }
 
 function renderOfficialCopyright(conf) {

--- a/src/w3c/templates/headers.js
+++ b/src/w3c/templates/headers.js
@@ -291,7 +291,7 @@ function renderCopyright(conf) {
     return html`<p class="copyright">
       This document is licensed under a
       ${linkLicense(
-        `${conf.licenseInfo.name}`,
+        conf.licenseInfo.name,
         conf.licenseInfo.url,
         "subfoot"
       )}

--- a/tests/spec/w3c/defaults-spec.js
+++ b/tests/spec/w3c/defaults-spec.js
@@ -6,7 +6,7 @@ describe("W3C — Defaults", () => {
   afterAll(flushIframes);
   it("sets sensible defaults for w3c specs", async () => {
     const ops = {
-      config: { editors: [{ name: "foo" }] },
+      config: { editors: [{ name: "foo" }], specStatus: "base" },
       body: makeDefaultBody(),
     };
     const doc = await makeRSDoc(ops);

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -1023,7 +1023,7 @@ describe("W3C — Headers", () => {
       ops.config = {
         shortName: "whatever",
         specStatus: "unofficial",
-        licenses: "not a thing",
+        license: "not a thing",
         editors: [{ name: "foo" }],
       };
       const doc = await makeRSDoc(ops);

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -1001,21 +1001,102 @@ describe("W3C — Headers", () => {
     });
   });
 
-  describe("license - w3c-software-doc", () => {
-    it("includes the W3C Software and Document Notice and License (w3c-software-doc)", async () => {
+  describe("license configuration", () => {
+    it("defaults to cc-by when spec status is unofficial", async () => {
       const ops = makeStandardOps();
-      const newProps = {
-        specStatus: "FPWD",
-        license: "w3c-software-doc",
+      ops.config = {
+        shortName: "whatever",
+        specStatus: "unofficial",
+        editors: [{ name: "foo" }],
       };
-      Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
       const licenses = doc.querySelectorAll("div.head a[rel=license]");
       expect(licenses).toHaveSize(1);
       expect(licenses[0].tagName).toBe("A");
       expect(licenses[0].href).toBe(
+        "https://creativecommons.org/licenses/by/4.0/legalcode"
+      );
+    });
+
+    it("falls back to cc-by when license is unknown and spec status is unofficial", async () => {
+      const ops = makeStandardOps();
+      ops.config = {
+        shortName: "whatever",
+        specStatus: "unofficial",
+        licenses: "not a thing",
+        editors: [{ name: "foo" }],
+      };
+      const doc = await makeRSDoc(ops);
+      const licenses = doc.querySelectorAll("div.head a[rel=license]");
+      expect(licenses).toHaveSize(1);
+      expect(licenses[0].tagName).toBe("A");
+      expect(licenses[0].href).toBe(
+        "https://creativecommons.org/licenses/by/4.0/legalcode"
+      );
+    });
+
+    it("includes the W3C Software and Document Notice and License (w3c-software-doc)", async () => {
+      const ops = makeStandardOps();
+      ops.config = {
+        specStatus: "FPWD",
+        license: "w3c-software-doc",
+        shortName: "whatever",
+        editors: [{ name: "foo" }],
+      };
+      const doc = await makeRSDoc(ops);
+      const licenses = doc.querySelectorAll("div.head a[rel=license]");
+      expect(licenses).toHaveSize(1);
+      expect(licenses[0].href).toBe(
         "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"
       );
+    });
+
+    it("supports the W3C Document Notice and License (w3c-software)", async () => {
+      const ops = makeStandardOps();
+      const newProps = {
+        specStatus: "unofficial",
+        license: "w3c-software",
+      };
+      Object.assign(ops.config, newProps);
+      const doc = await makeRSDoc(ops);
+      const licenses = doc.querySelectorAll("div.head a[rel=license]");
+      expect(licenses).toHaveSize(1);
+      expect(licenses[0].href).toBe(
+        "https://www.w3.org/Consortium/Legal/2002/copyright-software-20021231"
+      );
+    });
+
+    it("supports cc0 when spec status is unofficial", async () => {
+      const ops = makeStandardOps();
+      ops.config = {
+        specStatus: "unofficial",
+        license: "cc0",
+        shortName: "whatever",
+        editors: [{ name: "foo" }],
+      };
+      const doc = await makeRSDoc(ops);
+      const licenses = doc.querySelectorAll("div.head a[rel=license]");
+      expect(licenses).toHaveSize(1);
+      expect(licenses[0].tagName).toBe("A");
+      expect(licenses[0].href).toBe(
+        "https://creativecommons.org/publicdomain/zero/1.0/"
+      );
+    });
+
+    it("makes sure that p.copyright wins", async () => {
+      const ops = makeStandardOps();
+      ops.body += "<p class='copyright'>pass</p>";
+      ops.config = {
+        specStatus: "unofficial",
+        license: "cc0",
+        shortName: "whatever",
+        editors: [{ name: "foo" }],
+      };
+      const doc = await makeRSDoc(ops);
+      const copyright = doc.querySelectorAll("div.head p.copyright");
+      expect(copyright).toHaveSize(1);
+      expect(copyright[0].tagName).toBe("P");
+      expect(copyright[0].textContent).toBe("pass");
     });
   });
 
@@ -1239,18 +1320,6 @@ describe("W3C — Headers", () => {
       const doc = await makeRSDoc(ops);
       expect(doc.querySelector(".head .copyright").textContent).toMatch(
         /XXX\s+&\s+the\s+Contributors\s+to\s+the/
-      );
-    });
-    it("takes additionalCopyrightHolders into account when spec is unofficial", async () => {
-      const ops = makeStandardOps();
-      const newProps = {
-        specStatus: "unofficial",
-        additionalCopyrightHolders: "XXX",
-      };
-      Object.assign(ops.config, newProps);
-      const doc = await makeRSDoc(ops);
-      expect(doc.querySelector(".head .copyright").textContent.trim()).toBe(
-        "XXX"
       );
     });
 

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -1003,12 +1003,11 @@ describe("W3C — Headers", () => {
 
   describe("license configuration", () => {
     it("defaults to cc-by when spec status is unofficial", async () => {
-      const ops = makeStandardOps();
-      ops.config = {
+      const ops = makeStandardOps({
         shortName: "whatever",
         specStatus: "unofficial",
-        editors: [{ name: "foo" }],
-      };
+      });
+
       const doc = await makeRSDoc(ops);
       const licenses = doc.querySelectorAll("div.head a[rel=license]");
       expect(licenses).toHaveSize(1);

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -1018,13 +1018,12 @@ describe("W3C — Headers", () => {
     });
 
     it("falls back to cc-by when license is unknown and spec status is unofficial", async () => {
-      const ops = makeStandardOps();
-      ops.config = {
+      const ops = makeStandardOps({
         shortName: "whatever",
         specStatus: "unofficial",
         license: "not a thing",
         editors: [{ name: "foo" }],
-      };
+      });
       const doc = await makeRSDoc(ops);
       const licenses = doc.querySelectorAll("div.head a[rel=license]");
       expect(licenses).toHaveSize(1);
@@ -1035,13 +1034,12 @@ describe("W3C — Headers", () => {
     });
 
     it("includes the W3C Software and Document Notice and License (w3c-software-doc)", async () => {
-      const ops = makeStandardOps();
-      ops.config = {
+      const ops = makeStandardOps({
         specStatus: "FPWD",
         license: "w3c-software-doc",
         shortName: "whatever",
         editors: [{ name: "foo" }],
-      };
+      });
       const doc = await makeRSDoc(ops);
       const licenses = doc.querySelectorAll("div.head a[rel=license]");
       expect(licenses).toHaveSize(1);
@@ -1051,12 +1049,10 @@ describe("W3C — Headers", () => {
     });
 
     it("supports the W3C Document Notice and License (w3c-software)", async () => {
-      const ops = makeStandardOps();
-      const newProps = {
+      const ops = makeStandardOps({
         specStatus: "unofficial",
         license: "w3c-software",
-      };
-      Object.assign(ops.config, newProps);
+      });
       const doc = await makeRSDoc(ops);
       const licenses = doc.querySelectorAll("div.head a[rel=license]");
       expect(licenses).toHaveSize(1);
@@ -1066,13 +1062,12 @@ describe("W3C — Headers", () => {
     });
 
     it("supports cc0 when spec status is unofficial", async () => {
-      const ops = makeStandardOps();
-      ops.config = {
+      const ops = makeStandardOps({
         specStatus: "unofficial",
         license: "cc0",
         shortName: "whatever",
         editors: [{ name: "foo" }],
-      };
+      });
       const doc = await makeRSDoc(ops);
       const licenses = doc.querySelectorAll("div.head a[rel=license]");
       expect(licenses).toHaveSize(1);
@@ -1083,14 +1078,15 @@ describe("W3C — Headers", () => {
     });
 
     it("makes sure that p.copyright wins", async () => {
-      const ops = makeStandardOps();
-      ops.body += "<p class='copyright'>pass</p>";
-      ops.config = {
+      const config = {
         specStatus: "unofficial",
         license: "cc0",
         shortName: "whatever",
         editors: [{ name: "foo" }],
       };
+      const body = "<p class='copyright'>pass</p>";
+      const ops = makeStandardOps(config, body);
+
       const doc = await makeRSDoc(ops);
       const copyright = doc.querySelectorAll("div.head p.copyright");
       expect(copyright).toHaveSize(1);


### PR DESCRIPTION
Closes #3064 

It no longer hard codes cc-by into the template, which was overriding license selection. 