### PR TITLE
tests(build): fix fileExists check, remove chai, run in CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -51,6 +51,7 @@ jobs:
           npm ci
           npm run build:w3c
       - run: npm run test:headless
+      - run: npm run test:build
 
   test-karma:
     name: Karma Unit Tests (${{ matrix.browser }})

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,12 +46,10 @@ jobs:
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-12-${{ hashFiles('**/package-lock.json') }}
-      - name: install & build
-        run: |
-          npm ci
-          npm run build:w3c
-      - run: npm run test:headless
+      - run: npm ci
       - run: npm run test:build
+      - run: npm run build:w3c
+      - run: npm run test:headless
 
   test-karma:
     name: Karma Unit Tests (${{ matrix.browser }})

--- a/package-lock.json
+++ b/package-lock.json
@@ -478,12 +478,6 @@
         "es-abstract": "^1.17.0-next.1"
       }
     },
-    "assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true
-    },
     "astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -716,20 +710,6 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
-    "chai": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.4.tgz",
-      "integrity": "sha512-yS5H68VYOCtN1cjfwumDSuzn/9c+yza4f3reKXlE5rUg7SFcCEy90gJvydNgOYtblyf4Zi6jIWRnXOgErta0KA==",
-      "dev": true,
-      "requires": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
-        "get-func-name": "^2.0.0",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.5"
-      }
-    },
     "chalk": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -740,12 +720,6 @@
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       }
-    },
-    "check-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
-      "dev": true
     },
     "chokidar": {
       "version": "3.5.1",
@@ -1061,15 +1035,6 @@
       "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
       "requires": {
         "ms": "2.1.2"
-      }
-    },
-    "deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-      "dev": true,
-      "requires": {
-        "type-detect": "^4.0.0"
       }
     },
     "deep-equal": {
@@ -1932,12 +1897,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "dev": true
-    },
-    "get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
       "dev": true
     },
     "get-stream": {
@@ -2979,12 +2938,6 @@
       "requires": {
         "pify": "^2.0.0"
       }
-    },
-    "pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true
     },
     "pend": {
       "version": "1.2.0",
@@ -4071,12 +4024,6 @@
       "requires": {
         "prelude-ls": "^1.2.1"
       }
-    },
-    "type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true
     },
     "type-fest": {
       "version": "0.20.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@types/marked": "^2.0.0",
     "@types/pluralize": "0.0.29",
     "boxen": "^5.0.0",
-    "chai": "^4.3.4",
     "chokidar": "^3.5.1",
     "clean-css": "^5.1.2",
     "epipebomb": "^1.0.0",

--- a/tests/test-build.js
+++ b/tests/test-build.js
@@ -1,6 +1,7 @@
 /* eslint-env node */
 const { readFile, access } = require("fs/promises");
 const { F_OK } = require("fs").constants;
+const { execSync } = require("child_process");
 const path = require("path");
 const { Builder } = require("../tools/builder");
 
@@ -17,6 +18,7 @@ describe("builder (tool)", () => {
   jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
 
   const profiles = ["w3c", "geonovum"];
+  const rootDir = path.join(__dirname, "..");
 
   beforeAll(async () => {
     await Promise.all(
@@ -24,9 +26,13 @@ describe("builder (tool)", () => {
     );
   });
 
+  afterAll(() => {
+    execSync("git checkout -- builds", { cwd: rootDir });
+  });
+
   for (const profile of profiles) {
-    const profileFile = path.join(__dirname, `../builds/respec-${profile}.js`);
-    const mapFile = path.join(__dirname, `../builds/respec-${profile}.js.map`);
+    const profileFile = path.join(rootDir, `builds/respec-${profile}.js`);
+    const mapFile = path.join(rootDir, `builds/respec-${profile}.js.map`);
     it(`builds the "${profile}" profile and sourcemap`, async () => {
       await expectAsync(fileExists(profileFile)).toBeResolvedTo(true);
       await expectAsync(fileExists(mapFile)).toBeResolvedTo(true);

--- a/tests/test-build.js
+++ b/tests/test-build.js
@@ -1,6 +1,8 @@
 /* eslint-env node */
-const { readFile, access } = require("fs/promises");
-const { F_OK } = require("fs").constants;
+const {
+  constants: { F_OK },
+  promises: { readFile, access },
+} = require("fs");
 const { execSync } = require("child_process");
 const path = require("path");
 const { Builder } = require("../tools/builder");

--- a/tests/test-build.js
+++ b/tests/test-build.js
@@ -29,7 +29,7 @@ describe("builder (tool)", () => {
   });
 
   afterAll(() => {
-    execSync("git checkout -- builds", { cwd: rootDir });
+    execSync("git restore builds", { cwd: rootDir });
   });
 
   for (const profile of profiles) {

--- a/tests/test-build.js
+++ b/tests/test-build.js
@@ -39,7 +39,7 @@ describe("builder (tool)", () => {
     });
     it(`includes sourcemap link for "${profile}"`, async () => {
       const source = await readFile(profileFile, "utf-8");
-      expect(source.includes(`${profile}.js.map`)).toBeTrue();
+      expect(source).toContain(`${profile}.js.map`);
     });
   }
 });

--- a/tests/test-build.js
+++ b/tests/test-build.js
@@ -1,12 +1,16 @@
 /* eslint-env node */
-const { readFile, lstat } = require("fs").promises;
+const { readFile, access } = require("fs/promises");
+const { F_OK } = require("fs").constants;
 const path = require("path");
-const expect = require("chai").expect;
 const { Builder } = require("../tools/builder");
 
 async function fileExists(filePath) {
-  const stats = await lstat(filePath);
-  return stats.fileExists();
+  try {
+    await access(filePath, F_OK);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 describe("builder (tool)", () => {
@@ -24,12 +28,12 @@ describe("builder (tool)", () => {
     const profileFile = path.join(__dirname, `../builds/respec-${profile}.js`);
     const mapFile = path.join(__dirname, `../builds/respec-${profile}.js.map`);
     it(`builds the "${profile}" profile and sourcemap`, async () => {
-      expect(await fileExists(profileFile)).to.equal(true);
-      expect(await fileExists(mapFile)).to.equal(true);
+      await expectAsync(fileExists(profileFile)).toBeResolvedTo(true);
+      await expectAsync(fileExists(mapFile)).toBeResolvedTo(true);
     });
     it(`includes sourcemap link for "${profile}"`, async () => {
       const source = await readFile(profileFile, "utf-8");
-      expect(source.includes(`${profile}.js.map`)).to.equal(true);
+      expect(source.includes(`${profile}.js.map`)).toBeTrue();
     });
   }
 });


### PR DESCRIPTION
- Fix fileExists check in `test-build.js` (`stats.fileExists()` is not a function)
- Remove chai dependency, use jasmine's matchers
- Cleanup `builds` dir after running `test:build`
- Run `test:build` in CI