### PR TITLE
fix(tools/dev-server): regression, browsers arg must be an array

### DIFF
--- a/tools/dev-server.js
+++ b/tools/dev-server.js
@@ -17,8 +17,8 @@ sade("./tools/dev-server.js", true)
   .option("-p, --profile", "Name of profile to build.", "w3c")
   .option("-i, --interactive", "Run in interactive mode.", false)
   .option(
-    "--browsers",
-    'Browsers for Karma unit tests, space seperated (e.g., "Chrome Firefox")'
+    "--browser",
+    'Browser for Karma unit tests (e.g., "Chrome"). Multiple allowed.'
   )
   .option("--grep", "Run specific tests using karma --grep")
   .action(opts => run(opts))
@@ -29,7 +29,8 @@ function run(args) {
   const karmaConfig = karma.config.parseConfig(
     path.join(__dirname, "../karma.conf.js"),
     {
-      browsers: args.browsers?.split(/\s/) || [],
+      browsers:
+        typeof args.browser === "string" ? [args.browser] : args.browser,
       autoWatch: false,
       port: KARMA_PORT,
       logLevel: karma.constants.LOG_WARN,

--- a/tools/dev-server.js
+++ b/tools/dev-server.js
@@ -16,18 +16,20 @@ const SERVE_PORT = 5000;
 sade("./tools/dev-server.js", true)
   .option("-p, --profile", "Name of profile to build.", "w3c")
   .option("-i, --interactive", "Run in interactive mode.", false)
-  .option("--browsers", "Browsers for Karma unit tests")
+  .option(
+    "--browsers",
+    'Browsers for Karma unit tests, space seperated (e.g., "Chrome Firefox")'
+  )
   .option("--grep", "Run specific tests using karma --grep")
   .action(opts => run(opts))
   .parse(process.argv);
 
 function run(args) {
   let isActive = false;
-
   const karmaConfig = karma.config.parseConfig(
     path.join(__dirname, "../karma.conf.js"),
     {
-      browsers: args.browsers,
+      browsers: args.browsers?.split(/\s/) || [],
       autoWatch: false,
       port: KARMA_PORT,
       logLevel: karma.constants.LOG_WARN,


### PR DESCRIPTION
Looks like a small regression from #3317 ... was wondering how Sade determined the types. Now I know 🤣