### PR TITLE
fix(assets/respec.css): darken pre background in examples

### DIFF
--- a/assets/examples.css
+++ b/assets/examples.css
@@ -1,28 +1,43 @@
 /* --- EXAMPLES --- */
 span.example-title {
-    text-transform: none;
+  text-transform: none;
 }
-aside.example, div.example, div.illegal-example {
-    padding: 0.5em;
-    margin: 1em 0;
-    position: relative;
-    clear: both;
+
+aside.example,
+div.example,
+div.illegal-example {
+  padding: 0.5em;
+  margin: 1em 0;
+  position: relative;
+  clear: both;
 }
-div.illegal-example { color: red }
-div.illegal-example p { color: black }
-aside.example, div.example {
-    padding: .5em;
-    border-left-width: .5em;
-    border-left-style: solid;
-    border-color: #e0cb52;
-    background: #fcfaee;
+
+div.illegal-example {
+  color: red;
+}
+
+div.illegal-example p {
+  color: black;
+}
+
+aside.example,
+div.example {
+  padding: 0.5em;
+  border-left-width: 0.5em;
+  border-left-style: solid;
+  border-color: #e0cb52;
+  background: #fcfaee;
 }
 
 aside.example div.example {
-    border-left-width: .1em;
-    border-color: #999;
-    background: #fff;
+  border-left-width: 0.1em;
+  border-color: #999;
+  background: #fff;
 }
 aside.example div.example span.example-title {
-    color: #999;
+  color: #999;
+}
+
+.example pre {
+  background-color: rgba(0, 0, 0, 0.03);
 }

--- a/assets/respec.css
+++ b/assets/respec.css
@@ -234,10 +234,6 @@ aside.example .marker > a.self-link {
   color: inherit;
 }
 
-.example pre {
-  background-color: rgba(0, 0, 0, .03);
-}
-
 h2 > a.self-link,
 h3 > a.self-link,
 h4 > a.self-link,

--- a/assets/respec.css
+++ b/assets/respec.css
@@ -234,6 +234,10 @@ aside.example .marker > a.self-link {
   color: inherit;
 }
 
+.example pre {
+  background-color: rgba(0, 0, 0, .03);
+}
+
 h2 > a.self-link,
 h3 > a.self-link,
 h4 > a.self-link,


### PR DESCRIPTION
Makes the `<pre>`s inside `.example` blocks a little darker, and matches what Bikeshed does: 

![Screen Shot 2021-02-24 at 12 24 54 pm](https://user-images.githubusercontent.com/870154/108931215-60bdec00-769b-11eb-9381-a7688ca4f620.png)

This is nice in the it better splits up code and text:

![Screen Shot 2021-02-24 at 12 29 51 pm](https://user-images.githubusercontent.com/870154/108931597-ffe2e380-769b-11eb-98b4-69eba60162db.png)

