### PR TITLE
tests(core/a11y): increase timeout

### DIFF
--- a/tests/spec/core/a11y-spec.js
+++ b/tests/spec/core/a11y-spec.js
@@ -3,7 +3,13 @@
 import { flushIframes, makeRSDoc, makeStandardOps } from "../SpecHelper.js";
 
 describe("Core — a11y", () => {
-  afterAll(flushIframes);
+  beforeAll(() => {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL *= 2;
+  });
+  afterAll(() => {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL /= 2;
+    flushIframes();
+  });
 
   const body = `
     <section>


### PR DESCRIPTION
To avoid tests failing due to timeout, which often requires restarting them.