### PR TITLE
fix(w3c/templates/headers): show versions links for TAG docs

### DIFF
--- a/src/w3c/templates/headers.js
+++ b/src/w3c/templates/headers.js
@@ -140,7 +140,7 @@ export default (conf, options) => {
         : ""}
     </h2>
     <dl>
-      ${!conf.isNoTrack
+      ${conf.isTagFinding || !conf.isNoTrack
         ? html`
             <dt>${l10n.this_version}</dt>
             <dd>

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -68,6 +68,26 @@ describe("W3C — Headers", () => {
       );
     });
 
+    it("includes version links for 'draft-finding'", async () => {
+      const ops = makeStandardOps({
+        showname: "test",
+        specStatus: "draft-finding",
+      });
+      const doc = await makeRSDoc(ops);
+      const definitions = doc.querySelectorAll(".head dt");
+      const [firstDt, secondDt, thirdDt] = definitions;
+
+      expect(firstDt.textContent).toContain("This version:");
+      const firstA = firstDt.nextElementSibling.querySelector("a");
+      expect(firstA.href).toContain("/2001/tag/");
+
+      expect(secondDt.textContent).toContain("Latest published version:");
+      const secondA = secondDt.nextElementSibling.querySelector("a");
+      expect(secondA.href).toContain("/2001/tag/");
+
+      expect(thirdDt.textContent).toContain("Latest editor's draft:");
+    });
+
     describe("specStatus - base", () => {
       it("doesn't add 'w3c' to header when status is base", async () => {
         const ops = makeStandardOps({

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -83,7 +83,7 @@ describe("W3C — Headers", () => {
 
       expect(secondDt.textContent).toContain("Latest published version:");
       const secondA = secondDt.nextElementSibling.querySelector("a");
-      expect(secondA.href).toContain("/2001/tag/");
+      expect(secondA.href).toContain("/2001/tag/doc/test");
 
       expect(thirdDt.textContent).toContain("Latest editor's draft:");
     });

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -70,7 +70,7 @@ describe("W3C — Headers", () => {
 
     it("includes version links for 'draft-finding'", async () => {
       const ops = makeStandardOps({
-        showname: "test",
+        shortName: "test",
         specStatus: "draft-finding",
       });
       const doc = await makeRSDoc(ops);

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -79,7 +79,7 @@ describe("W3C — Headers", () => {
 
       expect(firstDt.textContent).toContain("This version:");
       const firstA = firstDt.nextElementSibling.querySelector("a");
-      expect(firstA.href).toContain("/2001/tag/");
+      expect(firstA.href).toContain("/2001/tag/doc/test-");
 
       expect(secondDt.textContent).toContain("Latest published version:");
       const secondA = secondDt.nextElementSibling.querySelector("a");


### PR DESCRIPTION
Fixes https://github.com/w3c/respec/issues/3541