### PR TITLE
refactor(tests/headless): use jasmine instead of custom runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "server": "serve",
     "start": "node ./tools/dev-server.js",
     "test:build": "jasmine --random=false ./tests/test-build.js",
-    "test:headless": "node ./tests/headless.js",
+    "test:headless": "jasmine --random=false ./tests/headless.js",
     "test:karma": "karma start --single-run"
   },
   "dependencies": {


### PR DESCRIPTION
Less custom stuff is better I guess.
Logs aren't as pretty as before, but that can be fixed by using a different jasmine reporter (when jasmine makes it easier).