### PR TITLE
feat(tools/respec2html): provide more detailed logs

### DIFF
--- a/tools/respec2html.js
+++ b/tools/respec2html.js
@@ -43,18 +43,27 @@ class Logger {
     console.error(header, time, message);
   }
 
-  /** @param {{ message: string }} rsError */
+  /**
+   * @typedef {import("./respecDocWriter.js").RsError} RsError
+   * @param {RsError} rsError
+   */
   error(rsError) {
     const header = colors.bgRed.white.bold("[ERROR]");
     const message = colors.red(this._formatMarkdown(rsError.message));
     console.error(header, message);
+    if (rsError.plugin) {
+      this._printDetails(rsError);
+    }
   }
 
-  /** @param {{ message: string }} rsError */
+  /** @param {RsError} rsError */
   warn(rsError) {
     const header = colors.bgYellow.black.bold("[WARNING]");
     const message = colors.yellow(this._formatMarkdown(rsError.message));
     console.error(header, message);
+    if (rsError.plugin) {
+      this._printDetails(rsError);
+    }
   }
 
   /** @param {Error | string} error */
@@ -67,6 +76,19 @@ class Logger {
   _formatMarkdown(str) {
     if (typeof str !== "string") return str;
     return marked(str, { smartypants: true, renderer: new Renderer() });
+  }
+
+  /** @param {import("./respecDocWriter").ReSpecError} rsError */
+  _printDetails(rsError) {
+    const print = (title, value) => {
+      if (!value) return;
+      const padWidth = "Plugin".length + 1; // "Plugin" is the longest title
+      const paddedTitle = `${title}:`.padStart(padWidth);
+      console.error(" ", colors.bold(paddedTitle), this._formatMarkdown(value));
+    };
+    print("Count", rsError.elements && String(rsError.elements.length));
+    print("Plugin", rsError.plugin);
+    print("Hint", rsError.hint);
   }
 }
 

--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -261,9 +261,23 @@ async function evaluateHTML(version, timer) {
 }
 
 /**
+ * @typedef {object} RsErrorBasic
+ * @property {string} RsErrorBasic.message
+ *
+ * @typedef {object} ReSpecError
+ * @property {string} ReSpecError.message
+ * @property {string} ReSpecError.plugin
+ * @property {string} [ReSpecError.hint]
+ * @property {HTMLElement[]} [ReSpecError.elements]
+ * @property {string} [ReSpecError.title]
+ * @property {string} [ReSpecError.details]
+ *
+ * @typedef {RsErrorBasic | ReSpecError} RsError
+ */
+
+/**
  * Specifies what to do when the browser emits "error" and "warn" console messages.
  * @param  {import("puppeteer").Page} page Instance of page to listen on.
- * @typedef {{ message: string }} RsError
  * @param {(error: RsError) => void} onError
  * @param {(error: RsError) => void} onWarning
  */


### PR DESCRIPTION
Remaining part of https://github.com/w3c/respec/pull/3342

![image](https://user-images.githubusercontent.com/8426945/111277495-8583fe80-865e-11eb-9e97-f3ab7d825810.png)
![image](https://user-images.githubusercontent.com/8426945/111277516-8c127600-865e-11eb-8cbb-6a3567019407.png)

Didn't provide `ReSpecError.details` yet, as it gets noisy. Will add sometime later as a followup (maybe behind a --log-level arg?).