### PR TITLE
fix(core/data-cite|xref): use xref hrefs when available

### DIFF
--- a/src/core/data-cite.js
+++ b/src/core/data-cite.js
@@ -127,7 +127,7 @@ const findPath = makeComponentFinder("/");
  * @property {boolean} isNormative
  * @property {string} frag
  * @property {string} path
- * @property {string} href - canonical href coming from xref
+ * @property {string} [href] - canonical href coming from xref
  * @param {HTMLElement} elem
  * @return {CiteDetails};
  */

--- a/src/core/data-cite.js
+++ b/src/core/data-cite.js
@@ -71,40 +71,42 @@ function linkElem(elem, linkProps, citeDetails) {
   const { href, title } = linkProps;
   const wrapInCiteEl = !citeDetails.path && !citeDetails.frag;
 
-  if (elem instanceof HTMLAnchorElement) {
-    if (elem.textContent === "" && elem.dataset.lt !== "the-empty-string") {
-      elem.textContent = title;
+  if (elem.localName === "a") {
+    const anchor = /** @type {HTMLAnchorElement} */ (elem);
+    if (anchor.textContent === "" && anchor.dataset.lt !== "the-empty-string") {
+      anchor.textContent = title;
     }
-    elem.href = href;
+    anchor.href = href;
     if (wrapInCiteEl) {
       const cite = document.createElement("cite");
-      elem.replaceWith(cite);
-      cite.append(elem);
+      anchor.replaceWith(cite);
+      cite.append(anchor);
     }
     return;
   }
-  // It's a dfn
-  const anchor = document.createElement("a");
-  anchor.href = href;
-  if (!elem.textContent) {
-    anchor.textContent = title;
-    elem.append(anchor);
-  } else {
-    wrapInner(elem, anchor);
+
+  if (elem.localName === "dfn") {
+    const anchor = document.createElement("a");
+    anchor.href = href;
+    if (!elem.textContent) {
+      anchor.textContent = title;
+      elem.append(anchor);
+    } else {
+      wrapInner(elem, anchor);
+    }
+    if (wrapInCiteEl) {
+      const cite = document.createElement("cite");
+      cite.append(anchor);
+      elem.append(cite);
+    }
+    if ("export" in elem.dataset) {
+      const msg = "Exporting an linked external definition is not allowed.";
+      const hint = "Please remove the `data-export` attribute.";
+      showError(msg, name, { hint, elements: [elem] });
+      delete elem.dataset.export;
+    }
+    elem.dataset.noExport = "";
   }
-  if (wrapInCiteEl) {
-    const cite = document.createElement("cite");
-    cite.append(anchor);
-    elem.append(cite);
-  }
-  if ("export" in elem.dataset) {
-    const msg = "Exporting an linked external definition is not allowed.";
-    const hint = "Please remove the `data-export` attribute.";
-    showError(msg, name, { hint, elements: [elem] });
-    delete elem.dataset.export;
-  }
-  elem.classList.add("externalDFN");
-  elem.dataset.noExport = "";
 }
 
 /**

--- a/src/core/data-cite.js
+++ b/src/core/data-cite.js
@@ -29,7 +29,7 @@ export const THIS_SPEC = "__SPEC__";
  * @param {CiteDetails} citeDetails
  */
 async function getLinkProps(citeDetails) {
-  const { key, frag, path } = citeDetails;
+  const { key, frag, path, href: canonicalHref } = citeDetails;
   let href = "";
   let title = "";
   // This is just referring to this document
@@ -44,13 +44,18 @@ async function getLinkProps(citeDetails) {
     href = entry.href;
     title = entry.title;
   }
-  if (path) {
-    // See: https://github.com/w3c/respec/issues/1856#issuecomment-429579475
-    const relPath = path.startsWith("/") ? `.${path}` : path;
-    href = new URL(relPath, href).href;
-  }
-  if (frag) {
-    href = new URL(frag, href).href;
+  if (canonicalHref) {
+    // Xref gave us a canonical link, so let's use that.
+    href = canonicalHref;
+  } else {
+    if (path) {
+      // See: https://github.com/w3c/respec/issues/1856#issuecomment-429579475
+      const relPath = path.startsWith("/") ? `.${path}` : path;
+      href = new URL(relPath, href).href;
+    }
+    if (frag) {
+      href = new URL(frag, href).href;
+    }
   }
   return { href, title };
 }
@@ -66,42 +71,40 @@ function linkElem(elem, linkProps, citeDetails) {
   const { href, title } = linkProps;
   const wrapInCiteEl = !citeDetails.path && !citeDetails.frag;
 
-  if (elem.localName === "a") {
-    const anchor = /** @type {HTMLAnchorElement} */ (elem);
-    if (anchor.textContent === "" && anchor.dataset.lt !== "the-empty-string") {
-      anchor.textContent = title;
+  if (elem instanceof HTMLAnchorElement) {
+    if (elem.textContent === "" && elem.dataset.lt !== "the-empty-string") {
+      elem.textContent = title;
     }
-    anchor.href = href;
+    elem.href = href;
     if (wrapInCiteEl) {
       const cite = document.createElement("cite");
-      anchor.replaceWith(cite);
-      cite.append(anchor);
+      elem.replaceWith(cite);
+      cite.append(elem);
     }
     return;
   }
-
-  if (elem.localName === "dfn") {
-    const anchor = document.createElement("a");
-    anchor.href = href;
-    if (!elem.textContent) {
-      anchor.textContent = title;
-      elem.append(anchor);
-    } else {
-      wrapInner(elem, anchor);
-    }
-    if (wrapInCiteEl) {
-      const cite = document.createElement("cite");
-      cite.append(anchor);
-      elem.append(cite);
-    }
-    if ("export" in elem.dataset) {
-      const msg = "Exporting an linked external definition is not allowed.";
-      const hint = "Please remove the `data-export` attribute.";
-      showError(msg, name, { hint, elements: [elem] });
-      delete elem.dataset.export;
-    }
-    elem.dataset.noExport = "";
+  // It's a dfn
+  const anchor = document.createElement("a");
+  anchor.href = href;
+  if (!elem.textContent) {
+    anchor.textContent = title;
+    elem.append(anchor);
+  } else {
+    wrapInner(elem, anchor);
   }
+  if (wrapInCiteEl) {
+    const cite = document.createElement("cite");
+    cite.append(anchor);
+    elem.append(cite);
+  }
+  if ("export" in elem.dataset) {
+    const msg = "Exporting an linked external definition is not allowed.";
+    const hint = "Please remove the `data-export` attribute.";
+    showError(msg, name, { hint, elements: [elem] });
+    delete elem.dataset.export;
+  }
+  elem.classList.add("externalDFN");
+  elem.dataset.noExport = "";
 }
 
 /**
@@ -124,13 +127,14 @@ const findPath = makeComponentFinder("/");
  * @property {boolean} isNormative
  * @property {string} frag
  * @property {string} path
- *
+ * @property {string} href - canonical href coming from xref
  * @param {HTMLElement} elem
  * @return {CiteDetails};
  */
 export function toCiteDetails(elem) {
   const { dataset } = elem;
-  const { cite: rawKey, citeFrag, citePath } = dataset;
+  const { cite: rawKey, citeFrag, citePath, citeHref } = dataset;
+
   // The key is a fragment, resolve using the shortName as key
   if (rawKey.startsWith("#") && !citeFrag) {
     // Closes data-cite not starting with "#"
@@ -152,7 +156,7 @@ export function toCiteDetails(elem) {
   // key is before "/" and "#" but after "!" or "?" (e.g., ?key/path#frag)
   const hasPrecedingMark = /^[?|!]/.test(rawKey);
   const key = rawKey.split(/[/|#]/)[0].substring(Number(hasPrecedingMark));
-  const details = { key, isNormative, frag, path };
+  const details = { key, isNormative, frag, path, href: citeHref };
   return details;
 }
 

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -391,11 +391,17 @@ function addDataCite(elem, query, result, conf) {
   const { uri, shortname, spec, normative, type, for: forContext } = result;
   // if authored spec context had `result.spec`, use it instead of shortname
   const cite = specs.flat().includes(spec) ? spec : shortname;
-  const url = new URL(uri, "https://example.org");
+  // we use this "partial" URL to resolve parts of urls...
+  // but sometimes we get lucky and we get an absolute URL from xref
+  // which we can then use in other places (e.g., data-cite.js)
+  const url = new URL(uri, "https://partial");
   const { pathname: citePath } = url;
   const citeFrag = url.hash.slice(1);
   const dataset = { cite, citePath, citeFrag, type };
   if (forContext) dataset.linkFor = forContext[0];
+  if (url.origin && url.origin !== "https://partial") {
+    dataset.citeHref = url.href;
+  }
   Object.assign(elem.dataset, dataset);
 
   addToReferences(elem, cite, normative, term, conf);


### PR DESCRIPTION
Somewhat high priority... this is what was causing those weird URL issues that we saw the other day where, for example, we ended up with urls like TR/foo/TR/foo#whatever.  
 