### PR TITLE
fix(w3c/sotd): allow CGs to prefer github coms

### DIFF
--- a/src/w3c/templates/cgbg-sotd.js
+++ b/src/w3c/templates/cgbg-sotd.js
@@ -1,5 +1,10 @@
 // @ts-check
-import { l10n, renderPreview, renderPublicList } from "./sotd.js";
+import {
+  l10n,
+  linkToCommunity,
+  renderPreview,
+  renderPublicList,
+} from "./sotd.js";
 import { html } from "../../core/import-maps.js";
 
 export default (conf, opts) => {
@@ -31,7 +36,8 @@ export default (conf, opts) => {
       >.
     </p>
     ${!conf.sotdAfterWGinfo ? opts.additionalContent : ""}
-    ${conf.wgPublicList ? renderPublicList(conf, opts) : ""}
+    ${!conf.github && conf.wgPublicList ? renderPublicList(conf, opts) : ""}
+    ${conf.github ? linkToCommunity(conf, opts) : ""}
     ${conf.sotdAfterWGinfo ? opts.additionalContent : ""}
     ${opts.additionalSections}
   `;

--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -405,7 +405,7 @@ function linkToWorkingGroup(conf) {
   </p>`;
 }
 
-function linkToCommunity(conf, opts) {
+export function linkToCommunity(conf, opts) {
   if (!conf.github && !conf.wgPublicList) {
     return;
   }
@@ -425,14 +425,13 @@ function linkToCommunity(conf, opts) {
           <a href="${opts.mailToWGPublicListWithSubject}"
             >${conf.wgPublicList}@w3.org</a
           >
-          (<a
+          (<a href="${opts.mailToWGPublicListSubscription}">subscribe</a>,
+          <a
             href="${`https://lists.w3.org/Archives/Public/${conf.wgPublicList}/`}"
             >archives</a
           >)${conf.subjectPrefix
-            ? html`
-                with <code>${conf.subjectPrefix}</code> at the start of your
-                email's subject
-              `
+            ? html` with <code>${conf.subjectPrefix}</code> at the start of your
+                email's subject`
             : ""}.
         `
       : ""}

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -1622,6 +1622,60 @@ describe("W3C — Headers", () => {
       );
     });
 
+    it("handles CG-DRAFT status with just github preferred", async () => {
+      const ops = makeStandardOps({
+        specStatus: "CG-DRAFT",
+        group: "maps4html",
+        github: "Maps4HTML/MapML",
+        editors: [{ name: "test" }],
+      });
+      const doc = await makeRSDoc(ops);
+      const sotd = doc.getElementById("sotd");
+      // Link to github
+      expect(
+        sotd.querySelectorAll(
+          "a[href='https://github.com/Maps4HTML/MapML/issues/']"
+        )
+      ).toHaveSize(1);
+      expect(contains(sotd, "a", "GitHub Issues")).toHaveSize(1);
+      // No Mailiing list
+      expect(sotd.querySelector("a[href^=mailto]")).toBeNull();
+    });
+
+    it("handles CG-DRAFT status with github and mailing list", async () => {
+      const ops = makeStandardOps({
+        specStatus: "CG-DRAFT",
+        group: "maps4html",
+        wgPublicList: "WGLIST",
+        subjectPrefix: "[The Prefix]",
+        github: "Maps4HTML/MapML",
+        editors: [{ name: "test" }],
+      });
+      const doc = await makeRSDoc(ops);
+      const sotd = doc.getElementById("sotd");
+      // Link to github
+      expect(
+        sotd.querySelectorAll(
+          "a[href='https://github.com/Maps4HTML/MapML/issues/']"
+        )
+      ).toHaveSize(1);
+      expect(contains(sotd, "a", "GitHub Issues")).toHaveSize(1);
+      // Mailiing list
+      expect(contains(sotd, "a", "Maps For HTML Community Group")).toHaveSize(
+        1
+      );
+      expect(contains(sotd, "a", "WGLIST")).toHaveSize(1);
+      expect(contains(sotd, "a", "WGLIST")[0].getAttribute("href")).toBe(
+        "mailto:WGLIST@w3.org?subject=%5BThe%20Prefix%5D"
+      );
+      expect(contains(sotd, "a", "subscribe")[0].getAttribute("href")).toBe(
+        "mailto:WGLIST-request@w3.org?subject=subscribe"
+      );
+      expect(contains(sotd, "a", "archives")[0].getAttribute("href")).toBe(
+        "https://lists.w3.org/Archives/Public/WGLIST/"
+      );
+    });
+
     it("handles BG-FINAL status", async () => {
       const ops = makeStandardOps();
       const newProps = {


### PR DESCRIPTION
Plus adds "subscribe" to mailing list link that was missing for everyone. Looks like: 

![Screen Shot 2021-02-17 at 6 15 55 pm](https://user-images.githubusercontent.com/870154/108168941-31175d00-714c-11eb-9b33-63b58e395922.png)

Closes #1636