### PR TITLE
feat(core/dfn): use class name for definition type

### DIFF
--- a/src/core/dfn.js
+++ b/src/core/dfn.js
@@ -96,10 +96,10 @@ function computeTypeAndExport(dfn, linkingText) {
       break;
   }
 
-  // Get closest type from context
   // If the Editor explicitly asked for it to be exported, so let's export it.
   if (dfn.classList.contains("export")) shouldExport = true;
   
+  // Get closest type from context
   if (!type) {
     /** @type {HTMLElement} */
     const closestType = dfn.closest("[data-dfn-type]");

--- a/src/core/dfn.js
+++ b/src/core/dfn.js
@@ -98,7 +98,7 @@ function computeTypeAndExport(dfn, linkingText) {
 
   // If the Editor explicitly asked for it to be exported, so let's export it.
   if (dfn.classList.contains("export")) shouldExport = true;
-  
+
   // Get closest type from context
   if (!type) {
     /** @type {HTMLElement} */

--- a/src/core/dfn.js
+++ b/src/core/dfn.js
@@ -60,23 +60,7 @@ export function run() {
     }
 
     const [linkingText] = titles;
-
-    let { type, shouldExport } = computeTypeAndExport(dfn, linkingText);
-
-    // If the Editor explicitly asked for it to be exported, so let's export it.
-    if (dfn.classList.contains("export")) shouldExport = true;
-
-    if (shouldExport && !dfn.dataset.hasOwnProperty("noexport")) {
-      dfn.dataset.export = "";
-    }
-
-    // Get closest type from context
-    if (!type) {
-      /** @type {HTMLElement} */
-      const closestType = dfn.closest("[data-dfn-type]");
-      type = closestType?.dataset.dfnType;
-    }
-    if (!dfn.dataset.dfnType && type) dfn.dataset.dfnType = type;
+    computeTypeAndExport(dfn, linkingText);
 
     // Only add `lt`s that are different from the text content
     if (titles.length === 1 && linkingText === norm(dfn.textContent)) {
@@ -110,7 +94,21 @@ function computeTypeAndExport(dfn, linkingText) {
       type = processAsInternalSlot(linkingText, dfn);
       break;
   }
-  return { type, shouldExport };
+
+  // If the Editor explicitly asked for it to be exported, so let's export it.
+  if (dfn.classList.contains("export")) shouldExport = true;
+
+  if (shouldExport && !dfn.dataset.hasOwnProperty("noexport")) {
+    dfn.dataset.export = "";
+  }
+
+  // Get closest type from context
+  if (!type) {
+    /** @type {HTMLElement} */
+    const closestType = dfn.closest("[data-dfn-type]");
+    type = closestType?.dataset.dfnType;
+  }
+  if (!dfn.dataset.dfnType && type) dfn.dataset.dfnType = type;
 }
 
 function validateDefinition(dfn, linkingText, type) {

--- a/src/core/dfn.js
+++ b/src/core/dfn.js
@@ -97,16 +97,16 @@ function computeTypeAndExport(dfn, linkingText) {
   }
 
   // Get closest type from context
+  // If the Editor explicitly asked for it to be exported, so let's export it.
+  if (dfn.classList.contains("export")) shouldExport = true;
+  
   if (!type) {
     /** @type {HTMLElement} */
     const closestType = dfn.closest("[data-dfn-type]");
     type = closestType?.dataset.dfnType;
   }
+
   if (!dfn.dataset.dfnType && type) dfn.dataset.dfnType = type;
-
-  // If the Editor explicitly asked for it to be exported, so let's export it.
-  if (dfn.classList.contains("export")) shouldExport = true;
-
   if (shouldExport && !dfn.hasAttribute("data-noexport")) {
     dfn.dataset.export = "";
   }

--- a/src/core/dfn.js
+++ b/src/core/dfn.js
@@ -87,6 +87,11 @@ export function run() {
   sub("plugins-done", addContractDefaults);
 }
 
+/**
+ * @param {HTMLElement} dfn
+ * @param {string} linkingText
+ * @return {Object}
+ * */
 function computeTypeAndExport(dfn, linkingText) {
   let shouldExport = false;
   let type = "";

--- a/src/core/dfn.js
+++ b/src/core/dfn.js
@@ -30,7 +30,7 @@ const knownTypesMap = new Map([
     {
       requiresFor: true,
       associateWith: "an HTML attribute",
-      validator: validateDOMName,
+      validator: validateCommonName,
     },
   ],
   ["element", { requiresFor: false, validator: validateDOMName }],

--- a/src/core/dfn.js
+++ b/src/core/dfn.js
@@ -21,6 +21,7 @@ import { sub } from "./pubsubhub.js";
 
 export const name = "core/dfn";
 
+/** @type {Map<string, { requiresFor: boolean, validator?: (...args: any[]) => boolean, associateWith?: string}>}  */
 const knownTypesMap = new Map([
   ["abstract-op", { requiresFor: false }],
   ["attribute", { requiresFor: false, validator: validateDOMName }],
@@ -55,7 +56,7 @@ export function run() {
     registerDefinition(dfn, titles);
 
     // It's a legacy cite or redefining a something it doesn't own, so it gets no benefit.
-    if (dfn.dataset.cite && /.+#./.test(dfn.dataset.cite)) {
+    if (dfn.dataset.cite && /\b#\b/.test(dfn.dataset.cite)) {
       continue;
     }
 
@@ -74,7 +75,6 @@ export function run() {
 /**
  * @param {HTMLElement} dfn
  * @param {string} linkingText
- * @return {Object}
  * */
 function computeTypeAndExport(dfn, linkingText) {
   let shouldExport = false;
@@ -98,7 +98,7 @@ function computeTypeAndExport(dfn, linkingText) {
   // If the Editor explicitly asked for it to be exported, so let's export it.
   if (dfn.classList.contains("export")) shouldExport = true;
 
-  if (shouldExport && !dfn.dataset.hasOwnProperty("noexport")) {
+  if (shouldExport && !dfn.hasAttribute("data-noexport")) {
     dfn.dataset.export = "";
   }
 

--- a/src/core/dfn.js
+++ b/src/core/dfn.js
@@ -85,7 +85,7 @@ function computeTypeAndExport(dfn, linkingText) {
     case knownTypes.some(name => dfn.classList.contains(name)):
       // First one wins
       type = [...dfn.classList].find(className =>
-        knownTypes.includes(className)
+        knownTypesMap.has(className)
       );
       validateDefinition(linkingText, type, dfn);
       shouldExport = true;

--- a/src/core/dfn.js
+++ b/src/core/dfn.js
@@ -84,9 +84,7 @@ function computeTypeAndExport(dfn, linkingText) {
     // class defined type (e.g., "<dfn class="element">)
     case knownTypes.some(name => dfn.classList.contains(name)):
       // First one wins
-      type = [...dfn.classList].find(className =>
-        knownTypesMap.has(className)
-      );
+      type = [...dfn.classList].find(className => knownTypesMap.has(className));
       validateDefinition(linkingText, type, dfn);
       shouldExport = true;
       break;
@@ -98,13 +96,6 @@ function computeTypeAndExport(dfn, linkingText) {
       break;
   }
 
-  // If the Editor explicitly asked for it to be exported, so let's export it.
-  if (dfn.classList.contains("export")) shouldExport = true;
-
-  if (shouldExport && !dfn.hasAttribute("data-noexport")) {
-    dfn.dataset.export = "";
-  }
-
   // Get closest type from context
   if (!type) {
     /** @type {HTMLElement} */
@@ -112,6 +103,13 @@ function computeTypeAndExport(dfn, linkingText) {
     type = closestType?.dataset.dfnType;
   }
   if (!dfn.dataset.dfnType && type) dfn.dataset.dfnType = type;
+
+  // If the Editor explicitly asked for it to be exported, so let's export it.
+  if (dfn.classList.contains("export")) shouldExport = true;
+
+  if (shouldExport && !dfn.hasAttribute("data-noexport")) {
+    dfn.dataset.export = "";
+  }
 }
 
 /**

--- a/src/core/dfn.js
+++ b/src/core/dfn.js
@@ -21,7 +21,7 @@ import { sub } from "./pubsubhub.js";
 
 export const name = "core/dfn";
 
-/** @type {Map<string, { requiresFor: boolean, validator?: (...args: any[]) => boolean, associateWith?: string}>}  */
+/** @type {Map<string, { requiresFor: boolean, validator?: DefinitionValidator, associateWith?: string}>}  */
 const knownTypesMap = new Map([
   ["abstract-op", { requiresFor: false }],
   ["attribute", { requiresFor: false, validator: validateDOMName }],
@@ -84,7 +84,7 @@ function computeTypeAndExport(dfn, linkingText) {
     // class defined type (e.g., "<dfn class="element">)
     case knownTypes.some(name => dfn.classList.contains(name)):
       type = knownTypes.find(name => dfn.classList.contains(name));
-      validateDefinition(dfn, linkingText, type);
+      validateDefinition(linkingText, type, dfn);
       shouldExport = true;
       break;
 
@@ -111,7 +111,12 @@ function computeTypeAndExport(dfn, linkingText) {
   if (!dfn.dataset.dfnType && type) dfn.dataset.dfnType = type;
 }
 
-function validateDefinition(dfn, linkingText, type) {
+/**
+ * @param {string} text
+ * @param {string} type
+ * @param {HTMLElement} dfn
+ */
+function validateDefinition(text, type, dfn) {
   const entry = knownTypesMap.get(type);
   if (entry.requiresFor && !dfn.dataset.dfnFor) {
     const msg = docLink`Definition of type "\`${type}\`" requires a ${"[data-dfn-for]"} attribute.`;
@@ -121,7 +126,7 @@ function validateDefinition(dfn, linkingText, type) {
   }
 
   if (entry.validator) {
-    entry.validator(linkingText, type, dfn, name);
+    entry.validator(text, type, dfn, name);
   }
 }
 

--- a/src/core/dfn.js
+++ b/src/core/dfn.js
@@ -83,7 +83,10 @@ function computeTypeAndExport(dfn, linkingText) {
   switch (true) {
     // class defined type (e.g., "<dfn class="element">)
     case knownTypes.some(name => dfn.classList.contains(name)):
-      type = knownTypes.find(name => dfn.classList.contains(name));
+      // First one wins
+      type = [...dfn.classList].find(className =>
+        knownTypes.includes(className)
+      );
       validateDefinition(linkingText, type, dfn);
       shouldExport = true;
       break;

--- a/src/core/dfn.js
+++ b/src/core/dfn.js
@@ -61,7 +61,7 @@ export function run() {
 
     const [linkingText] = titles;
 
-    let { type, shouldExport } = computeTypeAndExport(linkingText);
+    let { type, shouldExport } = computeTypeAndExport(dfn, linkingText);
 
     // If the Editor explicitly asked for it to be exported, so let's export it.
     if (dfn.classList.contains("export")) shouldExport = true;

--- a/tests/spec/core/dfn-spec.js
+++ b/tests/spec/core/dfn-spec.js
@@ -329,4 +329,218 @@ describe("Core — Definitions", () => {
       expect(dfnErrors).toHaveSize(2);
     });
   });
+
+  describe("CSS class based definitions types", () => {
+    it("allows exporting definitions through a class", async () => {
+      const body = `
+      <section>
+        <h2>abstract operations</h2>
+        <p>
+          <dfn class="export">just a regular definition</dfn>
+        </p>
+      </section>
+      `;
+      const ops = makeStandardOps(null, body);
+      const doc = await makeRSDoc(ops);
+      const dfn = doc.querySelector("dfn");
+      expect(dfn.textContent).toBe("just a regular definition");
+      expect(dfn.dataset.export).toBe("");
+      expect(dfn.dataset.noexport).toBeUndefined();
+
+      // Check validation error
+      const errors = doc.respec.errors.filter(err => err.plugin === "core/dfn");
+      expect(errors).toHaveSize(0);
+    });
+
+    it("handles abstract operations", async () => {
+      const body = `
+      <section>
+        <h2>abstract operations</h2>
+        <p id="abstract-op">
+          <dfn class="abstract-op">abstract operation</dfn>
+        </p>
+      </section>
+      `;
+      const ops = makeStandardOps(null, body);
+      const doc = await makeRSDoc(ops);
+      const dfn = doc.querySelector("#abstract-op dfn");
+      expect(dfn.dataset.dfnType).toBe("abstract-op");
+      expect(dfn.dataset.export).toBe("");
+    });
+
+    it("handles attributes", async () => {
+      const body = `
+        <section>
+          <h2>Attributes</h2>
+          <p id="attributes">
+            <dfn class="attribute">some-attribute</dfn>
+          </p>
+          <p id="attribute-bad">
+            <dfn class="attribute">-attribute</dfn>
+          </p>
+        </section>
+      `;
+      const ops = makeStandardOps(null, body);
+      const doc = await makeRSDoc(ops);
+      const dfn = doc.querySelector("#attributes dfn");
+      expect(dfn.dataset.dfnType).toBe("attribute");
+      expect(dfn.dataset.export).toBe("");
+
+      // Check validation error
+      const errors = doc.respec.errors.filter(err => err.plugin === "core/dfn");
+      expect(errors).toHaveSize(1);
+    });
+
+    it("handles attribute values", async () => {
+      const body = `
+        <section>
+          <h2>Attribute values</h2>
+          <p id="attr-value">
+            <dfn class="attr-value" data-dfn-for="input/type">password</dfn>
+          </p>
+          <p id="attr-value-errors">
+            <dfn class="attr-value">some-text</dfn>
+            <dfn class="attr-value">-not-ok!</dfn>
+          </p>
+        </section>
+      `;
+      const ops = makeStandardOps(null, body);
+      const doc = await makeRSDoc(ops);
+      const dfn = doc.querySelector("#attr-value dfn");
+      expect(dfn.dataset.dfnFor).toBe("input/type");
+      expect(dfn.dataset.dfnType).toBe("attr-value");
+      expect(dfn.dataset.export).toBe("");
+
+      // Check validation error
+      const errors = doc.respec.errors.filter(err => err.plugin === "core/dfn");
+      expect(errors).toHaveSize(2);
+    });
+
+    it("handles elements", async () => {
+      const body = `
+        <section>
+          <h2>Elements</h2>
+          <p id="elements">
+            <dfn class="element">element</dfn>
+          </p>
+          <p id="elements-bad">
+            <dfn class="element">-element</dfn>
+          </p>
+        </section>
+      `;
+      const ops = makeStandardOps(null, body);
+      const doc = await makeRSDoc(ops);
+      const dfn = doc.querySelector("#elements dfn");
+      expect(dfn.dataset.dfnType).toBe("element");
+      expect(dfn.dataset.export).toBe("");
+
+      // Check validation error
+      const errors = doc.respec.errors.filter(err => err.plugin === "core/dfn");
+      expect(errors).toHaveSize(1);
+      expect(errors[0].message).toContain("-element");
+    });
+
+    it("handles element states", async () => {
+      const body = `
+        <section>
+          <h2>Element states</h2>
+          <p id="element-state">
+            <dfn data-dfn-for="input" data-dfn-type="element-state">Password</dfn>
+          </p>
+          <p id="element-state-bad">
+            <dfn class="element-state">terrible state</dfn>
+          </p>
+        </section>
+      `;
+      const ops = makeStandardOps(null, body);
+      const doc = await makeRSDoc(ops);
+      const dfn = doc.querySelector("#element-state dfn");
+      expect(dfn.dataset.dfnFor).toBe("input");
+      expect(dfn.dataset.dfnType).toBe("element-state");
+      expect(dfn.dataset.export).toBe("");
+
+      // Check validation error
+      const errors = doc.respec.errors.filter(err => err.plugin === "core/dfn");
+      // missing data-dfn-for and invalid name
+      expect(errors).toHaveSize(2);
+    });
+
+    it("handles events", async () => {
+      const body = `
+        <section>
+          <h2>Events</h2>
+          <p id="events">
+            <dfn class="event">DOMContentLoaded</dfn>
+          </p>
+          <p id="events-bad">
+            <dfn class="event">-event</dfn>
+          </p>
+        </section>
+      `;
+      const ops = makeStandardOps(null, body);
+      const doc = await makeRSDoc(ops);
+      const dfn = doc.querySelector("#events dfn");
+      expect(dfn.dataset.dfnType).toBe("event");
+      expect(dfn.dataset.export).toBe("");
+
+      // Check validation error
+      const errors = doc.respec.errors.filter(err => err.plugin === "core/dfn");
+      expect(errors).toHaveSize(1);
+      expect(errors[0].message).toContain("-event");
+    });
+
+    it("handles http-headers", async () => {
+      const body = `
+        <section>
+          <h2>HTTP Header</h2>
+          <p id="http-header">
+            <dfn class="http-header">Some-Header</dfn>
+          </p>
+        </section>
+      `;
+      const ops = makeStandardOps(null, body);
+      const doc = await makeRSDoc(ops);
+      const dfn = doc.querySelector("#http-header dfn");
+      expect(dfn.dataset.dfnType).toBe("http-header");
+      expect(dfn.dataset.export).toBe("");
+    });
+
+    it("handles schemes", async () => {
+      const body = `
+        <section>
+          <h2>Scheme</h2>
+          <p id="http-header">
+            <dfn class="scheme">scheme</dfn>
+          </p>
+        </section>
+      `;
+      const ops = makeStandardOps(null, body);
+      const doc = await makeRSDoc(ops);
+      const dfn = doc.querySelector("#http-header dfn");
+      expect(dfn.dataset.dfnType).toBe("scheme");
+      expect(dfn.dataset.export).toBe("");
+    });
+
+    it("handles media types", async () => {
+      const body = `
+        <section>
+          <h2>HTTP Header</h2>
+          <p id="http-header">
+            <dfn class="media-type">application/something-something</dfn>
+          </p>
+          <p id="http-header-bad">
+            <dfn class="media-type">bad type</dfn>
+        </section>
+      `;
+      const ops = makeStandardOps(null, body);
+      const doc = await makeRSDoc(ops);
+      const dfn = doc.querySelector("#http-header dfn");
+      expect(dfn.dataset.dfnType).toBe("media-type");
+      expect(dfn.dataset.export).toBe("");
+
+      // Check validation error
+      const errors = doc.respec.errors.filter(err => err.plugin === "core/dfn");
+      expect(errors).toHaveSize(1);
+    });
+  });
 });

--- a/tests/spec/core/dfn-spec.js
+++ b/tests/spec/core/dfn-spec.js
@@ -11,7 +11,8 @@ import {
 describe("Core — Definitions", () => {
   afterAll(flushIframes);
 
-  const findDfnErrors = doc => doc.respec.errors.filter(err => err.plugin === "core/dfn");
+  const findDfnErrors = doc =>
+    doc.respec.errors.filter(err => err.plugin === "core/dfn");
 
   it("processes definitions", async () => {
     const ops = {

--- a/tests/spec/core/dfn-spec.js
+++ b/tests/spec/core/dfn-spec.js
@@ -11,7 +11,7 @@ import {
 describe("Core — Definitions", () => {
   afterAll(flushIframes);
 
-  const findDfnErrors = err => err.plugin === "core/dfn";
+  const findDfnErrors = doc => doc.respec.errors.filter(err => err.plugin === "core/dfn");
 
   it("processes definitions", async () => {
     const ops = {

--- a/tests/spec/core/dfn-spec.js
+++ b/tests/spec/core/dfn-spec.js
@@ -445,7 +445,7 @@ describe("Core — Definitions", () => {
         <section>
           <h2>Element states</h2>
           <p id="element-state">
-            <dfn data-dfn-for="input" data-dfn-type="element-state">Password</dfn>
+            <dfn class="element-state" data-dfn-for="input">Password</dfn>
           </p>
           <p id="element-state-bad">
             <dfn class="element-state">terrible state</dfn>

--- a/tests/spec/core/dfn-spec.js
+++ b/tests/spec/core/dfn-spec.js
@@ -10,6 +10,9 @@ import {
 
 describe("Core — Definitions", () => {
   afterAll(flushIframes);
+
+  const findDfnErrors = err => err.plugin === "core/dfn";
+
   it("processes definitions", async () => {
     const ops = {
       config: makeBasicConfig(),
@@ -348,7 +351,7 @@ describe("Core — Definitions", () => {
       expect(dfn.dataset.noexport).toBeUndefined();
 
       // Check validation error
-      const errors = doc.respec.errors.filter(err => err.plugin === "core/dfn");
+      const errors = doc.respec.errors.filter(findDfnErrors);
       expect(errors).toHaveSize(0);
     });
 
@@ -387,8 +390,9 @@ describe("Core — Definitions", () => {
       expect(dfn.dataset.export).toBe("");
 
       // Check validation error
-      const errors = doc.respec.errors.filter(err => err.plugin === "core/dfn");
+      const errors = doc.respec.errors.filter(findDfnErrors);
       expect(errors).toHaveSize(1);
+      expect(errors[0].message).toContain("-attribute");
     });
 
     it("handles attribute values", async () => {
@@ -400,7 +404,7 @@ describe("Core — Definitions", () => {
           </p>
           <p id="attr-value-errors">
             <dfn class="attr-value">some-text</dfn>
-            <dfn class="attr-value">-not-ok!</dfn>
+            <dfn class="attr-value" data-dfn-for="input/type">-not-ok!</dfn>
           </p>
         </section>
       `;
@@ -412,8 +416,10 @@ describe("Core — Definitions", () => {
       expect(dfn.dataset.export).toBe("");
 
       // Check validation error
-      const errors = doc.respec.errors.filter(err => err.plugin === "core/dfn");
+      const errors = doc.respec.errors.filter(findDfnErrors);
       expect(errors).toHaveSize(2);
+      expect(errors[0].message).toContain("attr-value");
+      expect(errors[1].message).toContain("-not-ok!");
     });
 
     it("handles elements", async () => {
@@ -435,7 +441,7 @@ describe("Core — Definitions", () => {
       expect(dfn.dataset.export).toBe("");
 
       // Check validation error
-      const errors = doc.respec.errors.filter(err => err.plugin === "core/dfn");
+      const errors = doc.respec.errors.filter(findDfnErrors);
       expect(errors).toHaveSize(1);
       expect(errors[0].message).toContain("-element");
     });
@@ -460,9 +466,10 @@ describe("Core — Definitions", () => {
       expect(dfn.dataset.export).toBe("");
 
       // Check validation error
-      const errors = doc.respec.errors.filter(err => err.plugin === "core/dfn");
+      const errors = doc.respec.errors.filter(findDfnErrors);
       // missing data-dfn-for and invalid name
       expect(errors).toHaveSize(2);
+      expect(errors[1].message).toContain("terrible state");
     });
 
     it("handles events", async () => {
@@ -484,7 +491,7 @@ describe("Core — Definitions", () => {
       expect(dfn.dataset.export).toBe("");
 
       // Check validation error
-      const errors = doc.respec.errors.filter(err => err.plugin === "core/dfn");
+      const errors = doc.respec.errors.filter(findDfnErrors);
       expect(errors).toHaveSize(1);
       expect(errors[0].message).toContain("-event");
     });
@@ -539,8 +546,9 @@ describe("Core — Definitions", () => {
       expect(dfn.dataset.export).toBe("");
 
       // Check validation error
-      const errors = doc.respec.errors.filter(err => err.plugin === "core/dfn");
+      const errors = doc.respec.errors.filter(findDfnErrors);
       expect(errors).toHaveSize(1);
+      expect(errors[0].message).toContain("bad type");
     });
   });
 });

--- a/tests/spec/core/dfn-spec.js
+++ b/tests/spec/core/dfn-spec.js
@@ -351,7 +351,7 @@ describe("Core — Definitions", () => {
       expect(dfn.dataset.noexport).toBeUndefined();
 
       // Check validation error
-      const errors = doc.respec.errors.filter(findDfnErrors);
+      const errors = findDfnErrors(doc);
       expect(errors).toHaveSize(0);
     });
 
@@ -390,7 +390,7 @@ describe("Core — Definitions", () => {
       expect(dfn.dataset.export).toBe("");
 
       // Check validation error
-      const errors = doc.respec.errors.filter(findDfnErrors);
+      const errors = findDfnErrors(doc);
       expect(errors).toHaveSize(1);
       expect(errors[0].message).toContain("-attribute");
     });
@@ -416,7 +416,7 @@ describe("Core — Definitions", () => {
       expect(dfn.dataset.export).toBe("");
 
       // Check validation error
-      const errors = doc.respec.errors.filter(findDfnErrors);
+      const errors = findDfnErrors(doc);
       expect(errors).toHaveSize(2);
       expect(errors[0].message).toContain("attr-value");
       expect(errors[1].message).toContain("-not-ok!");
@@ -441,7 +441,7 @@ describe("Core — Definitions", () => {
       expect(dfn.dataset.export).toBe("");
 
       // Check validation error
-      const errors = doc.respec.errors.filter(findDfnErrors);
+      const errors = findDfnErrors(doc);
       expect(errors).toHaveSize(1);
       expect(errors[0].message).toContain("-element");
     });
@@ -466,7 +466,7 @@ describe("Core — Definitions", () => {
       expect(dfn.dataset.export).toBe("");
 
       // Check validation error
-      const errors = doc.respec.errors.filter(findDfnErrors);
+      const errors = findDfnErrors(doc);
       // missing data-dfn-for and invalid name
       expect(errors).toHaveSize(2);
       expect(errors[1].message).toContain("terrible state");
@@ -491,7 +491,7 @@ describe("Core — Definitions", () => {
       expect(dfn.dataset.export).toBe("");
 
       // Check validation error
-      const errors = doc.respec.errors.filter(findDfnErrors);
+      const errors = findDfnErrors(doc);
       expect(errors).toHaveSize(1);
       expect(errors[0].message).toContain("-event");
     });
@@ -546,7 +546,7 @@ describe("Core — Definitions", () => {
       expect(dfn.dataset.export).toBe("");
 
       // Check validation error
-      const errors = doc.respec.errors.filter(findDfnErrors);
+      const errors = findDfnErrors(doc);
       expect(errors).toHaveSize(1);
       expect(errors[0].message).toContain("bad type");
     });

--- a/tests/spec/core/dfn-spec.js
+++ b/tests/spec/core/dfn-spec.js
@@ -550,5 +550,22 @@ describe("Core — Definitions", () => {
       expect(errors).toHaveSize(1);
       expect(errors[0].message).toContain("bad type");
     });
+
+    it("handles multiple types in the class by allowing the first one to win", async () => {
+      const body = `
+        <section>
+          <h2>Multiple definitions</h2>
+          <p>
+            <dfn id="multiple-definitions" class="banana event element media-type">event</dfn>
+          </p>
+        </section>
+      `;
+      const ops = makeStandardOps(null, body);
+      const doc = await makeRSDoc(ops);
+      const dfn = doc.querySelector("#multiple-definitions");
+      expect(dfn.dataset.dfnType).toBe("event");
+      expect(dfn.textContent).toBe("event");
+      expect(dfn.dataset.export).toBe("");
+    });
   });
 });


### PR DESCRIPTION
Supports the following definition classes, to align with Bikeshed (per the contract):

  * abstract-op
  * attribute
  * attr-value
  * element
  * element-state
  * event
  * http-header
  * scheme

Adds one new one:

  * media-type

