### PR TITLE
fix(core/linter/local-refs-exist): check links not starting with hash

### DIFF
--- a/src/core/linter-rules/local-refs-exist.js
+++ b/src/core/linter-rules/local-refs-exist.js
@@ -22,7 +22,7 @@ export function run(conf) {
   }
 
   /** @type {NodeListOf<HTMLAnchorElement>} */
-  const elems = document.querySelectorAll("a[href^='#']");
+  const elems = document.querySelectorAll("a[href]");
   const offendingElements = [...elems].filter(isBrokenHyperlink);
   if (offendingElements.length) {
     showWarning(l10n.msg, name, {
@@ -32,8 +32,13 @@ export function run(conf) {
   }
 }
 
+/** @param {HTMLAnchorElement} elem */
 function isBrokenHyperlink(elem) {
-  const id = elem.getAttribute("href").substring(1);
+  if (elem.pathname !== location.pathname || !elem.hash) {
+    return false;
+  }
+
+  const id = elem.hash.substring(1);
   const doc = elem.ownerDocument;
   return !doc.getElementById(id) && !doc.getElementsByName(id).length;
 }

--- a/src/core/linter-rules/local-refs-exist.js
+++ b/src/core/linter-rules/local-refs-exist.js
@@ -23,7 +23,10 @@ export function run(conf) {
 
   /** @type {NodeListOf<HTMLAnchorElement>} */
   const elems = document.querySelectorAll("a[href]");
-  const offendingElements = [...elems].filter(isBrokenHyperlink);
+  const baseURI = new URL(document.baseURI);
+  const offendingElements = [...elems].filter(elem =>
+    isBrokenHyperlink(elem, baseURI)
+  );
   if (offendingElements.length) {
     showWarning(l10n.msg, name, {
       hint: l10n.hint,
@@ -32,9 +35,16 @@ export function run(conf) {
   }
 }
 
-/** @param {HTMLAnchorElement} elem */
-function isBrokenHyperlink(elem) {
-  if (!elem.hash || elem.pathname !== new URL(document.baseURI).pathname) {
+/**
+ * @param {HTMLAnchorElement} elem
+ * @param {URL} baseURI
+ */
+function isBrokenHyperlink(elem, baseURI) {
+  if (!elem.hash) {
+    return false;
+  }
+  if (elem.origin === baseURI.origin && elem.pathname !== baseURI.pathname) {
+    // skip fragment links outside current page
     return false;
   }
 

--- a/src/core/linter-rules/local-refs-exist.js
+++ b/src/core/linter-rules/local-refs-exist.js
@@ -34,11 +34,11 @@ export function run(conf) {
 
 /** @param {HTMLAnchorElement} elem */
 function isBrokenHyperlink(elem) {
-  if (elem.pathname !== location.pathname || !elem.hash) {
+  if (!elem.hash || elem.pathname !== new URL(document.baseURI).pathname) {
     return false;
   }
 
-  const id = elem.hash.substring(1);
+  const id = decodeURIComponent(elem.hash.substring(1));
   const doc = elem.ownerDocument;
   return !doc.getElementById(id) && !doc.getElementsByName(id).length;
 }

--- a/tests/unit/core/linter-rules/local-refs-exist-spec.js
+++ b/tests/unit/core/linter-rules/local-refs-exist-spec.js
@@ -19,13 +19,15 @@ describe("Core Linter Rule - 'local-refs-exist'", () => {
       <a href="#ID">PASS</a>
       <a href="#ID-NOT-EXIST">FAIL</a>
       <a href="#ID-NOT-EXIST">FAIL</a>
+      <a href="/outside-this-page-1234#ID-NOT-EXIST">PASS</a>
+      <a href="${location.pathname}#ID-NOT-EXIST">FAIL</a>
     `;
 
     const warnings = await getWarnings(body);
     expect(warnings).toHaveSize(1);
 
     const [warning] = warnings;
-    expect(warning.elements).toHaveSize(2);
+    expect(warning.elements).toHaveSize(3);
     const [offendingElement] = warning.elements;
     const { hash } = new URL(offendingElement.href);
     expect(hash).toBe("#ID-NOT-EXIST");


### PR DESCRIPTION
Had a URL like `http://localhost:3000/docs/#/docs%23examples` when serving a directory having a `docs` folder (not serving from docs as root). Found via spec-prod.