### PR TITLE
fix(core/dfn-panel): don't add title attribute to dfn

### DIFF
--- a/src/core/dfn-panel.js
+++ b/src/core/dfn-panel.js
@@ -28,7 +28,6 @@ export async function run() {
     // allowing keyboard action as needed.
     el.tabIndex = 0;
     el.setAttribute("aria-haspopup", "dialog");
-    if (!el.title) el.title = "Show what links to this definition";
   }
   document.body.append(panels);
 

--- a/tests/spec/core/dfn-index-spec.js
+++ b/tests/spec/core/dfn-index-spec.js
@@ -364,7 +364,6 @@ describe("Core — dfn-index", () => {
 
       expect(term.tabIndex).toBe(0);
       expect(term.getAttribute("aria-haspopup")).toBe("dialog");
-      expect(term.title).toBe("Show what links to this definition");
 
       expect(term.textContent).toBe("Event interface");
       expect(term.id).toBe("index-term-event-interface");


### PR DESCRIPTION
Fixes https://github.com/w3c/respec/issues/3592
Hotfix until we find a better solution.

We should probably use:
- `aria-controls`, or
- the `<dfn>term</dfn><button class="visually hidden">Show what links to this dfn: term</button>` approach.

I'll have to read more.