### PR TITLE
refactor(styles): convert css files to js

### DIFF
--- a/assets/algorithms.css
+++ b/assets/algorithms.css
@@ -1,7 +1,0 @@
-/* For assertions in lists containing algorithms */
-
-.assert {
-    background: #EEE;
-    border-left: 0.5em solid #AAA;
-    padding: 0.3em;
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -192,6 +192,16 @@
         }
       }
     },
+    "@types/clean-css": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@types/clean-css/-/clean-css-4.2.3.tgz",
+      "integrity": "sha512-ET0ldU/vpXecy5vO8JRIhtJWSrk1vzXdJcp3Bjf8bARZynl6vfkhEKY/A7njfNIRlmyTGuVFuqnD6I3tOGdXpQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "source-map": "^0.6.0"
+      }
+    },
     "@types/component-emitter": {
       "version": "1.2.10",
       "resolved": "https://registry.npmjs.org/@types/component-emitter/-/component-emitter-1.2.10.tgz",
@@ -216,6 +226,17 @@
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
+    "@types/html-minifier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@types/html-minifier/-/html-minifier-3.5.3.tgz",
+      "integrity": "sha512-j1P/4PcWVVCPEy5lofcHnQ6BtXz9tHGiFPWzqm7TtGuWZEfCHEP446HlkSNc9fQgNJaJZ6ewPtp2aaFla/Uerg==",
+      "dev": true,
+      "requires": {
+        "@types/clean-css": "*",
+        "@types/relateurl": "*",
+        "@types/uglify-js": "*"
+      }
+    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -238,6 +259,21 @@
       "resolved": "https://registry.npmjs.org/@types/pluralize/-/pluralize-0.0.29.tgz",
       "integrity": "sha512-BYOID+l2Aco2nBik+iYS4SZX0Lf20KPILP5RGmM1IgzdwNdTs0eebiFriOPcej1sX9mLnSoiNte5zcFxssgpGA==",
       "dev": true
+    },
+    "@types/relateurl": {
+      "version": "0.2.28",
+      "resolved": "https://registry.npmjs.org/@types/relateurl/-/relateurl-0.2.28.tgz",
+      "integrity": "sha1-a9p9uGU/piZD9e5p6facEaOS46Y=",
+      "dev": true
+    },
+    "@types/uglify-js": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.13.0.tgz",
+      "integrity": "sha512-EGkrJD5Uy+Pg0NUR8uA4bJ5WMfljyad0G+784vLCNUkD+QwOJXUbBYExXfVGf7YtyzdQp3L/XMYcliB987kL5Q==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.1"
+      }
     },
     "@types/yauzl": {
       "version": "2.9.1",
@@ -715,6 +751,16 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
+    },
+    "camel-case": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-3.0.0.tgz",
+      "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0",
+        "upper-case": "^1.1.1"
+      }
     },
     "chai": {
       "version": "4.3.4",
@@ -1661,6 +1707,12 @@
       "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
       "dev": true
     },
+    "estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true
+    },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2006,6 +2058,12 @@
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
       "dev": true
     },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
     "highlight.js": {
       "version": "10.7.1",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.1.tgz",
@@ -2017,6 +2075,32 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
       "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
       "dev": true
+    },
+    "html-minifier": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-4.0.0.tgz",
+      "integrity": "sha512-aoGxanpFPLg7MkIl/DDFYtb0iWz7jMFGqFhvEDZga6/4QTjneiD8I/NXL1x5aaoCp7FSIT6h/OhykDdPsbtMig==",
+      "dev": true,
+      "requires": {
+        "camel-case": "^3.0.0",
+        "clean-css": "^4.2.1",
+        "commander": "^2.19.0",
+        "he": "^1.2.0",
+        "param-case": "^2.1.1",
+        "relateurl": "^0.2.7",
+        "uglify-js": "^3.5.1"
+      },
+      "dependencies": {
+        "clean-css": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
+          "integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
+          "dev": true,
+          "requires": {
+            "source-map": "~0.6.0"
+          }
+        }
+      }
     },
     "http-errors": {
       "version": "1.7.2",
@@ -2619,6 +2703,12 @@
         }
       }
     },
+    "lower-case": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
+      "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
+      "dev": true
+    },
     "lru-cache": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
@@ -2627,6 +2717,15 @@
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
+      }
+    },
+    "magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
       }
     },
     "marked": {
@@ -2665,6 +2764,30 @@
       "dev": true,
       "requires": {
         "mime-db": "1.44.0"
+      }
+    },
+    "minify-html-literals": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/minify-html-literals/-/minify-html-literals-1.3.5.tgz",
+      "integrity": "sha512-p8T8ryePRR8FVfJZLVFmM53WY25FL0moCCTycUDuAu6rf9GMLwy0gNjXBGNin3Yun7Y+tIWd28axOf0t2EpAlQ==",
+      "dev": true,
+      "requires": {
+        "@types/html-minifier": "^3.5.3",
+        "clean-css": "^4.2.1",
+        "html-minifier": "^4.0.0",
+        "magic-string": "^0.25.0",
+        "parse-literals": "^1.2.1"
+      },
+      "dependencies": {
+        "clean-css": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.3.tgz",
+          "integrity": "sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==",
+          "dev": true,
+          "requires": {
+            "source-map": "~0.6.0"
+          }
+        }
       }
     },
     "minimatch": {
@@ -2728,6 +2851,15 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
       "dev": true
+    },
+    "no-case": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
+      "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
+      "dev": true,
+      "requires": {
+        "lower-case": "^1.1.1"
+      }
     },
     "node-fetch": {
       "version": "2.6.1",
@@ -2913,6 +3045,15 @@
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true
     },
+    "param-case": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/param-case/-/param-case-2.1.1.tgz",
+      "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
+      "dev": true,
+      "requires": {
+        "no-case": "^2.2.0"
+      }
+    },
     "parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -2929,6 +3070,15 @@
       "dev": true,
       "requires": {
         "error-ex": "^1.2.0"
+      }
+    },
+    "parse-literals": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/parse-literals/-/parse-literals-1.2.1.tgz",
+      "integrity": "sha512-Ml0w104Ph2wwzuRdxrg9booVWsngXbB4bZ5T2z6WyF8b5oaNkUmBiDtahi34yUIpXD8Y13JjAK6UyIyApJ73RQ==",
+      "dev": true,
+      "requires": {
+        "typescript": "^2.9.2 || ^3.0.0 || ^4.0.0"
       }
     },
     "parseurl": {
@@ -3287,6 +3437,12 @@
         "rc": "^1.0.1"
       }
     },
+    "relateurl": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
+      "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
+      "dev": true
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -3359,6 +3515,16 @@
         "fsevents": "~2.3.1"
       }
     },
+    "rollup-plugin-minify-html-literals": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-minify-html-literals/-/rollup-plugin-minify-html-literals-1.2.6.tgz",
+      "integrity": "sha512-JRq2fjlCTiw0zu+1Sy3ClHGCxA79dWGr4HLHWSQgd060StVW9fBVksuj8Xw/suPkNSGClJf/4xNQ1MF6JeXPaw==",
+      "dev": true,
+      "requires": {
+        "minify-html-literals": "^1.3.5",
+        "rollup-pluginutils": "^2.8.2"
+      }
+    },
     "rollup-plugin-terser": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-7.0.2.tgz",
@@ -3369,6 +3535,15 @@
         "jest-worker": "^26.2.1",
         "serialize-javascript": "^4.0.0",
         "terser": "^5.0.0"
+      }
+    },
+    "rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "requires": {
+        "estree-walker": "^0.6.1"
       }
     },
     "sade": {
@@ -4112,6 +4287,12 @@
       "integrity": "sha512-LHmiAd5QuAv7pU2vbh+Zq9YOnqVK0H764p2Ozinpfy9ka58OID4IsGLiXsitqH7n0NAIDxvax1A/kDXpii/Ckg==",
       "dev": true
     },
+    "uglify-js": {
+      "version": "3.13.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.2.tgz",
+      "integrity": "sha512-SbMu4D2Vo95LMC/MetNaso1194M1htEA+JrqE9Hk+G2DhI+itfS9TRu9ZKeCahLDNa/J3n4MqUJ/fOHMzQpRWw==",
+      "dev": true
+    },
     "umap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/umap/-/umap-1.0.2.tgz",
@@ -4147,6 +4328,12 @@
         "registry-auth-token": "3.3.2",
         "registry-url": "3.1.0"
       }
+    },
+    "upper-case": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
+      "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=",
+      "dev": true
     },
     "uri-js": {
       "version": "4.2.2",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "prettier": "^2.2.1",
     "prompt": "^1.1.0",
     "rollup": "^2.42.2",
+    "rollup-plugin-minify-html-literals": "^1.2.6",
     "rollup-plugin-terser": "^7.0.2",
     "serve": "^11.3.2",
     "typescript": "^4.2.3",

--- a/src/core/algorithms.js
+++ b/src/core/algorithms.js
@@ -2,20 +2,9 @@
 /**
 Currently used only for adding 'assert' class to algorithm lists
 */
-
-import { fetchAsset } from "./text-loader.js";
+import css from "../styles/algorithms.css.js";
 
 export const name = "core/algorithms";
-
-const cssPromise = loadStyle();
-
-async function loadStyle() {
-  try {
-    return (await import("text!../../assets/algorithms.css")).default;
-  } catch {
-    return fetchAsset("algorithms.css");
-  }
-}
 
 export async function run() {
   const elements = Array.from(document.querySelectorAll("ol.algorithm li"));
@@ -24,7 +13,7 @@ export async function run() {
     .forEach(li => li.classList.add("assert"));
   if (document.querySelector(".assert")) {
     const style = document.createElement("style");
-    style.textContent = await cssPromise;
+    style.textContent = css;
     document.head.appendChild(style);
   }
 }

--- a/src/core/algorithms.js
+++ b/src/core/algorithms.js
@@ -6,7 +6,7 @@ import css from "../styles/algorithms.css.js";
 
 export const name = "core/algorithms";
 
-export async function run() {
+export function run() {
   const elements = Array.from(document.querySelectorAll("ol.algorithm li"));
   elements
     .filter(li => li.textContent.trim().startsWith("Assert: "))

--- a/src/core/caniuse.js
+++ b/src/core/caniuse.js
@@ -31,7 +31,7 @@ const BROWSERS = new Set([
   "samsung",
 ]);
 
-export async function prepare(conf) {
+export function prepare(conf) {
   if (!conf.caniuse) {
     return; // nothing to do.
   }

--- a/src/core/caniuse.js
+++ b/src/core/caniuse.js
@@ -6,7 +6,7 @@
  */
 import { pub, sub } from "./pubsubhub.js";
 import { showError, showWarning } from "./utils.js";
-import { fetchAsset } from "./text-loader.js";
+import css from "../styles/caniuse.css.js";
 import { html } from "./import-maps.js";
 
 export const name = "core/caniuse";
@@ -31,14 +31,6 @@ const BROWSERS = new Set([
   "samsung",
 ]);
 
-async function loadStyle() {
-  try {
-    return (await import("text!../../assets/caniuse.css")).default;
-  } catch {
-    return fetchAsset("caniuse.css");
-  }
-}
-
 export async function prepare(conf) {
   if (!conf.caniuse) {
     return; // nothing to do.
@@ -49,9 +41,8 @@ export async function prepare(conf) {
     return; // no feature to show
   }
 
-  const caniuseCss = await loadStyle();
   document.head.appendChild(html`<style class="removeOnSave">
-    ${caniuseCss}
+    ${css}
   </style>`);
 
   const apiUrl = options.apiURL || API_URL;

--- a/src/core/data-type.js
+++ b/src/core/data-type.js
@@ -5,19 +5,9 @@
  * Also adds the CSS for the data type tooltip.
  * Set `conf.highlightVars = true` to enable.
  */
-import { fetchAsset } from "./text-loader.js";
+import css from "../styles/datatype.css.js";
 
 export const name = "core/data-type";
-
-const tooltipStylePromise = loadStyle();
-
-async function loadStyle() {
-  try {
-    return (await import("text!../../assets/datatype.css")).default;
-  } catch {
-    return fetchAsset("datatype.css");
-  }
-}
 
 export async function run(conf) {
   if (!conf.highlightVars) {
@@ -25,7 +15,7 @@ export async function run(conf) {
   }
 
   const style = document.createElement("style");
-  style.textContent = await tooltipStylePromise;
+  style.textContent = css;
   document.head.appendChild(style);
 
   let section = null;

--- a/src/core/data-type.js
+++ b/src/core/data-type.js
@@ -9,7 +9,7 @@ import css from "../styles/datatype.css.js";
 
 export const name = "core/data-type";
 
-export async function run(conf) {
+export function run(conf) {
   if (!conf.highlightVars) {
     return;
   }

--- a/src/core/dfn-index.js
+++ b/src/core/dfn-index.js
@@ -46,14 +46,14 @@ const CODE_TYPES = new Set([
  * @typedef {{ term: string, type: string, linkFor: string, elem: HTMLAnchorElement }} Entry
  */
 
-export async function run() {
+export function run() {
   const index = document.querySelector("section#index");
   if (!index) {
     return;
   }
 
   const styleEl = document.createElement("style");
-  styleEl.textContent = await css;
+  styleEl.textContent = css;
   document.head.appendChild(styleEl);
 
   index.classList.add("appendix");

--- a/src/core/dfn-index.js
+++ b/src/core/dfn-index.js
@@ -6,7 +6,7 @@
  */
 
 import { addId, getIntlData, norm } from "./utils.js";
-import { fetchAsset } from "./text-loader.js";
+import css from "../styles/dfn-index.css.js";
 import { getTermFromElement } from "./xref.js";
 import { html } from "./import-maps.js";
 import { renderInlineCitation } from "./render-biblio.js";
@@ -53,7 +53,7 @@ export async function run() {
   }
 
   const styleEl = document.createElement("style");
-  styleEl.textContent = await loadStyle();
+  styleEl.textContent = await css;
   document.head.appendChild(styleEl);
 
   index.classList.add("appendix");
@@ -360,14 +360,6 @@ function getTermText(entry) {
   }
 
   return text;
-}
-
-async function loadStyle() {
-  try {
-    return (await import("text!../../assets/dfn-index.css")).default;
-  } catch {
-    return fetchAsset("dfn-index.css");
-  }
 }
 
 /** @param {Document} doc */

--- a/src/core/dfn-panel.js
+++ b/src/core/dfn-panel.js
@@ -2,14 +2,14 @@
 // Constructs "dfn panels" which show all the local references to a dfn and a
 // self link to the selected dfn. Based on Bikeshed's dfn panels at
 // https://github.com/tabatkins/bikeshed/blob/ef44162c2e/bikeshed/dfnpanels.py
-import { fetchAsset, fetchBase } from "./text-loader.js";
+import css from "../styles/dfn-panel.css.js";
+import { fetchBase } from "./text-loader.js";
 import { html } from "./import-maps.js";
 import { norm } from "./utils.js";
 
 export const name = "core/dfn-panel";
 
 export async function run() {
-  const css = await loadStyle();
   document.head.insertBefore(
     html`<style>
       ${css}
@@ -146,14 +146,6 @@ function getReferenceTitle(link) {
   const heading = section.querySelector("h1, h2, h3, h4, h5, h6");
   if (!heading) return null;
   return norm(heading.textContent);
-}
-
-async function loadStyle() {
-  try {
-    return (await import("text!../../assets/dfn-panel.css")).default;
-  } catch {
-    return fetchAsset("dfn-panel.css");
-  }
 }
 
 async function loadScript() {

--- a/src/core/examples.js
+++ b/src/core/examples.js
@@ -7,7 +7,7 @@
 // be used by a containing shell to extract all examples.
 
 import { addId, getIntlData } from "./utils.js";
-import { fetchAsset } from "./text-loader.js";
+import css from "../styles/examples.css.js";
 import { html } from "./import-maps.js";
 import { pub } from "./pubsubhub.js";
 
@@ -38,16 +38,6 @@ const localizationStrings = {
 };
 
 const l10n = getIntlData(localizationStrings);
-
-const cssPromise = loadStyle();
-
-async function loadStyle() {
-  try {
-    return (await import("text!../../assets/examples.css")).default;
-  } catch {
-    return fetchAsset("examples.css");
-  }
-}
 
 /**
  * @typedef {object} Report
@@ -80,7 +70,6 @@ export async function run() {
   );
   if (!examples.length) return;
 
-  const css = await cssPromise;
   document.head.insertBefore(
     html`<style>
       ${css}

--- a/src/core/examples.js
+++ b/src/core/examples.js
@@ -63,7 +63,7 @@ function makeTitle(elem, num, report) {
   </div>`;
 }
 
-export async function run() {
+export function run() {
   /** @type {NodeListOf<HTMLElement>} */
   const examples = document.querySelectorAll(
     "pre.example, pre.illegal-example, aside.example"

--- a/src/core/highlight-vars.js
+++ b/src/core/highlight-vars.js
@@ -13,7 +13,7 @@ import { sub } from "./pubsubhub.js";
 
 export const name = "core/highlight-vars";
 
-export async function run(conf) {
+export function run(conf) {
   if (!conf.highlightVars) {
     return;
   }

--- a/src/core/highlight-vars.js
+++ b/src/core/highlight-vars.js
@@ -7,28 +7,18 @@
  * All is done while keeping in mind that exported html stays clean
  * on export.
  */
-import { fetchAsset } from "./text-loader.js";
+import css from "../styles/var.css.js";
 import { norm } from "./utils.js";
 import { sub } from "./pubsubhub.js";
 
 export const name = "core/highlight-vars";
-
-const hlVarsPromise = loadStyle();
-
-async function loadStyle() {
-  try {
-    return (await import("text!../../assets/var.css")).default;
-  } catch {
-    return fetchAsset("var.css");
-  }
-}
 
 export async function run(conf) {
   if (!conf.highlightVars) {
     return;
   }
   const styleElement = document.createElement("style");
-  styleElement.textContent = await hlVarsPromise;
+  styleElement.textContent = css;
   styleElement.classList.add("removeOnSave");
   document.head.appendChild(styleElement);
 

--- a/src/core/highlight.js
+++ b/src/core/highlight.js
@@ -4,23 +4,13 @@
  *
  * Performs syntax highlighting to all pre and code elements.
  */
-import { fetchAsset } from "./text-loader.js";
+import css from "../styles/highlight.css.js";
 import { html } from "./import-maps.js";
 import { msgIdGenerator } from "./utils.js";
 import { workerPromise } from "./worker.js";
 export const name = "core/highlight";
 
 const nextMsgId = msgIdGenerator("highlight");
-
-const ghCssPromise = loadStyle();
-
-async function loadStyle() {
-  try {
-    return (await import("text!../../assets/highlight.css")).default;
-  } catch {
-    return fetchAsset("highlight.css");
-  }
-}
 
 function getLanguageHint(classList) {
   return Array.from(classList)
@@ -101,10 +91,9 @@ export async function run(conf) {
   const promisesToHighlight = highlightables
     .filter(elem => elem.textContent.trim())
     .map(highlightElement);
-  const ghCss = await ghCssPromise;
   document.head.appendChild(
     html`<style>
-      ${ghCss}
+      ${css}
     </style>`
   );
   await Promise.all(promisesToHighlight);

--- a/src/core/issues-notes.js
+++ b/src/core/issues-notes.js
@@ -19,7 +19,7 @@ import {
   showError,
   showWarning,
 } from "./utils.js";
-import { fetchAsset } from "./text-loader.js";
+import css from "../styles/issues-notes.css.js";
 import { html } from "./import-maps.js";
 import { pub } from "./pubsubhub.js";
 
@@ -77,16 +77,6 @@ const localizationStrings = {
     warning: "警告",
   },
 };
-
-const cssPromise = loadStyle();
-
-async function loadStyle() {
-  try {
-    return (await import("text!../../assets/issues-notes.css")).default;
-  } catch {
-    return fetchAsset("issues-notes.css");
-  }
-}
 
 const l10n = getIntlData(localizationStrings);
 
@@ -385,7 +375,6 @@ export async function run(conf) {
     return; // nothing to do.
   }
   const ghIssues = await fetchAndStoreGithubIssues(conf.github);
-  const css = await cssPromise;
   const { head: headElem } = document;
   headElem.insertBefore(
     html`<style>

--- a/src/core/mdn-annotation.js
+++ b/src/core/mdn-annotation.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { fetchAndCache, getIntlData, showError } from "./utils.js";
-import { fetchAsset } from "./text-loader.js";
+import css from "../styles/mdn-annotation.css.js";
 import { html } from "./import-maps.js";
 
 export const name = "core/mdn-annotation";
@@ -41,14 +41,6 @@ const localizationStrings = {
   },
 };
 const l10n = getIntlData(localizationStrings);
-
-async function loadStyle() {
-  try {
-    return (await import("text!../../assets/mdn-annotation.css")).default;
-  } catch {
-    return fetchAsset("mdn-annotation.css");
-  }
-}
 
 /**
  * @param {HTMLElement} node
@@ -141,7 +133,7 @@ export async function run(conf) {
   if (!mdnSpecJson) return;
 
   const style = document.createElement("style");
-  style.textContent = await loadStyle();
+  style.textContent = css;
   document.head.append(style);
 
   for (const elem of findElements(mdnSpecJson)) {

--- a/src/core/style.js
+++ b/src/core/style.js
@@ -24,7 +24,7 @@ function insertStyle() {
   return styleElement;
 }
 
-export async function run(conf) {
+export function run(conf) {
   if (conf.noReSpecCSS) {
     styleElement.remove();
   }

--- a/src/core/style.js
+++ b/src/core/style.js
@@ -9,30 +9,23 @@
 // CONFIGURATION
 //  - noReSpecCSS: if you're using a profile that loads this module but you don't want
 //    the style, set this to true
-import { fetchAsset } from "./text-loader.js";
+import css from "../styles/respec.css.js";
+
 export const name = "core/style";
 
 // Opportunistically inserts the style, with the chance to reduce some FOUC
 const styleElement = insertStyle();
 
-async function loadStyle() {
-  try {
-    return (await import("text!../../assets/respec.css")).default;
-  } catch {
-    return fetchAsset("respec.css");
-  }
-}
-
-async function insertStyle() {
+function insertStyle() {
   const styleElement = document.createElement("style");
   styleElement.id = "respec-mainstyle";
-  styleElement.textContent = await loadStyle();
+  styleElement.textContent = css;
   document.head.appendChild(styleElement);
   return styleElement;
 }
 
 export async function run(conf) {
   if (conf.noReSpecCSS) {
-    (await styleElement).remove();
+    styleElement.remove();
   }
 }

--- a/src/core/text-loader.js
+++ b/src/core/text-loader.js
@@ -5,10 +5,3 @@ export async function fetchBase(path) {
   const response = await fetch(new URL(`../../${path}`, import.meta.url));
   return await response.text();
 }
-
-/**
- * @param {string} fileName
- */
-export async function fetchAsset(fileName) {
-  return fetchBase(`assets/${fileName}`);
-}

--- a/src/core/ui.js
+++ b/src/core/ui.js
@@ -9,7 +9,7 @@
 //  - make a release candidate that people can test
 //  - once we have something decent, merge, ship as 3.2.0
 import { html, pluralize } from "./import-maps.js";
-import { fetchAsset } from "./text-loader.js";
+import css from "../styles/ui.css.js";
 import { joinAnd } from "./utils.js";
 import { markdownToHtml } from "./markdown.js";
 import { sub } from "./pubsubhub.js";
@@ -18,18 +18,10 @@ export const name = "core/ui";
 // Opportunistically inserts the style, with the chance to reduce some FOUC
 insertStyle();
 
-async function loadStyle() {
-  try {
-    return (await import("text!../../assets/ui.css")).default;
-  } catch {
-    return fetchAsset("ui.css");
-  }
-}
-
-async function insertStyle() {
+function insertStyle() {
   const styleElement = document.createElement("style");
   styleElement.id = "respec-ui-styles";
-  styleElement.textContent = await loadStyle();
+  styleElement.textContent = css;
   styleElement.classList.add("removeOnSave");
   document.head.appendChild(styleElement);
   return styleElement;

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -14,7 +14,7 @@ import {
 import { decorateDfn, findDfn } from "./dfn-finder.js";
 import { html, webidl2 } from "./import-maps.js";
 import { addCopyIDLButton } from "./webidl-clipboard.js";
-import { fetchAsset } from "./text-loader.js";
+import css from "../styles/webidl.css.js";
 import { registerDefinition } from "./dfn-map.js";
 
 export const name = "core/webidl";
@@ -377,16 +377,6 @@ export function addIDLHeader(pre) {
   addCopyIDLButton(header);
 }
 
-const cssPromise = loadStyle();
-
-async function loadStyle() {
-  try {
-    return (await import("text!../../assets/webidl.css")).default;
-  } catch {
-    return fetchAsset("webidl.css");
-  }
-}
-
 export async function run() {
   const idls = document.querySelectorAll("pre.idl, pre.webidl");
   if (!idls.length) {
@@ -396,7 +386,7 @@ export async function run() {
     const link = document.querySelector("head link");
     if (link) {
       const style = document.createElement("style");
-      style.textContent = await cssPromise;
+      style.textContent = css;
       link.before(style);
     }
   }

--- a/src/styles/algorithms.css.js
+++ b/src/styles/algorithms.css.js
@@ -1,0 +1,12 @@
+/* For assertions in lists containing algorithms */
+const css = String.raw;
+
+// Prettier ignore only to keep code indented from level 0.
+// prettier-ignore
+export default css`
+.assert {
+  background: #eee;
+  border-left: 0.5em solid #aaa;
+  padding: 0.3em;
+}
+`;

--- a/src/styles/caniuse.css.js
+++ b/src/styles/caniuse.css.js
@@ -1,4 +1,9 @@
 /* container for stats */
+const css = String.raw;
+
+// Prettier ignore only to keep code indented from level 0.
+// prettier-ignore
+export default css`
 .caniuse-stats {
   display: flex;
   flex-wrap: wrap;
@@ -125,3 +130,4 @@ see https://github.com/Fyrd/caniuse/blob/master/CONTRIBUTING.md for stats */
 .caniuse-stats .caniuse-browser:hover > ul {
   display: block;
 }
+`;

--- a/src/styles/datatype.css.js
+++ b/src/styles/datatype.css.js
@@ -1,3 +1,8 @@
+const css = String.raw;
+
+// Prettier ignore only to keep code indented from level 0.
+// prettier-ignore
+export default css`
 var {
   position: relative;
   cursor: pointer;
@@ -43,3 +48,4 @@ var[data-type]:hover::after,
 var[data-type]:hover::before {
   opacity: 1;
 }
+`;

--- a/src/styles/dfn-index.css.js
+++ b/src/styles/dfn-index.css.js
@@ -2,6 +2,11 @@
 @module "core/dfn-index"
 Extends and overrides some styles from `base.css`.
 */
+const css = String.raw;
+
+// Prettier ignore only to keep code indented from level 0.
+// prettier-ignore
+export default css`
 ul.index {
   columns: 30ch;
   column-gap: 1.5em;
@@ -34,3 +39,4 @@ ul.index code {
     display: initial;
   }
 }
+`;

--- a/src/styles/dfn-panel.css.js
+++ b/src/styles/dfn-panel.css.js
@@ -3,6 +3,11 @@
  * TODO: Revert changes due to https://github.com/w3c/respec/pull/2888 when
  * https://github.com/w3c/css-validator/pull/111 is fixed.
  */
+const css = String.raw;
+
+// Prettier ignore only to keep code indented from level 0.
+// prettier-ignore
+export default css`
 dfn {
   cursor: pointer;
 }
@@ -109,3 +114,4 @@ dfn {
   max-height: 30vh;
   overflow: auto;
 }
+`;

--- a/src/styles/examples.css.js
+++ b/src/styles/examples.css.js
@@ -1,4 +1,9 @@
 /* --- EXAMPLES --- */
+const css = String.raw;
+
+// Prettier ignore only to keep code indented from level 0.
+// prettier-ignore
+export default css`
 span.example-title {
   text-transform: none;
 }
@@ -41,3 +46,4 @@ aside.example div.example span.example-title {
 .example pre {
   background-color: rgba(0, 0, 0, 0.03);
 }
+`;

--- a/src/styles/highlight.css.js
+++ b/src/styles/highlight.css.js
@@ -15,6 +15,11 @@ hue-6:   #986801
 hue-6-2: #c18401
 */
 
+const css = String.raw;
+
+// Prettier ignore only to keep code indented from level 0.
+// prettier-ignore
+export default css`
 .hljs {
   display: block;
   overflow-x: auto;
@@ -92,3 +97,4 @@ hue-6-2: #c18401
 .hljs-link {
   text-decoration: underline;
 }
+`;

--- a/src/styles/issues-notes.css.js
+++ b/src/styles/issues-notes.css.js
@@ -1,4 +1,9 @@
 /* --- ISSUES/NOTES --- */
+const css = String.raw;
+
+// Prettier ignore only to keep code indented from level 0.
+// prettier-ignore
+export default css`
 .issue-label {
     text-transform: initial;
 }
@@ -52,3 +57,4 @@ input.task-list-item-checkbox {
   border: none;
   display: inline-block;
 }
+`;

--- a/src/styles/mdn-annotation.css.js
+++ b/src/styles/mdn-annotation.css.js
@@ -1,3 +1,8 @@
+const css = String.raw;
+
+// Prettier ignore only to keep code indented from level 0.
+// prettier-ignore
+export default css`
 .mdn {
   font-size: 0.75em;
   position: absolute;
@@ -134,3 +139,4 @@
 .mdn .webview_android::before {
   background-image: url(https://resources.whatwg.org/browser-logos/android-webview.png);
 }
+`;

--- a/src/styles/respec.css.js
+++ b/src/styles/respec.css.js
@@ -1,6 +1,9 @@
-/*****************************************************************
- * ReSpec specific CSS
- *****************************************************************/
+/* ReSpec specific CSS */
+const css = String.raw;
+
+// Prettier ignore only to keep code indented from level 0.
+// prettier-ignore
+export default css`
 @keyframes pop {
   0% {
     transform: scale(1, 1);
@@ -283,3 +286,4 @@ h6 > a.self-link::before {
     display: none;
   }
 }
+`;

--- a/src/styles/ui.css.js
+++ b/src/styles/ui.css.js
@@ -1,3 +1,8 @@
+const css = String.raw;
+
+// Prettier ignore only to keep code indented from level 0.
+// prettier-ignore
+export default css`
 .respec-modal .close-button {
   position: absolute;
   z-index: inherit;
@@ -448,3 +453,4 @@
   margin: 0 0.5em 0.5em;
   border-bottom-width: 1px;
 }
+`;

--- a/src/styles/ui.css.js
+++ b/src/styles/ui.css.js
@@ -6,7 +6,7 @@ export default css`
 .respec-modal .close-button {
   position: absolute;
   z-index: inherit;
-  padding: .2em;
+  padding: 0.2em;
   font-weight: bold;
   cursor: pointer;
   margin-left: 5px;
@@ -333,107 +333,13 @@ export default css`
   left: 127px;
 }
 
-#specref-ui {
-  margin: 0 2%;
-  margin-bottom: 0.5cm;
-}
-
-#specref-ui header {
-  font-size: 0.7em;
-  background-color: #eee;
-  text-align: center;
-  padding: 0.2cm;
-  margin-bottom: 0.5cm;
-  border-radius: 0 0 0.2cm 0.2cm;
-}
-
-#specref-ui header h1 {
-  padding: 0;
-  margin: 0;
-  color: black;
-}
-
-#specref-ui p {
-  padding: 0;
-  margin: 0;
-  font-size: 0.8em;
-  text-align: center;
-}
-
-#specref-ui p.state {
-  margin: 1cm;
-}
-
-#specref-ui .searchcomponent {
-  font-size: 16px;
-  display: grid;
-  grid-template-columns: auto 2cm;
-}
-#specref-ui .searchcomponent:focus {
-}
-
-#specref-ui input,
-#specref-ui button {
-  border: 0;
-  padding: 6px 12px;
-}
-
-#specref-ui label {
-  font-size: 0.6em;
-  grid-column-end: 3;
-  text-align: right;
-  grid-column-start: 1;
-}
-
-#specref-ui input[type="search"] {
-  -webkit-appearance: none;
-  font-size: 16px;
-  border-radius: 0.1cm 0 0 0.1cm;
-  border: 1px solid rgb(204, 204, 204);
-}
-
-#specref-ui button[type="submit"] {
-  color: white;
-  border-radius: 0 0.1cm 0.1cm 0;
-  background-color: rgb(51, 122, 183);
-}
-
-#specref-ui button[type="submit"]:hover {
-  background-color: #286090;
-  border-color: #204d74;
-}
-
-#specref-ui .result-stats {
-  margin: 0;
-  padding: 0;
-  color: rgb(128, 128, 128);
-  font-size: 0.7em;
-  font-weight: bold;
-}
-
-#specref-ui .specref-results {
-  font-size: 0.8em;
-}
-
-#specref-ui .specref-results dd + dt {
-  margin-top: 0.51cm;
-}
-
-#specref-ui .specref-results a {
-  text-transform: capitalize;
-}
-#specref-ui .specref-results .authors {
-  display: block;
-  color: #006621;
-}
-
 @media print {
   #respec-ui {
     display: none;
   }
 }
 
-#xref-ui {
+.respec-iframe {
   width: 100%;
   min-height: 550px;
   height: 100%;
@@ -443,11 +349,11 @@ export default css`
   border: 0;
 }
 
-#xref-ui:not(.ready) {
+.respec-iframe:not(.ready) {
   background: url("https://respec.org/xref/loader.gif") no-repeat center;
 }
 
-#xref-ui + a[href] {
+.respec-iframe + a[href] {
   font-size: 0.9rem;
   float: right;
   margin: 0 0.5em 0.5em;

--- a/src/styles/var.css.js
+++ b/src/styles/var.css.js
@@ -1,3 +1,8 @@
+const css = String.raw;
+
+// Prettier ignore only to keep code indented from level 0.
+// prettier-ignore
+export default css`
 var:hover {
   text-decoration: underline;
   cursor: pointer;
@@ -47,3 +52,4 @@ var.respec-hl-c7 {
     box-shadow: unset;
   }
 }
+`;

--- a/src/styles/webidl.css.js
+++ b/src/styles/webidl.css.js
@@ -1,5 +1,9 @@
 /* --- WEB IDL --- */
+const css = String.raw;
 
+// Prettier ignore only to keep code indented from level 0.
+// prettier-ignore
+export default css`
 pre.idl {
   padding: 1em;
   position: relative;
@@ -138,3 +142,4 @@ a.idlEnumItem {
     visibility: hidden;
   }
 }
+`;

--- a/tools/builder.js
+++ b/tools/builder.js
@@ -7,7 +7,6 @@ const { promises: fsp } = require("fs");
 const path = require("path");
 const { rollup } = require("rollup");
 const alias = require("@rollup/plugin-alias");
-const minifyHTML = require("rollup-plugin-minify-html-literals").default;
 
 colors.setTheme({
   error: "red",
@@ -83,17 +82,18 @@ const Builder = {
         string({
           include: [/\.runtime\.js$/, /\.svg$/, /respec-worker\.js$/],
         }),
-        minifyHTML({
-          include: [/\.css\.js$/],
-          options: {
-            minifyOptions: {
-              minifyCSS: { format: "keep-breaks" },
+        !debug &&
+          require("rollup-plugin-minify-html-literals").default({
+            include: [/\.css\.js$/],
+            options: {
+              minifyOptions: {
+                minifyCSS: { format: "keep-breaks" },
+              },
+              // disable html`` minification
+              shouldMinify: () => false,
+              shouldMinifyCSS: ({ tag }) => !debug && tag === "css",
             },
-            // disable html`` minification
-            shouldMinify: () => false,
-            shouldMinifyCSS: ({ tag }) => !debug && tag === "css",
-          },
-        }),
+          }),
       ],
       onwarn(warning, warn) {
         if (warning.code !== "CIRCULAR_DEPENDENCY") {


### PR DESCRIPTION
This PR converts all `fetchAsset(file.css)` and `import(text!file.css)` to regular JS imports. 
The benefit being, cleaner code and less async-await, and slightly smaller bundle size. Worth doing?

<details>
<summary>Size changes</summary>

| File             |  After | Before | Diff      |
| ---------------- | -----: | -----: | --------: |
| respec-w3c.js    | 305747 | 308252 | -2.5Kb 🟢 |
| respec-w3c.js.br |  84910 |  84815 | +0.1Kb 🔴 |
| respec-w3c.js.gz |  99233 |  98219 | +1.0Kb 🔴 |

</details>