### PR TITLE
tests(core/markdown): workaround highlight.js lang detection bug

### DIFF
--- a/tests/spec/core/markdown-spec.js
+++ b/tests/spec/core/markdown-spec.js
@@ -301,7 +301,7 @@ describe("Core - Markdown", () => {
       \`\`\`
 
       \`\`\`
-      IDK what I am
+      IDK what I'am
       \`\`\`
     `;
     const ops = makeStandardOps({ format: "markdown" }, body);


### PR DESCRIPTION
hljs was detecting the test block as "CSS".

Follow up: As we've access to highlight languages, we should probably use `highlight(lang, code)` instead of `highlightAuto(code, langSuggestions)`. Should also move respec-hljs into respec repo, to make such changes easier.