### PR TITLE
fix(w3c/style): misspelled finding-draft

### DIFF
--- a/src/w3c/style.js
+++ b/src/w3c/style.js
@@ -148,7 +148,7 @@ export function run(conf) {
       styleFile += "UD";
       break;
     case "FINDING":
-    case "FINDING-DRAFT":
+    case "DRAFT-FINDING":
     case "BASE":
       styleFile = "base.css";
       break;

--- a/tests/spec/w3c/style-spec.js
+++ b/tests/spec/w3c/style-spec.js
@@ -23,6 +23,10 @@ const specStatus = [
     expectedURL: "https://www.w3.org/StyleSheets/TR/{version}base.css",
   },
   {
+    status: "draft-finding",
+    expectedURL: "https://www.w3.org/StyleSheets/TR/{version}base.css",
+  },
+  {
     status: "unofficial",
     expectedURL: "https://www.w3.org/StyleSheets/TR/{version}W3C-UD",
   },


### PR DESCRIPTION
this was backwards 🥴