### PR TITLE
fix(core/anchor-expander): don't copy attributes when expanding

### DIFF
--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -552,14 +552,23 @@ export function getLinkTargets(elem) {
  * Changes name of a DOM Element
  * @param {Element} elem element to rename
  * @param {String} newName new element name
+ * @param {Object} options
+ * @param {boolean} options.copyAttributes
+ *
  * @returns {Element} new renamed element
  */
-export function renameElement(elem, newName) {
+export function renameElement(
+  elem,
+  newName,
+  options = { copyAttributes: true }
+) {
   if (elem.localName === newName) return elem;
   const newElement = elem.ownerDocument.createElement(newName);
   // copy attributes
-  for (const { name, value } of elem.attributes) {
-    newElement.setAttribute(name, value);
+  if (options.copyAttributes) {
+    for (const { name, value } of elem.attributes) {
+      newElement.setAttribute(name, value);
+    }
   }
   // copy child nodes
   newElement.append(...elem.childNodes);
@@ -717,10 +726,7 @@ export function makeSafeCopy(node) {
   const clone = node.cloneNode(true);
   clone.querySelectorAll("[id]").forEach(elem => elem.removeAttribute("id"));
   clone.querySelectorAll("dfn").forEach(dfn => {
-    const span = renameElement(dfn, "span");
-    for (const { name } of span.attributes) {
-      span.removeAttribute(name);
-    }
+    renameElement(dfn, "span", { copyAttributes: false });
   });
   if (clone.hasAttribute("id")) clone.removeAttribute("id");
   removeCommentNodes(clone);

--- a/tests/spec/core/anchor-expander-spec.js
+++ b/tests/spec/core/anchor-expander-spec.js
@@ -85,6 +85,32 @@ describe("Core - anchor-expander", () => {
     expect(secondSpan.textContent).toBe("span");
     expect(secondSpan.dataset.value).toBe("pass");
   });
+
+  it("safely copies IDL defined things without copying their attributes", async () => {
+    const body = `
+    <section data-dfn-for="Foo" id="thefoo">
+      <h2>
+        <dfn>Foo</dfn> interface
+      </h2>
+      <pre class="idl">
+      [Exposed=Window]
+      interface Foo {};
+      </pre>
+      <p id="expansion">
+       [[[#thefoo]]]
+      </p>
+    </section>`;
+    const ops = makeStandardOps({}, body);
+    const doc = await makeRSDoc(ops);
+    expect(doc.querySelector("#expansion dfn")).toBeNull();
+    expect(doc.querySelector("#expansion *[id]")).toBeNull();
+    const span = doc.querySelector("#expansion a > span");
+    expect(span.attributes).toHaveSize(0);
+    const code = span.firstElementChild;
+    expect(code.localName).toBe("code");
+    expect(code.textContent).toBe("Foo");
+  });
+
   it("gets applies contextual directional and language information to expanded nodes", async () => {
     const body = `
       <section lang="ar" class="introductory">

--- a/tests/spec/core/utils-spec.js
+++ b/tests/spec/core/utils-spec.js
@@ -470,6 +470,19 @@ describe("Core - Utils", () => {
         div.remove();
         a.remove();
       });
+
+      it("renames elements and doesn't copy attributes when copyAttributes is false", () => {
+        const a = document.createElement("a");
+        a.setAttribute("class", "some-class");
+        a.setAttribute("title", "title");
+        a.innerHTML = "<span id='inner-pass'>pass</span>";
+        document.body.appendChild(a);
+        const div = utils.renameElement(a, "div", { copyAttributes: false });
+        expect(div instanceof HTMLDivElement).toBe(true);
+        expect(div.attributes).toHaveSize(0);
+        div.remove();
+        a.remove();
+      });
     });
 
     describe("addId", () => {


### PR DESCRIPTION
Should close #3486 