### PR TITLE
feat(tools/respec2html): add --version flag

### DIFF
--- a/tools/respec2html.js
+++ b/tools/respec2html.js
@@ -60,6 +60,12 @@ cli.action((source, destination, opts) => {
   });
 });
 
+// https://github.com/lukeed/sade/issues/28
+cli._version = () => {
+  const { version } = require("../package.json");
+  console.log(version);
+};
+
 cli.parse(process.argv);
 
 async function run(source, destination, options) {

--- a/tools/respec2html.js
+++ b/tools/respec2html.js
@@ -60,7 +60,7 @@ cli.action((source, destination, opts) => {
   });
 });
 
-// https://github.com/lukeed/sade/issues/28
+// https://github.com/lukeed/sade/issues/28#issuecomment-516104013
 cli._version = () => {
   const { version } = require("../package.json");
   console.log(version);


### PR DESCRIPTION
> (By the way, it would be useful if --help or --version gave some ReSpec version info). ― https://github.com/w3c/respec/issues/3292#issue-800749440