### PR TITLE
feat(core/extensions): add extensions API

### DIFF
--- a/examples/basic.html
+++ b/examples/basic.html
@@ -15,6 +15,15 @@
           name: "Your Name",
           url: "https://your-site.com",
         }],
+        extensions: [
+          {
+            name: "my-extension",
+            on: "before-markdown",
+            async run(conf, utils) {
+              utils.showWarning("oops from extension", this.name);
+            }
+          }
+        ],
         github: "https://github.com/w3c/some-API/",
         testSuiteURI: "https://w3c-test.org/some-API/",
         implementationReportURI: "https://w3c.github.io/test-results/some-API",

--- a/src/core/extensions.js
+++ b/src/core/extensions.js
@@ -1,0 +1,62 @@
+// @ts-check
+import { showError, showWarning } from "./utils.js";
+
+export const name = "core/extensions";
+
+/**
+ * @param {any[]} corePlugins
+ * @param {Conf} conf
+ */
+export function setupExtensions(corePlugins, conf) {
+  /** @type {Map<Extension["on"], Extension[]>} */
+  const extMap = new Map();
+  for (const [i, ext] of Object.entries(conf.extensions || [])) {
+    if (!ext.name) {
+      const msg = `Extension #${i} does not have a \`name\`.`;
+      showWarning(msg, name);
+    }
+    ext.name = `extensions/${ext.name || i}`;
+
+    if (ext.run instanceof Function == false) {
+      const msg = `${ext.name} does not have a \`run()\` function.`;
+      showError(msg, name);
+      continue;
+    }
+
+    const { on } = ext;
+    const extsByHookName = extMap.get(on) || extMap.set(on, []).get(on);
+    extsByHookName.push(ext);
+  }
+
+  const allPlugins = [];
+  for (const corePlugin of corePlugins) {
+    const beforeHookName = corePlugin.hooks?.find(s => s.startsWith("before-"));
+    if (beforeHookName && extMap.has(beforeHookName)) {
+      allPlugins.push(...extMap.get(beforeHookName));
+      extMap.delete(beforeHookName);
+    }
+
+    allPlugins.push(corePlugin);
+
+    const afterHookName = corePlugin.hooks?.find(s => s.startsWith("after-"));
+    if (afterHookName && extMap.has(afterHookName)) {
+      allPlugins.push(...extMap.get(afterHookName));
+      extMap.delete(afterHookName);
+    }
+  }
+
+  // remaining extensions have no corresponding hooks.
+  for (const [on, exts] of extMap) {
+    for (const ext of exts) {
+      const msg = `${ext.name} does not have a valid \`on\` hook. Found "${on}".`;
+      showError(msg, name);
+    }
+  }
+
+  return allPlugins;
+}
+
+export const utils = {
+  showError,
+  showWarning,
+};

--- a/src/core/markdown.js
+++ b/src/core/markdown.js
@@ -305,6 +305,8 @@ const processMDSections = convertElements("[data-format='markdown']:not(body)");
 const blockLevelElements =
   "[data-format=markdown], section, div, address, article, aside, figure, header, main";
 
+export const hooks = ["before-markdown", "after-markdown"];
+
 export function run(conf) {
   const hasMDSections = !!document.querySelector(
     "[data-format=markdown]:not(body)"

--- a/src/type-helper.d.ts
+++ b/src/type-helper.d.ts
@@ -115,12 +115,20 @@ interface BiblioData {
   status?: string;
   etAl?: boolean;
 }
+
+interface Extension {
+  on: string;
+  name: string;
+  run(conf: Conf, utils: Record<string, Function>): Promise<void>;
+}
+
 interface Conf {
   informativeReferences: Set<string>;
   normativeReferences: Set<string>;
   localBiblio?: Record<string, BiblioData>;
   biblio: Record<string, BiblioData>;
   shortName: string;
+  extensions?: Extension[];
 }
 
 type ResourceHintOption = {


### PR DESCRIPTION
Closes https://github.com/w3c/respec/issues/1976

Support two extension hooks: before-markdown and after-markdown.
Support two extension utils: showError and showWarning.