### PR TITLE
fix(w3c/headers): don't add W3C to h2 for 'base' documents

### DIFF
--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -157,7 +157,7 @@ const status2text = {
   REC: "Recommendation",
   RSCND: "Rescinded Recommendation",
   unofficial: "Unofficial Draft",
-  base: "Document",
+  base: "",
   finding: "TAG Finding",
   "draft-finding": "Draft TAG Finding",
   "CG-DRAFT": "Draft Community Group Report",

--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -514,7 +514,7 @@ export function run(conf) {
       "Add an [`errata`](https://respec.org/docs/#errata) URL to your respecConfig.";
     showError(msg, name, { hint });
   }
-  conf.prependW3C = !conf.isUnofficial;
+  conf.prependW3C = !conf.isBasic && !conf.isUnofficial;
   conf.isED = conf.specStatus === "ED";
   conf.isCR = conf.specStatus === "CR" || conf.specStatus === "CRD";
   conf.isCRDraft = conf.specStatus === "CRD";

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -67,6 +67,16 @@ describe("W3C — Headers", () => {
         "has received the endorsement of the W3C and its Members. W3C recommends the wide deployment of this specification as a standard for the Web."
       );
     });
+
+    describe("specStatus - base", () => {
+      it("doesn't add 'w3c' to header when status is base", async () => {
+        const ops = makeStandardOps({
+          specStatus: "base",
+        });
+        const doc = await makeRSDoc(ops);
+        expect(doc.querySelector(".head h2").textContent).not.toContain("W3C");
+      });
+    });
   });
 
   describe("shortName", () => {


### PR DESCRIPTION
closes #3542