### PR TITLE
Fix including markdown

### DIFF
--- a/src/core/data-include.js
+++ b/src/core/data-include.js
@@ -21,19 +21,19 @@ export const name = "core/data-include";
  * @param {boolean} options.replace
  */
 function fillWithText(el, data, { replace }) {
-  const { includeFormat } = el.dataset;
+  const { format } = el.dataset;
   let fill = data;
-  if (includeFormat === "markdown") {
+  if (format === "markdown") {
     fill = markdownToHtml(fill);
   }
 
-  if (includeFormat === "text") {
+  if (format === "text") {
     el.textContent = fill;
   } else {
     el.innerHTML = fill;
   }
 
-  if (includeFormat === "markdown") {
+  if (format === "markdown") {
     restructure(el);
   }
 


### PR DESCRIPTION
I've been exploring `include` and `markdown` for [w3c/coga](https://github.com/w3c/coga) and found the combination was only working in 2 very limited cases.

After lots of userland permutation testing I finally debugged the code and found a broken destructuring assignment. This PR fixes it.

There seems to be some test code coverage issues as well as this didn't break the tests but my fix does. I can look at those too if you like?

Ideally this would be released ASAP as it is holding me back.

Thanks.