### PR TITLE
feat(core/dfn): support "no-export" class

### DIFF
--- a/src/core/dfn.js
+++ b/src/core/dfn.js
@@ -61,7 +61,8 @@ export function run() {
     }
 
     const [linkingText] = titles;
-    computeTypeAndExport(dfn, linkingText);
+    computeType(dfn, linkingText);
+    computeExport(dfn);
 
     // Only add `lt`s that are different from the text content
     if (titles.length === 1 && linkingText === norm(dfn.textContent)) {
@@ -76,8 +77,7 @@ export function run() {
  * @param {HTMLElement} dfn
  * @param {string} linkingText
  * */
-function computeTypeAndExport(dfn, linkingText) {
-  let shouldExport = false;
+function computeType(dfn, linkingText) {
   let type = "";
 
   switch (true) {
@@ -86,29 +86,47 @@ function computeTypeAndExport(dfn, linkingText) {
       // First one wins
       type = [...dfn.classList].find(className => knownTypesMap.has(className));
       validateDefinition(linkingText, type, dfn);
-      shouldExport = true;
       break;
 
     // Internal slots: attributes+ methods (e.g., [[some words]](with, optional, arguments))
     case slotRegex.test(linkingText):
-      shouldExport = false;
       type = processAsInternalSlot(linkingText, dfn);
       break;
-  }
 
   // If the Editor explicitly asked for it to be exported, so let's export it.
   if (dfn.classList.contains("export")) shouldExport = true;
 
-  // Get closest type from context
+  // Assign the type
   if (!type) {
     /** @type {HTMLElement} */
     const closestType = dfn.closest("[data-dfn-type]");
     type = closestType?.dataset.dfnType;
+  } else if (!dfn.dataset.dfnType) {
+    dfn.dataset.dfnType = type;
   }
+}
 
-  if (!dfn.dataset.dfnType && type) dfn.dataset.dfnType = type;
-  if (shouldExport && !dfn.hasAttribute("data-noexport")) {
-    dfn.dataset.export = "";
+// Deal with export/no export
+function computeExport(dfn) {
+  switch (true) {
+    // If we have both exports and no exports, we should show an error.
+    case dfn.matches(".export.no-export"): {
+      const msg = docLink`Definition of declares both "export" and "no-export" css class.`;
+      const hint = "Please use only one.";
+      showError(msg, name, { elements: [dfn], hint });
+      break;
+    }
+
+    // No export wins
+    case dfn.matches(".no-export") || dfn.matches("[data-no-export]"):
+      delete dfn.dataset.export;
+      dfn.dataset.noexport = "";
+      break;
+
+    // If the author explicitly asked for it to be exported, so let's export it.
+    case dfn.matches(".export") && !dfn.matches("[data-no-export]"):
+      dfn.dataset.export = "";
+      break;
   }
 }
 
@@ -156,7 +174,9 @@ function processAsInternalSlot(title, dfn) {
   }
 
   // Don't export internal slots by default, as they are not supposed to be public.
-  if (!dfn.dataset.hasOwnProperty("export")) dfn.dataset.noexport = "";
+  if (!dfn.matches("export") && !dfn.matches("[data-export]")) {
+    dfn.dataset.noexport = "";
+  }
 
   // If it ends with a ), then it's method. Attribute otherwise.
   const derivedType = title.endsWith(")") ? "method" : "attribute";

--- a/src/core/dfn.js
+++ b/src/core/dfn.js
@@ -92,9 +92,7 @@ function computeType(dfn, linkingText) {
     case slotRegex.test(linkingText):
       type = processAsInternalSlot(linkingText, dfn);
       break;
-
-  // If the Editor explicitly asked for it to be exported, so let's export it.
-  if (dfn.classList.contains("export")) shouldExport = true;
+  }
 
   // Derive closest type
   if (!type && !dfn.matches("[data-dfn-type]")) {

--- a/src/core/dfn.js
+++ b/src/core/dfn.js
@@ -120,7 +120,7 @@ function computeExport(dfn) {
     }
 
     // No export wins
-    case dfn.matches(".no-export") || dfn.matches("[data-noexport]"):
+    case dfn.matches(".no-export, [data-noexport]"):
       if (dfn.matches("[data-export]")) {
         const msg = docLink`Declares ${"[no-export]"} CSS class, but also has a "${"[data-export]"}" attribute.`;
         const hint = "Please chose only one.";

--- a/src/core/dfn.js
+++ b/src/core/dfn.js
@@ -96,14 +96,18 @@ function computeType(dfn, linkingText) {
   // If the Editor explicitly asked for it to be exported, so let's export it.
   if (dfn.classList.contains("export")) shouldExport = true;
 
-  // Assign the type
-  if (!type) {
+  // Derive closest type
+  if (!type && !dfn.matches("[data-dfn-type]")) {
     /** @type {HTMLElement} */
     const closestType = dfn.closest("[data-dfn-type]");
     type = closestType?.dataset.dfnType;
-  } else if (!dfn.dataset.dfnType) {
+  }
+  // only if we have type and one wasn't explicitly given.
+  if (type && !dfn.dataset.dfnType) {
     dfn.dataset.dfnType = type;
   }
+  // Finally, addContractDefaults() will add the type to the dfn if it's not there.
+  // But other modules may end up adding a type (e.g., the WebIDL module)
 }
 
 // Deal with export/no export

--- a/src/core/dfn.js
+++ b/src/core/dfn.js
@@ -176,7 +176,7 @@ function processAsInternalSlot(title, dfn) {
   }
 
   // Don't export internal slots by default, as they are not supposed to be public.
-  if (!dfn.matches("export") && !dfn.matches("[data-export]")) {
+  if (!dfn.matches(".export") && !dfn.matches("[data-export]")) {
     dfn.dataset.noexport = "";
   }
 

--- a/src/core/dfn.js
+++ b/src/core/dfn.js
@@ -113,7 +113,7 @@ function computeExport(dfn) {
   switch (true) {
     // Error if we have both exports and no exports.
     case dfn.matches(".export.no-export"): {
-      const msg = docLink`Declares both "${"[no-export]"}" and "${"[export]"}" css class.`;
+      const msg = docLink`Declares both "${"[no-export]"}" and "${"[export]"}" CSS class.`;
       const hint = "Please use only one.";
       showError(msg, name, { elements: [dfn], hint });
       break;

--- a/src/core/dfn.js
+++ b/src/core/dfn.js
@@ -120,7 +120,7 @@ function computeExport(dfn) {
     }
 
     // No export wins
-    case isNoExport(dfn):
+    case dfn.matches(".no-export") || dfn.matches("[data-noexport]"):
       if (dfn.matches("[data-export]")) {
         const msg = docLink`Declares ${"[no-export]"} CSS class, but also has a "${"[data-export]"}" attribute.`;
         const hint = "Please chose only one.";

--- a/src/core/dfn.js
+++ b/src/core/dfn.js
@@ -131,7 +131,7 @@ function computeExport(dfn) {
       break;
 
     // If the author explicitly asked for it to be exported, so let's export it.
-    case dfn.matches(".export") && !dfn.matches("[data-no-export]"):
+    case dfn.matches(".export") && !dfn.matches("[data-noexport]"):
       dfn.dataset.export = "";
       break;
   }

--- a/src/core/dfn.js
+++ b/src/core/dfn.js
@@ -181,7 +181,7 @@ function processAsInternalSlot(title, dfn) {
   }
 
   // Don't export internal slots by default, as they are not supposed to be public.
-  if (!dfn.matches(".export") && !dfn.matches("[data-export]")) {
+  if (!dfn.matches(".export, [data-export]")) {
     dfn.dataset.noexport = "";
   }
 

--- a/src/core/dfn.js
+++ b/src/core/dfn.js
@@ -138,13 +138,6 @@ function computeExport(dfn) {
 }
 
 /**
- * @param {HTMLElement} dfn
- */
-function isNoExport(dfn) {
-  return dfn.matches(".no-export") || dfn.matches("[data-noexport]");
-}
-
-/**
  * @param {string} text
  * @param {string} type
  * @param {HTMLElement} dfn

--- a/src/core/dfn.js
+++ b/src/core/dfn.js
@@ -131,7 +131,7 @@ function computeExport(dfn) {
       break;
 
     // If the author explicitly asked for it to be exported, so let's export it.
-    case dfn.matches(".export") && !dfn.matches("[data-noexport]"):
+    case dfn.matches(":is(.export):not([data-noexport], .no-export)"):
       dfn.dataset.export = "";
       break;
   }

--- a/src/core/dfn.js
+++ b/src/core/dfn.js
@@ -111,17 +111,22 @@ function computeType(dfn, linkingText) {
 // Deal with export/no export
 function computeExport(dfn) {
   switch (true) {
-    // If we have both exports and no exports, we should show an error.
+    // Error if we have both exports and no exports.
     case dfn.matches(".export.no-export"): {
-      const msg = docLink`Definition of declares both "export" and "no-export" css class.`;
+      const msg = docLink`Declares both "${"[no-export]"}" and "${"[export]"}" css class.`;
       const hint = "Please use only one.";
       showError(msg, name, { elements: [dfn], hint });
       break;
     }
 
     // No export wins
-    case dfn.matches(".no-export") || dfn.matches("[data-no-export]"):
-      delete dfn.dataset.export;
+    case isNoExport(dfn):
+      if (dfn.matches("[data-export]")) {
+        const msg = docLink`Declares ${"[no-export]"} CSS class, but also has a "${"[data-export]"}" attribute.`;
+        const hint = "Please chose only one.";
+        showError(msg, name, { elements: [dfn], hint });
+        delete dfn.dataset.export;
+      }
       dfn.dataset.noexport = "";
       break;
 
@@ -130,6 +135,13 @@ function computeExport(dfn) {
       dfn.dataset.export = "";
       break;
   }
+}
+
+/**
+ * @param {HTMLElement} dfn
+ */
+function isNoExport(dfn) {
+  return dfn.matches(".no-export") || dfn.matches("[data-noexport]");
 }
 
 /**

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -142,7 +142,7 @@ function defineIdlName(escaped, data, parent) {
   const linkType = getDfnType(data.type);
   if (dfn) {
     if (!data.partial) {
-      dfn.dataset.export = "";
+      if (!dfn.matches("[data-noexport]")) dfn.dataset.export = "";
       dfn.dataset.dfnType = linkType;
     }
     decorateDfn(dfn, data, parentName, name);

--- a/tests/spec/core/dfn-spec.js
+++ b/tests/spec/core/dfn-spec.js
@@ -568,5 +568,22 @@ describe("Core — Definitions", () => {
       expect(dfn.textContent).toBe("event");
       expect(dfn.dataset.export).toBe("");
     });
+
+    it("errors if the dfn declares export and no-export classes", async () => {
+      const body = `
+        <section>
+          <h2>Confused exports</h2>
+          <p>
+            <dfn class="export no-export">can't decide</dfn>
+          </p>
+        </section>
+      `;
+      const ops = makeStandardOps(null, body);
+      const doc = await makeRSDoc(ops);
+      // Check validation error
+      const errors = findDfnErrors(doc);
+      expect(errors).toHaveSize(1);
+      expect(errors[0].message).toContain("declares both");
+    });
   });
 });

--- a/tests/spec/core/dfn-spec.js
+++ b/tests/spec/core/dfn-spec.js
@@ -609,7 +609,7 @@ describe("Core — Definitions", () => {
       expect(errors).toHaveSize(0);
     });
 
-    it("errors if the dfn declares export and no-export classes", async () => {
+    it("errors if the dfn declares both export and no-export classes", async () => {
       const body = `
         <section>
           <h2>Confused exports</h2>

--- a/tests/spec/core/dfn-spec.js
+++ b/tests/spec/core/dfn-spec.js
@@ -569,12 +569,53 @@ describe("Core — Definitions", () => {
       expect(dfn.dataset.export).toBe("");
     });
 
+    it("supports no-export class", async () => {
+      const body = `
+        <section data-dfn-for="Foo">
+          <h2>No export</h2>
+          <pre class="idl">
+            [Exposed=Window] interface Foo {};
+          </pre>
+          <p>
+            <dfn class="no-export">
+              no export
+            </dfn>
+            <!-- normally exported, so we override it -->
+            <dfn class="element no-export">
+              element
+            </dfn>
+            <dfn class="no-export">Foo</dfn>
+          </p>
+      </section>
+      `;
+      const ops = makeStandardOps(null, body);
+      const doc = await makeRSDoc(ops);
+      const [regularDfn, elementDfn, idlDfn] = doc.querySelectorAll("dfn");
+
+      expect(elementDfn.dataset.noexport).toBe("");
+      expect(regularDfn.dataset.dfnType).toBe("dfn");
+      expect(regularDfn.dataset.export).toBeUndefined();
+
+      expect(elementDfn.dataset.noexport).toBe("");
+      expect(elementDfn.dataset.dfnType).toBe("element");
+      expect(elementDfn.dataset.export).toBeUndefined();
+
+      expect(idlDfn.dataset.noexport).toBe("");
+      expect(idlDfn.dataset.dfnType).toBe("interface");
+      expect(idlDfn.dataset.export).toBeUndefined();
+
+      // Check validation error
+      const errors = findDfnErrors(doc);
+      expect(errors).toHaveSize(0);
+    });
+
     it("errors if the dfn declares export and no-export classes", async () => {
       const body = `
         <section>
           <h2>Confused exports</h2>
           <p>
             <dfn class="export no-export">can't decide</dfn>
+            <dfn class="no-export" data-export="">data noexport</dfn>
           </p>
         </section>
       `;
@@ -582,8 +623,9 @@ describe("Core — Definitions", () => {
       const doc = await makeRSDoc(ops);
       // Check validation error
       const errors = findDfnErrors(doc);
-      expect(errors).toHaveSize(1);
-      expect(errors[0].message).toContain("declares both");
+      expect(errors).toHaveSize(2);
+      expect(errors[0].message).toContain("Declares both");
+      expect(errors[1].message).toContain("but also has a");
     });
   });
 });


### PR DESCRIPTION
Support for `<dfn class="no-export">`, giving control to Editors over things they might want to keep private. 
 