### PR TITLE
feat(core/dfn-validators): export validateQuotedString()

### DIFF
--- a/src/core/dfn-validators.js
+++ b/src/core/dfn-validators.js
@@ -55,8 +55,20 @@ export function validateCommonName(text, type, elem, pluginName) {
   if (/^[a-z]+(-[a-z]+)*$/i.test(text)) {
     return true; // all good
   }
-  const msg = `Invalid ${type} name "${text}"`;
-  const hint = `Check that the ${type} name is allowed`;
+  const msg = `Invalid ${type} name "${text}".`;
+  const hint = `Check that the ${type} name is allowed per the naming rules for this type.`;
+  showError(msg, pluginName, { hint, elements: [elem] });
+  return false;
+}
+
+/**
+ * @type {DefinitionValidator} */
+export function validateQuotedString(text, type, elem, pluginName) {
+  if (text.startsWith(`"`) && text.endsWith(`"`)) {
+    return validateCommonName(text.slice(1, -1), type, elem, pluginName);
+  }
+  const msg = `Invalid ${type} "${text}".`;
+  const hint = `Check that the ${type} is quoted with double quotes.`;
   showError(msg, pluginName, { hint, elements: [elem] });
   return false;
 }

--- a/tests/spec/core/validators-spec.js
+++ b/tests/spec/core/validators-spec.js
@@ -2,6 +2,7 @@ import {
   validateCommonName,
   validateDOMName,
   validateMimeType,
+  validateQuotedString,
 } from "../../../src/core/dfn-validators.js";
 
 describe("Core - Validators", () => {
@@ -99,6 +100,42 @@ describe("Core - Validators", () => {
         const dfn = document.createElement("dfn");
         const context = `invalid mimeType: ${mimeType}`;
         expect(validateMimeType(mimeType, "mimetype", dfn, "foo/bar"))
+          .withContext(context)
+          .toBeFalse();
+        expect(dfn.classList.contains("respec-offending-element"))
+          .withContext(context)
+          .toBeTrue();
+      }
+    });
+  });
+
+  describe("validateQuotedString", () => {
+    it("doesn't generate an error if the string is valid", () => {
+      const names = ['"quoted"', '"quoted-string"'];
+      for (const name of names) {
+        const dfn = document.createElement("dfn");
+        const context = `string: ${name}`;
+        expect(validateQuotedString(name, "string", dfn, "foo/bar"))
+          .withContext(context)
+          .toBeTrue();
+        expect(dfn.classList.contains("respec-offending-element"))
+          .withContext(context)
+          .toBeFalse();
+      }
+    });
+
+    it("generates errors for unquoted strings", () => {
+      const names = [
+        "spaced string",
+        "thing$",
+        '"start only',
+        'end only"',
+        "-something",
+      ];
+      for (const name of names) {
+        const dfn = document.createElement("dfn");
+        const context = `invalid name: ${name}`;
+        expect(validateQuotedString(name, "permission", dfn, "foo/bar"))
           .withContext(context)
           .toBeFalse();
         expect(dfn.classList.contains("respec-offending-element"))


### PR DESCRIPTION
Checks definitions that are supposed to be wrapped in quotes, like permissions. 