### PR TITLE
fix(w3c/templates/sotd): pluralize groups when noRecTrack

### DIFF
--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -260,7 +260,9 @@ function renderDeliverer(conf) {
       `
     : "";
   const wontBeRec = recNotExpected
-    ? "The group does not expect this document to become a W3C Recommendation."
+    ? `The ${
+        multipleWGs ? "groups do" : "group does"
+      } not expect this document to become a W3C Recommendation.`
     : "";
   return html`<p data-deliverer="${isNote || isIGNote ? wgId : null}">
     ${producers} ${wontBeRec}

--- a/tests/spec/w3c/group-spec.js
+++ b/tests/spec/w3c/group-spec.js
@@ -39,6 +39,18 @@ describe("W3C — Group", () => {
     ]);
   });
 
+  it("when a multiple groups are specified, and it's noRecTrack true, it pluralizes the groups", async () => {
+    const ops = makeStandardOps({
+      group: ["payments", "webapps"],
+      noRecTrack: true,
+    });
+    const doc = await makeRSDoc(ops);
+    const sotd = doc.getElementById("sotd").textContent;
+    expect(sotd).toContain(
+      "The groups do not expect this document to become a W3C Recommendation."
+    );
+  });
+
   it("overrides superseded options", async () => {
     const inputConf = { group: "payments", wg: "foo", wgId: "1234" };
     const conf = await getGroupConf(inputConf);


### PR DESCRIPTION
closes #3494 