### PR TITLE
chore(tools/release): ensure npm 6 is used

### DIFF
--- a/tools/release.js
+++ b/tools/release.js
@@ -331,6 +331,10 @@ const indicators = new Map([
 ]);
 
 const run = async () => {
+  const npmVersion = await npm("--version");
+  if (!npmVersion.trim().startsWith("6")) {
+    throw new Error(`Must use npm 6.x for release. Found ${npmVersion}`);
+  }
   const initialBranch = await getCurrentBranch();
   try {
     // 1. Confirm maintainer is on up-to-date and on the develop branch ()


### PR DESCRIPTION
Can't use `lockfileVersion` as it gets generated some stage later.