### PR TITLE
refactor(core/linter-rules/a11y): convert core/a11y to linter rule

### DIFF
--- a/profiles/w3c.js
+++ b/profiles/w3c.js
@@ -74,7 +74,7 @@ const modules = [
   import("../src/core/linter-rules/privsec-section.js"),
   import("../src/core/linter-rules/wpt-tests-exist.js"),
   import("../src/core/linter-rules/no-http-props.js"),
-  import("../src/core/a11y.js"),
+  import("../src/core/linter-rules/a11y.js"),
 ];
 
 async function domReady() {

--- a/src/core/defaults.js
+++ b/src/core/defaults.js
@@ -14,6 +14,7 @@ export const coreDefaults = {
     "check-internal-slots": false,
     "check-charset": false,
     "privsec-section": false,
+    a11y: false,
   },
   pluralize: true,
   specStatus: "base",

--- a/src/core/defaults.js
+++ b/src/core/defaults.js
@@ -14,7 +14,6 @@ export const coreDefaults = {
     "check-internal-slots": false,
     "check-charset": false,
     "privsec-section": false,
-    a11y: false,
   },
   pluralize: true,
   specStatus: "base",

--- a/src/core/linter-rules/a11y.js
+++ b/src/core/linter-rules/a11y.js
@@ -1,12 +1,11 @@
 // @ts-check
 /**
- * Module: core/a11y
  * Lints for accessibility issues using axe-core package.
  */
 
-import { showError, showWarning } from "./utils.js";
+import { showError, showWarning } from "../utils.js";
 
-export const name = "core/a11y";
+export const name = "core/linter-rules//a11y";
 
 const DISABLED_RULES = [
   "color-contrast", // too slow 🐢
@@ -16,11 +15,12 @@ const DISABLED_RULES = [
 ];
 
 export async function run(conf) {
-  if (!conf.a11y) {
+  if (!conf.lint?.a11y && /** legacy */ !conf.a11y) {
     return;
   }
+  const config = conf.lint?.a11y || /** legacy */ conf.a11y;
 
-  const options = conf.a11y === true ? {} : conf.a11y;
+  const options = config === true ? {} : config;
   const violations = await getViolations(options);
   for (const violation of violations) {
     /**

--- a/src/core/linter-rules/a11y.js
+++ b/src/core/linter-rules/a11y.js
@@ -5,7 +5,7 @@
 
 import { showError, showWarning } from "../utils.js";
 
-export const name = "core/linter-rules//a11y";
+export const name = "core/linter-rules/a11y";
 
 const DISABLED_RULES = [
   "color-contrast", // too slow 🐢

--- a/src/type-helper.d.ts
+++ b/src/type-helper.d.ts
@@ -15,7 +15,7 @@ declare module "text!*" {
   export default value;
 }
 
-// See: core/a11y
+// See: core/linter-rules/a11y
 interface AxeViolation {
   id: string;
   help: string;

--- a/src/w3c/defaults.js
+++ b/src/w3c/defaults.js
@@ -19,6 +19,7 @@ const w3cDefaults = {
   lint: {
     "privsec-section": true,
     "wpt-tests-exist": false,
+    a11y: false,
   },
   doJsonLd: false,
   logos: [],

--- a/tests/spec/core/linter-rules/a11y-spec.js
+++ b/tests/spec/core/linter-rules/a11y-spec.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import { flushIframes, makeRSDoc, makeStandardOps } from "../SpecHelper.js";
+import { flushIframes, makeRSDoc, makeStandardOps } from "../../SpecHelper.js";
 
 describe("Core — a11y", () => {
   beforeAll(() => {
@@ -34,14 +34,14 @@ describe("Core — a11y", () => {
   });
 
   it("does nothing if disabled", async () => {
-    const ops = makeStandardOps({ a11y: false }, body);
+    const ops = makeStandardOps({ lint: { a11y: false } }, body);
     const doc = await makeRSDoc(ops);
     const offendingElements = doc.querySelectorAll(".respec-offending-element");
     expect(offendingElements).toHaveSize(0);
   });
 
   it("runs default tests if enabled", async () => {
-    const ops = makeStandardOps({ a11y: true }, body);
+    const ops = makeStandardOps({ lint: { a11y: true } }, body);
     const doc = await makeRSDoc(ops);
     const offendingElements = doc.querySelectorAll(".respec-offending-element");
 
@@ -54,7 +54,7 @@ describe("Core — a11y", () => {
     const a11yOptions = {
       runOnly: ["image-alt", "landmark-one-main"],
     };
-    const ops = makeStandardOps({ a11y: a11yOptions }, body);
+    const ops = makeStandardOps({ lint: { a11y: a11yOptions } }, body);
     const doc = await makeRSDoc(ops);
 
     const offendingElements = doc.querySelectorAll(".respec-offending-element");
@@ -71,7 +71,7 @@ describe("Core — a11y", () => {
         "image-alt": { enabled: false },
       },
     };
-    const ops = makeStandardOps({ a11y: a11yOptions }, body);
+    const ops = makeStandardOps({ lint: { a11y: a11yOptions } }, body);
     const doc = await makeRSDoc(ops);
 
     const offendingElements = doc.querySelectorAll(".respec-offending-element");

--- a/tests/spec/core/linter-rules/a11y-spec.js
+++ b/tests/spec/core/linter-rules/a11y-spec.js
@@ -62,6 +62,16 @@ describe("Core — a11y", () => {
     expect(offendingElements[0].id).toContain("a11y-landmark-one-main");
     expect(offendingElements[0].localName).toBe("html");
     expect(offendingElements[1].id).toBe("image-alt-1");
+
+    const warnings = doc.respec.warnings.filter(
+      warn => warn.plugin === "core/linter-rules/a11y"
+    );
+    expect(warnings).toHaveSize(2);
+    const [imageAltWarning, landmarkWarning] = warnings;
+    expect(imageAltWarning.message).toContain("image-alt");
+    expect(imageAltWarning.elements).toHaveSize(1);
+    expect(imageAltWarning.elements[0].id).toBe("image-alt-1");
+    expect(landmarkWarning.message).toContain("landmark-one-main");
   });
 
   it("allows overriding rules option", async () => {
@@ -78,5 +88,11 @@ describe("Core — a11y", () => {
     expect(offendingElements).toHaveSize(1);
     expect(offendingElements[0].id).toContain("a11y-landmark-one-main");
     expect(offendingElements[0].localName).toBe("html");
+
+    const warnings = doc.respec.warnings.filter(
+      warn => warn.plugin === "core/linter-rules/a11y"
+    );
+    expect(warnings).toHaveSize(1);
+    expect(warnings[0].message).toContain("landmark-one-main");
   });
 });

--- a/tests/spec/w3c/defaults-spec.js
+++ b/tests/spec/w3c/defaults-spec.js
@@ -21,6 +21,7 @@ describe("W3C — Defaults", () => {
       "check-internal-slots": false,
       "check-charset": false,
       "wpt-tests-exist": false,
+      a11y: false,
     });
     expect(rsConf.highlightVars).toBe(true);
     expect(rsConf.license).toBe("w3c-software-doc");
@@ -61,6 +62,7 @@ describe("W3C — Defaults", () => {
       "check-internal-slots": true,
       "check-charset": false,
       "wpt-tests-exist": false,
+      a11y: false,
     });
     expect(rsConf.highlightVars).toBe(false);
     expect(rsConf.license).toBe("c0");


### PR DESCRIPTION
- convert to linter-rule while supporting `conf.a11y` for backward compatibility.
- improve tests