### PR TITLE
fix(core/link-to-dfn): make shortName matching stricter

### DIFF
--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -287,17 +287,17 @@ function showLinkingError(elems) {
  * @param {Conf} conf
  */
 function updateReferences(conf) {
-  const shortName = new RegExp(
-    String.raw`^${(conf.shortName || "").toLowerCase()}([^-])\b`,
-    "i"
-  );
+  const shortName = conf?.shortName.toLowerCase() || "";
+
+  // Matches spec/path#frag (note optional ?! in start of data-cite)
+  const regex = new RegExp(String.raw`^([?!])?${shortName}\b([#\/?]?)`, "i");
 
   /** @type {NodeListOf<HTMLElement>} */
   const elems = document.querySelectorAll(
     "dfn[data-cite]:not([data-cite='']), a[data-cite]:not([data-cite=''])"
   );
   for (const elem of elems) {
-    elem.dataset.cite = elem.dataset.cite.replace(shortName, `${THIS_SPEC}$1`);
+    elem.dataset.cite = elem.dataset.cite.replace(regex, `${THIS_SPEC}$1`);
     const { key, isNormative } = toCiteDetails(elem);
     if (key === THIS_SPEC) continue;
 

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -290,14 +290,14 @@ function updateReferences(conf) {
   const shortName = conf?.shortName.toLowerCase() || "";
 
   // Matches spec/path#frag (note optional ?! in start of data-cite)
-  const regex = new RegExp(String.raw`^([?!])?${shortName}\b([#\/?]?)`, "i");
+  const regex = new RegExp(String.raw`^([?!])?${shortName}([#\/?]?)`, "i");
 
   /** @type {NodeListOf<HTMLElement>} */
   const elems = document.querySelectorAll(
     "dfn[data-cite]:not([data-cite='']), a[data-cite]:not([data-cite=''])"
   );
   for (const elem of elems) {
-    elem.dataset.cite = elem.dataset.cite.replace(regex, `${THIS_SPEC}$1`);
+    elem.dataset.cite = elem.dataset.cite.replace(regex, `$1${THIS_SPEC}$2`);
     const { key, isNormative } = toCiteDetails(elem);
     if (key === THIS_SPEC) continue;
 

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -287,7 +287,7 @@ function showLinkingError(elems) {
  * @param {Conf} conf
  */
 function updateReferences(conf) {
-  const shortName = conf.shortName?.toLowerCase() || "";
+  const { shortName = "" } = conf;
   // https://regex101.com/r/rsZyIJ/5
   const regex = new RegExp(String.raw`^([?!])?${shortName}\b([^-])`, "i");
 

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -287,7 +287,7 @@ function showLinkingError(elems) {
  * @param {Conf} conf
  */
 function updateReferences(conf) {
-  const shortName = conf?.shortName.toLowerCase() || "";
+  const shortName = conf.shortName?.toLowerCase() || "";
 
   // Matches spec/path#frag (note optional ?! in start of data-cite)
   const regex = new RegExp(String.raw`^([?!])?${shortName}([#\/?]?)`, "i");

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -288,7 +288,7 @@ function showLinkingError(elems) {
  */
 function updateReferences(conf) {
   const shortName = conf.shortName?.toLowerCase() || "";
-  // https://regex101.com/r/rsZyIJ/4
+  // https://regex101.com/r/rsZyIJ/5
   const regex = new RegExp(String.raw`^([?!])?${shortName}\b([^-])`, "i");
 
   /** @type {NodeListOf<HTMLElement>} */

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -289,8 +289,8 @@ function showLinkingError(elems) {
 function updateReferences(conf) {
   const shortName = conf.shortName?.toLowerCase() || "";
 
-  // Matches spec/path#frag (note optional ?! in start of data-cite)
-  const regex = new RegExp(String.raw`^([?!])?${shortName}([^-])\b`, "i");
+  // https://regex101.com/r/rsZyIJ/4
+  const regex = new RegExp(String.raw`^([?!])?${shortName}\b([^-])`, "i");
 
   /** @type {NodeListOf<HTMLElement>} */
   const elems = document.querySelectorAll(

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -288,6 +288,7 @@ function showLinkingError(elems) {
  */
 function updateReferences(conf) {
   const { shortName = "" } = conf;
+  // Match shortName in a data-cite (with optional leading ?!), while skipping shortName as prefix.
   // https://regex101.com/r/rsZyIJ/5
   const regex = new RegExp(String.raw`^([?!])?${shortName}\b([^-])`, "i");
 

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -11,8 +11,8 @@ import {
   showWarning,
   wrapInner,
 } from "./utils.js";
-import { THIS_SPEC, toCiteDetails } from "./data-cite.js";
 import { definitionMap } from "./dfn-map.js";
+import { toCiteDetails } from "./data-cite.js";
 
 export const name = "core/link-to-dfn";
 
@@ -287,19 +287,14 @@ function showLinkingError(elems) {
  * @param {Conf} conf
  */
 function updateReferences(conf) {
-  const shortName = new RegExp(
-    String.raw`^${(conf.shortName || "").toLowerCase()}([^-])\b`,
-    "i"
-  );
-
   /** @type {NodeListOf<HTMLElement>} */
   const elems = document.querySelectorAll(
     "dfn[data-cite]:not([data-cite='']), a[data-cite]:not([data-cite=''])"
   );
   for (const elem of elems) {
-    elem.dataset.cite = elem.dataset.cite.replace(shortName, `${THIS_SPEC}$1`);
     const { key, isNormative } = toCiteDetails(elem);
-    if (key === THIS_SPEC) continue;
+    // self cite, so skip
+    if (key === conf.shortName) continue;
 
     if (!isNormative && !conf.normativeReferences.has(key)) {
       conf.informativeReferences.add(key);

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -11,8 +11,8 @@ import {
   showWarning,
   wrapInner,
 } from "./utils.js";
+import { THIS_SPEC, toCiteDetails } from "./data-cite.js";
 import { definitionMap } from "./dfn-map.js";
-import { toCiteDetails } from "./data-cite.js";
 
 export const name = "core/link-to-dfn";
 
@@ -287,14 +287,19 @@ function showLinkingError(elems) {
  * @param {Conf} conf
  */
 function updateReferences(conf) {
+  const shortName = new RegExp(
+    String.raw`^${(conf.shortName || "").toLowerCase()}([^-])\b`,
+    "i"
+  );
+
   /** @type {NodeListOf<HTMLElement>} */
   const elems = document.querySelectorAll(
     "dfn[data-cite]:not([data-cite='']), a[data-cite]:not([data-cite=''])"
   );
   for (const elem of elems) {
+    elem.dataset.cite = elem.dataset.cite.replace(shortName, `${THIS_SPEC}$1`);
     const { key, isNormative } = toCiteDetails(elem);
-    // self cite, so skip
-    if (key === conf.shortName) continue;
+    if (key === THIS_SPEC) continue;
 
     if (!isNormative && !conf.normativeReferences.has(key)) {
       conf.informativeReferences.add(key);

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -290,7 +290,7 @@ function updateReferences(conf) {
   const shortName = conf.shortName?.toLowerCase() || "";
 
   // Matches spec/path#frag (note optional ?! in start of data-cite)
-  const regex = new RegExp(String.raw`^([?!])?${shortName}([#\/?]?)`, "i");
+  const regex = new RegExp(String.raw`^([?!])?${shortName}([^-])\b`, "i");
 
   /** @type {NodeListOf<HTMLElement>} */
   const elems = document.querySelectorAll(

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -288,7 +288,7 @@ function showLinkingError(elems) {
  */
 function updateReferences(conf) {
   const shortName = new RegExp(
-    String.raw`\b${(conf.shortName || "").toLowerCase()}([^-])\b`,
+    String.raw`^${(conf.shortName || "").toLowerCase()}([^-])\b`,
     "i"
   );
 

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -288,7 +288,6 @@ function showLinkingError(elems) {
  */
 function updateReferences(conf) {
   const shortName = conf.shortName?.toLowerCase() || "";
-
   // https://regex101.com/r/rsZyIJ/4
   const regex = new RegExp(String.raw`^([?!])?${shortName}\b([^-])`, "i");
 

--- a/tests/spec/core/data-cite-spec.js
+++ b/tests/spec/core/data-cite-spec.js
@@ -64,6 +64,25 @@ describe("Core — data-cite attribute", () => {
     expect(t2.href).toEqual(location);
   });
 
+  it(`doesn't confuse similarly named specs as self citing`, async () => {
+    const body = `
+      <section>
+        <h2>test</h2>
+        <p id="test">
+          [[[webxr-gamepads-module-1]]], [[webxr-gamepads-module-1]]
+        </p>
+      </section>
+    `;
+    const ops = makeStandardOps({ shortName: "gamepad" }, body);
+    const doc = await makeRSDoc(ops);
+    const [anchor1, anchor2] = doc.querySelectorAll("#test a");
+
+    expect(anchor1.href).toContain("TR/webxr-gamepads-module-1/");
+    expect(anchor1.textContent).toBe("WebXR Gamepads Module - Level 1");
+    expect(anchor2.href).toContain("#bib-webxr-gamepads-module-1");
+    expect(anchor2.textContent).toBe("webxr-gamepads-module-1");
+  });
+
   it("links data-cite attributes as normative/informative reference when parent is citing", async () => {
     const body = `
       <section class="informative" data-cite="FETCH">


### PR DESCRIPTION
The `updateReferences()` function was being too generous with matching on shortname, meaning that webxr-gamepad-* was being seen as self citing.

<img width="594" alt="Screen Shot 2021-03-17 at 8 39 17 pm" src="https://user-images.githubusercontent.com/870154/111446771-db40cf80-8760-11eb-9bec-e4e25779e156.png">