### PR TITLE
chore(tools/dev-server): run dev server before tests, help msg

### DIFF
--- a/tools/dev-server.js
+++ b/tools/dev-server.js
@@ -120,11 +120,9 @@ async function run(args) {
     execSync("git checkout -- builds", { stdio: "inherit" });
   });
 
-  printWelcomeMessage(args);
-
-  await unitTestServer.start();
-  await integrationTestServer.start();
   devServer.listen(SERVE_PORT);
+  printWelcomeMessage(args);
+  await Promise.all([unitTestServer.start(), integrationTestServer.start()]);
   await buildAndTest({ profile: args.profile });
 
   function registerStdinHandler() {


### PR DESCRIPTION
If `BROWSERS` or `--browser` is not set, devServer didn't start (blocked on await KarmaServer).