### PR TITLE
fix(core/xref): order matters in tree

### DIFF
--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -242,7 +242,7 @@ function dedupeSpecContext(specs) {
     const uniqueSpecs = [...new Set(level)].filter(
       spec => !higherPriority.includes(spec)
     );
-    unique.push(uniqueSpecs.sort());
+    unique.push(uniqueSpecs);
   }
   return unique;
 }


### PR DESCRIPTION
@sidvishnoi, I think this might have been a mistake (but I'm a bit unsure)? The order at every level matters, so not sure this should be sorted?  