### PR TITLE
feat(core/respec-global): dispatch errors and warnings 

### DIFF
--- a/examples/basic.html
+++ b/examples/basic.html
@@ -19,6 +19,14 @@
         testSuiteURI: "https://w3c-test.org/some-API/",
         implementationReportURI: "https://w3c.github.io/test-results/some-API",
       };
+      document.addEventListener("respec-start", (ev) => {
+        document.respec.addEventListener("error", console.info)
+        document.respec.addEventListener("warning", console.debug);
+        document.respec.ready.then(() => {
+          console.log(document.respec.errors);
+          console.log(document.respec.warnings);
+        })
+      }, { once: true })
     </script>
   </head>
   <body>

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -19,14 +19,6 @@
         testSuiteURI: "https://w3c-test.org/some-API/",
         implementationReportURI: "https://w3c.github.io/test-results/some-API",
       };
-      document.addEventListener("respec-start", (ev) => {
-        document.respec.addEventListener("error", console.info)
-        document.respec.addEventListener("warning", console.debug);
-        document.respec.ready.then(() => {
-          console.log(document.respec.errors);
-          console.log(document.respec.warnings);
-        })
-      }, { once: true })
     </script>
   </head>
   <body>

--- a/src/core/pubsubhub.js
+++ b/src/core/pubsubhub.js
@@ -74,12 +74,4 @@ export function unsub({ topic, cb }) {
   return callbacks.delete(cb);
 }
 
-sub("error", rsError => {
-  console.error(rsError, rsError.toJSON());
-});
-
-sub("warn", rsWarning => {
-  console.warn(rsWarning, rsWarning.toJSON());
-});
-
 expose(name, { sub });

--- a/src/core/respec-global.js
+++ b/src/core/respec-global.js
@@ -47,7 +47,8 @@ class ReSpec extends EventTarget {
 export function init() {
   const respec = new ReSpec();
   Object.defineProperty(document, "respec", { value: respec });
-  document.dispatchEvent(new CustomEvent("respec-start"));
+  // Internal. Do not use.
+  document.dispatchEvent(new CustomEvent("__private_respec_start__"));
 
   let respecIsReadyWarningShown = false;
   Object.defineProperty(document, "respecIsReady", {

--- a/tests/spec/core/respec-global-spec.js
+++ b/tests/spec/core/respec-global-spec.js
@@ -43,4 +43,32 @@ describe("Core — Respec Global - document.respec", () => {
 
     expect(doc.respec.errors).toHaveSize(0);
   });
+
+  it("dispatches error and warning events", async () => {
+    const config = { lint: { "broken-refs-exist": true } };
+    const body = `
+      <div id="sotd"></div>
+      <p><a id="test-warning" href="#non-existent">FAIL</a></p>
+      <div id="warning-collector"></div>
+      <script>
+        document.addEventListener("respec-start", () => {
+          document.respec.addEventListener("warning", ev => {
+            const collector = document.getElementById("warning-collector");
+            const warningEl = document.createElement("p");
+            warningEl.textContent = ev.detail.plugin;
+            collector.append(warningEl);
+          });
+        });
+      </script>
+    `;
+    const ops = makeStandardOps(config, body);
+    const doc = await makeRSDoc(ops);
+
+    const warningCollector = doc.getElementById("warning-collector");
+    expect(warningCollector).toBeTruthy();
+    expect(warningCollector.querySelectorAll("p")).toHaveSize(1);
+    expect(warningCollector.querySelector("p").textContent).toBe(
+      "core/linter/local-refs-exist"
+    );
+  });
 });

--- a/tests/spec/core/respec-global-spec.js
+++ b/tests/spec/core/respec-global-spec.js
@@ -20,4 +20,27 @@ describe("Core — Respec Global - document.respec", () => {
     expect(doc.respec.ready).toBeInstanceOf(doc.defaultView.Promise);
     await expectAsync(doc.respec.ready).toBeResolvedTo(undefined);
   });
+
+  it("has an array of errors and warnings", async () => {
+    const config = { lint: { "broken-refs-exist": true } };
+    const body = `
+      <div id="sotd"></div>
+      <p><a id="test-warning" href="#non-existent">FAIL</a></p>
+    `;
+    const ops = makeStandardOps(config, body);
+    const doc = await makeRSDoc(ops);
+
+    expect(doc.respec.errors).toBeInstanceOf(doc.defaultView.Array);
+    expect(doc.respec.warnings).toBeInstanceOf(doc.defaultView.Array);
+
+    expect(doc.respec.warnings).toHaveSize(1);
+    const warning = doc.respec.warnings[0];
+    expect(warning.name).toBe("ReSpecWarning");
+    expect(warning.message).toMatch(/Broken local reference/);
+    expect(warning.elements).toHaveSize(1);
+    expect(warning.elements[0].textContent).toBe("FAIL");
+    expect(warning.elements[0].hash).toBe("#non-existent");
+
+    expect(doc.respec.errors).toHaveSize(0);
+  });
 });

--- a/tests/spec/core/respec-global-spec.js
+++ b/tests/spec/core/respec-global-spec.js
@@ -51,7 +51,7 @@ describe("Core — Respec Global - document.respec", () => {
       <p><a id="test-warning" href="#non-existent">FAIL</a></p>
       <div id="warning-collector"></div>
       <script>
-        document.addEventListener("respec-start", () => {
+        document.addEventListener("__private_respec_start__", () => {
           document.respec.addEventListener("warning", ev => {
             const collector = document.getElementById("warning-collector");
             const warningEl = document.createElement("p");


### PR DESCRIPTION
Closes https://github.com/w3c/respec/issues/1084

- Added an event ~`"respec-start"`~ `"__private_respec_start__"` on `document` that signals `document.respec` is available. Can change its target/name etc.
- `document.respec` is now an `EventTarget` that can emit "error" and "warning" `CustomEvent`s

```js
document.addEventListener("__private_respec_start__", (ev) => {
  document.respec.addEventListener("error", ({ detail: rsError }) => console.error(rsError));
  document.respec.addEventListener("warning", ({ detail: rsError }) => console.warn(rsError));
  document.respec.ready.then(() => {
    console.log(document.respec.errors);
    console.log(document.respec.warnings);
  })
}, { once: true })
```

As a follow up, I intend to use this in respecDocWriter, instead of relying on console messages.