### PR TITLE
fix(core/inlines): link global element attributes

### DIFF
--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -86,8 +86,7 @@ function inlineElementMatches(matched) {
     const isGlobalAttr = value.startsWith("/");
     if (isGlobalAttr) {
       return ["element-attr", null, forPart];
-    }
-    if (attrValue) {
+    } else if (attrValue) {
       return ["attr-value", `${forPart}/${attribute}`, attrValue];
     } else if (attribute) {
       return ["element-attr", forPart, attribute];

--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -76,17 +76,23 @@ const inlineElement = /(?:\[\^[^^]+\^\])/; // Inline [^element^]
  */
 function inlineElementMatches(matched) {
   const value = matched.slice(2, -2).trim();
-  const [element, attribute, attrValue] = value
+  const [forPart, attribute, attrValue] = value
     .split("/", 3)
     .map(s => s && s.trim())
     .filter(s => !!s);
+
   const [xrefType, xrefFor, textContent] = (() => {
+    // [^ /role ^], for example
+    const isGlobalAttr = value.startsWith("/");
+    if (isGlobalAttr) {
+      return ["element-attr", null, forPart];
+    }
     if (attrValue) {
-      return ["attr-value", `${element}/${attribute}`, attrValue];
+      return ["attr-value", `${forPart}/${attribute}`, attrValue];
     } else if (attribute) {
-      return ["element-attr", element, attribute];
+      return ["element-attr", forPart, attribute];
     } else {
-      return ["element", null, element];
+      return ["element", null, forPart];
     }
   })();
   return html`<code

--- a/tests/spec/core/inlines-spec.js
+++ b/tests/spec/core/inlines-spec.js
@@ -366,12 +366,13 @@ describe("Core - Inlines", () => {
     );
   });
 
-  it("processes inline inline [^element^]s.", async () => {
+  it("processes inline [^element^] and hierarchies.", async () => {
     const body = `
       <section>
         <p id="test">[^body^]</p>
         <p id="test2">[^iframe/allow^]</p>
         <p id="test3">[^ html-global/inputmode/text ^]</p>
+        <p id="test4">[^ /role ^]</p>
       </section>
     `;
     const doc = await makeRSDoc(makeStandardOps({ xref: ["HTML"] }, body));
@@ -383,6 +384,9 @@ describe("Core - Inlines", () => {
     const inputModeAnchor = doc.querySelector("#test3 a");
     expect(inputModeAnchor.textContent).toBe("text");
     expect(inputModeAnchor.hash).toBe("#attr-inputmode-keyword-text");
+    const roleAttribute = doc.querySelector("#test4 a");
+    expect(roleAttribute.textContent).toBe("role");
+    expect(roleAttribute.hash).toBe("#attr-aria-role");
   });
 
   it("processes [= BikeShed style inline links =]", async () => {


### PR DESCRIPTION
Fixes linking for `[^ /role ^]` attribute. 