### PR TITLE
feat(core/respec-global): collect errors and warnings

### DIFF
--- a/src/core/pubsubhub.js
+++ b/src/core/pubsubhub.js
@@ -74,12 +74,4 @@ export function unsub({ topic, cb }) {
   return callbacks.delete(cb);
 }
 
-sub("error", rsError => {
-  console.error(rsError, rsError.toJSON());
-});
-
-sub("warn", rsWarning => {
-  console.warn(rsWarning, rsWarning.toJSON());
-});
-
 expose(name, { sub });

--- a/src/core/respec-global.js
+++ b/src/core/respec-global.js
@@ -19,6 +19,18 @@ class ReSpec {
     this._respecDonePromise = new Promise(resolve => {
       sub("end-all", resolve, { once: true });
     });
+
+    this.errors = [];
+    this.warnings = [];
+
+    sub("error", rsError => {
+      console.error(rsError, rsError.toJSON());
+      this.errors.push(rsError);
+    });
+    sub("warn", rsError => {
+      console.warn(rsError, rsError.toJSON());
+      this.warnings.push(rsError);
+    });
   }
 
   get version() {

--- a/tests/spec/core/respec-global-spec.js
+++ b/tests/spec/core/respec-global-spec.js
@@ -36,10 +36,10 @@ describe("Core — Respec Global - document.respec", () => {
     expect(doc.respec.warnings).toHaveSize(1);
     const warning = doc.respec.warnings[0];
     expect(warning.name).toBe("ReSpecWarning");
+    expect(warning.plugin).toBe("core/linter/local-refs-exist");
     expect(warning.message).toMatch(/Broken local reference/);
     expect(warning.elements).toHaveSize(1);
     expect(warning.elements[0].textContent).toBe("FAIL");
-    expect(warning.elements[0].hash).toBe("#non-existent");
 
     expect(doc.respec.errors).toHaveSize(0);
   });

--- a/tests/spec/core/respec-global-spec.js
+++ b/tests/spec/core/respec-global-spec.js
@@ -20,4 +20,27 @@ describe("Core — Respec Global - document.respec", () => {
     expect(doc.respec.ready).toBeInstanceOf(doc.defaultView.Promise);
     await expectAsync(doc.respec.ready).toBeResolvedTo(undefined);
   });
+
+  it("has an array of errors and warnings", async () => {
+    const config = { lint: { "broken-refs-exist": true } };
+    const body = `
+      <div id="sotd"></div>
+      <p><a id="test-warning" href="#non-existent">FAIL</a></p>
+    `;
+    const ops = makeStandardOps(config, body);
+    const doc = await makeRSDoc(ops);
+
+    expect(doc.respec.errors).toBeInstanceOf(doc.defaultView.Array);
+    expect(doc.respec.warnings).toBeInstanceOf(doc.defaultView.Array);
+
+    expect(doc.respec.warnings).toHaveSize(1);
+    const warning = doc.respec.warnings[0];
+    expect(warning.name).toBe("ReSpecWarning");
+    expect(warning.message).toMatch(/Broken local reference/);
+    expect(warning.elements).toHaveSize(1);
+    expect(warning.elements[0].textContent).toBe("FAIL");
+    expect(warning.elements[0].hash).toBe("#non-existent");
+
+    expect(doc.respec.errors).toHaveSize(0);
+  });
 });


### PR DESCRIPTION
Closes #1084
Extracted from https://github.com/w3c/respec/pull/3338
Will implement `dispatchEvent` stuff when we need it.