### PR TITLE
fix(core/ui): display plugin name after error msg

### DIFF
--- a/src/core/ui.js
+++ b/src/core/ui.js
@@ -264,7 +264,7 @@ function rsErrorToHTML(err) {
     return err;
   }
 
-  const plugin = err.plugin ? ` <small>Plugin: "${err.plugin}"</small>` : "";
+  const plugin = err.plugin ? ` <small>(Plugin: "${err.plugin}")</small>.` : "";
   const hint = err.hint ? ` ${err.hint}` : "";
   const elements = Array.isArray(err.elements)
     ? ` Occurred at: ${joinAnd(err.elements.map(generateMarkdownLink))}.`
@@ -273,7 +273,7 @@ function rsErrorToHTML(err) {
     ? `\n\n<details>\n${err.details}\n</details>\n`
     : "";
 
-  const text = `${err.message}${hint}${elements}${details}${plugin}.`;
+  const text = `${err.message}${hint}${elements}${plugin}${details}`;
   return markdownToHtml(text);
 }
 

--- a/src/core/ui.js
+++ b/src/core/ui.js
@@ -264,7 +264,7 @@ function rsErrorToHTML(err) {
     return err;
   }
 
-  const plugin = err.plugin ? `(${err.plugin}): ` : "";
+  const plugin = err.plugin ? ` <small>Plugin: "${err.plugin}"</small>` : "";
   const hint = err.hint ? ` ${err.hint}` : "";
   const elements = Array.isArray(err.elements)
     ? ` Occurred at: ${joinAnd(err.elements.map(generateMarkdownLink))}.`
@@ -273,7 +273,7 @@ function rsErrorToHTML(err) {
     ? `\n\n<details>\n${err.details}\n</details>\n`
     : "";
 
-  const text = `${plugin}${err.message}${hint}${elements}${details}`;
+  const text = `${err.message}${hint}${elements}${details}${plugin}.`;
   return markdownToHtml(text);
 }
 


### PR DESCRIPTION
The plugin name itself is not very useful for regular users, but useful for debugging... so putting it last. 

<img width="1024" alt="Screen Shot 2021-05-20 at 12 08 11 pm" src="https://user-images.githubusercontent.com/870154/118908108-18456000-b964-11eb-8f31-3eb74a939ff0.png">