### PR TITLE
refactor(core): run global plugins like regular plugins

### DIFF
--- a/src/core/base-runner.js
+++ b/src/core/base-runner.js
@@ -4,8 +4,8 @@
 import "./include-config.js";
 import "./override-configuration.js";
 import { init as initReSpecGlobal } from "./respec-global.js";
-import { done as postProcessDone } from "./post-process.js";
-import { done as preProcessDone } from "./pre-process.js";
+import { run as postProcess } from "./post-process.js";
+import { run as preProcess } from "./pre-process.js";
 import { pub } from "./pubsubhub.js";
 import { removeReSpec } from "./utils.js";
 
@@ -53,7 +53,7 @@ export async function runAll(plugs) {
 
   pub("start-all", respecConfig);
   performance.mark(`${name}-start`);
-  await preProcessDone;
+  await preProcess(respecConfig);
   const runnables = plugs.filter(isRunnableModule).map(toRunnable);
   for (const task of runnables) {
     try {
@@ -63,7 +63,7 @@ export async function runAll(plugs) {
     }
   }
   pub("plugins-done", respecConfig);
-  await postProcessDone;
+  await postProcess(respecConfig);
   pub("end-all");
   removeReSpec(document);
   performance.mark(`${name}-end`);

--- a/src/core/base-runner.js
+++ b/src/core/base-runner.js
@@ -1,9 +1,9 @@
 // @ts-check
 // Module core/base-runner
 // The module in charge of running the whole processing pipeline.
-import "./include-config.js";
-import "./override-configuration.js";
+import { run as includeConfig } from "./include-config.js";
 import { init as initReSpecGlobal } from "./respec-global.js";
+import { run as overrideConfig } from "./override-configuration.js";
 import { run as postProcess } from "./post-process.js";
 import { run as preProcess } from "./pre-process.js";
 import { pub } from "./pubsubhub.js";
@@ -52,6 +52,8 @@ export async function runAll(plugs) {
   initReSpecGlobal();
 
   pub("start-all", respecConfig);
+  includeConfig(respecConfig);
+  overrideConfig(respecConfig);
   performance.mark(`${name}-start`);
   await preProcess(respecConfig);
   const runnables = plugs.filter(isRunnableModule).map(toRunnable);

--- a/src/core/include-config.js
+++ b/src/core/include-config.js
@@ -4,19 +4,23 @@
 import { sub } from "./pubsubhub.js";
 export const name = "core/include-config";
 
-const userConfig = {};
-const amendConfig = newValues => Object.assign(userConfig, newValues);
 const removeList = ["githubToken", "githubUser"];
 
-sub("start-all", amendConfig);
-sub("amend-user-config", amendConfig);
-sub("end-all", () => {
-  const script = document.createElement("script");
-  script.id = "initialUserConfig";
-  script.type = "application/json";
-  for (const prop of removeList) {
-    if (prop in userConfig) delete userConfig[prop];
-  }
-  script.innerHTML = JSON.stringify(userConfig, null, 2);
-  document.head.appendChild(script);
-});
+export function run(config) {
+  const userConfig = {};
+  const amendConfig = newValues => Object.assign(userConfig, newValues);
+
+  amendConfig(config);
+  sub("amend-user-config", amendConfig);
+
+  sub("end-all", () => {
+    const script = document.createElement("script");
+    script.id = "initialUserConfig";
+    script.type = "application/json";
+    for (const prop of removeList) {
+      if (prop in userConfig) delete userConfig[prop];
+    }
+    script.innerHTML = JSON.stringify(userConfig, null, 2);
+    document.head.appendChild(script);
+  });
+}

--- a/src/core/override-configuration.js
+++ b/src/core/override-configuration.js
@@ -5,11 +5,11 @@
 // tweaks to a document before generating the snapshot, without mucking with the source.
 // For example, you can change the status and date by appending:
 //      ?specStatus=LC&publishDate=2012-03-15
-import { pub, sub } from "./pubsubhub.js";
+import { pub } from "./pubsubhub.js";
 
 export const name = "core/override-configuration";
 
-function overrideConfig(config) {
+export function run(config) {
   const params = new URLSearchParams(document.location.search);
   const overrideEntries = Array.from(params)
     .filter(([key, value]) => !!key && !!value)
@@ -28,4 +28,3 @@ function overrideConfig(config) {
   Object.assign(config, overrideProps);
   pub("amend-user-config", overrideProps);
 }
-sub("start-all", overrideConfig, { once: true });

--- a/src/core/post-process.js
+++ b/src/core/post-process.js
@@ -10,46 +10,33 @@
  *  - afterEnd: final thing that is called.
  */
 import { showError } from "./utils.js";
-import { sub } from "./pubsubhub.js";
 
 export const name = "core/post-process";
 
-let doneResolver;
-export const done = new Promise(resolve => {
-  doneResolver = resolve;
-});
-
-sub(
-  "plugins-done",
-  async config => {
-    const result = [];
-    if (Array.isArray(config.postProcess)) {
-      const promises = config.postProcess
-        .filter(f => {
-          const isFunction = typeof f === "function";
-          if (!isFunction) {
-            const msg = "Every item in `postProcess` must be a JS function.";
-            showError(msg, name);
-          }
-          return isFunction;
-        })
-        .map(async f => {
-          try {
-            return await f(config, document);
-          } catch (err) {
-            const msg = `Function ${f.name} threw an error during \`postProcess\`.`;
-            const hint = "See developer console.";
-            showError(msg, name, { hint });
-            console.error(err);
-          }
-        });
-      const values = await Promise.all(promises);
-      result.push(...values);
-    }
-    if (typeof config.afterEnd === "function") {
-      result.push(await config.afterEnd(config, document));
-    }
-    doneResolver(result);
-  },
-  { once: true }
-);
+export async function run(config) {
+  if (Array.isArray(config.postProcess)) {
+    const promises = config.postProcess
+      .filter(f => {
+        const isFunction = typeof f === "function";
+        if (!isFunction) {
+          const msg = "Every item in `postProcess` must be a JS function.";
+          showError(msg, name);
+        }
+        return isFunction;
+      })
+      .map(async f => {
+        try {
+          return await f(config, document);
+        } catch (err) {
+          const msg = `Function ${f.name} threw an error during \`postProcess\`.`;
+          const hint = "See developer console.";
+          showError(msg, name, { hint });
+          console.error(err);
+        }
+      });
+    await Promise.all(promises);
+  }
+  if (typeof config.afterEnd === "function") {
+    await config.afterEnd(config, document);
+  }
+}

--- a/src/core/pre-process.js
+++ b/src/core/pre-process.js
@@ -9,43 +9,30 @@
  *      want to be using a new module with your own profile
  */
 import { showError } from "./utils.js";
-import { sub } from "./pubsubhub.js";
 
 export const name = "core/pre-process";
 
-let doneResolver;
-export const done = new Promise(resolve => {
-  doneResolver = resolve;
-});
-
-sub(
-  "start-all",
-  async config => {
-    const result = [];
-    if (Array.isArray(config.preProcess)) {
-      const promises = config.preProcess
-        .filter(f => {
-          const isFunction = typeof f === "function";
-          if (!isFunction) {
-            const msg = "Every item in `preProcess` must be a JS function.";
-            showError(msg, name);
-          }
-          return isFunction;
-        })
-        .map(async f => {
-          try {
-            return await f(config, document);
-          } catch (err) {
-            const msg = `Function ${f.name} threw an error during \`preProcess\`.`;
-            const hint = "See developer console.";
-            showError(msg, name, { hint });
-            console.error(err);
-          }
-        });
-      const values = await Promise.all(promises);
-      result.push(...values);
-    }
-    doneResolver(result);
-  },
-  { once: true }
-);
+export async function run(config) {
+  if (Array.isArray(config.preProcess)) {
+    const promises = config.preProcess
+      .filter(f => {
+        const isFunction = typeof f === "function";
+        if (!isFunction) {
+          const msg = "Every item in `preProcess` must be a JS function.";
+          showError(msg, name);
+        }
+        return isFunction;
+      })
+      .map(async f => {
+        try {
+          return await f(config, document);
+        } catch (err) {
+          const msg = `Function ${f.name} threw an error during \`preProcess\`.`;
+          const hint = "See developer console.";
+          showError(msg, name, { hint });
+          console.error(err);
+        }
+      });
+    await Promise.all(promises);
+  }
+}


### PR DESCRIPTION
We can further refactor these to be imported directly into profiles, not sure if that's preferable. 