### PR TITLE
feat(core/web-monetization): add object configuration

### DIFF
--- a/src/core/web-monetization.js
+++ b/src/core/web-monetization.js
@@ -9,25 +9,44 @@ import { html } from "./import-maps.js";
 
 export const name = "core/web-monetization";
 
-const DEFAULT_PAYMENT_POINTER = "$respec.org";
-
 export function run(conf) {
-  const { monetization } = conf;
-  if (monetization === false) {
+  if (conf.monetization === false) {
     return;
   }
+  const { monetization } = conf;
 
-  const paymentPointer =
-    typeof monetization === "string" ? monetization : DEFAULT_PAYMENT_POINTER;
+  const { removeOnSave, paymentPointer } = canonicalizeConfig(monetization);
 
-  if (paymentPointer === DEFAULT_PAYMENT_POINTER) {
-    document.head.append(
-      html`<!-- Support ReSpec's development - https://opencollective.com/respec --> `
-    );
-  }
+  const cssClass = removeOnSave ? "removeOnSave" : null;
   document.head.append(html`<meta
     name="monetization"
     content="${paymentPointer}"
-    class="removeOnSave"
+    class="${cssClass}"
   />`);
+}
+
+/**
+ * @param {object|string} rawConfig
+ * - {string} paymentPointer - The payment pointer to use.
+ * - {boolean} removeOnSave - Whether to remove the meta tag when the document is saved.
+ */
+function canonicalizeConfig(rawConfig) {
+  const config = {
+    paymentPointer: "$respec.org",
+    removeOnSave: true,
+  };
+  switch (typeof rawConfig) {
+    case "string":
+      config.paymentPointer = rawConfig;
+      break;
+    case "object":
+      if (rawConfig.paymentPointer) {
+        config.paymentPointer = String(rawConfig.paymentPointer);
+      }
+      if (rawConfig.removeOnSave === false) {
+        config.removeOnSave = false;
+      }
+      break;
+  }
+  return config;
 }

--- a/tests/spec/core/web-monetization-spec.js
+++ b/tests/spec/core/web-monetization-spec.js
@@ -37,4 +37,38 @@ describe("Core - Web Monetization", () => {
     expect(metaTag.content).toBe("$wallet.example.org");
     expect(metaTag.classList).toContain("removeOnSave");
   });
+
+  describe("object-based configuration", () => {
+    it("uses default payment pointer when using an empty object", async () => {
+      const ops = makeStandardOps({ monetization: {} });
+      const doc = await makeRSDoc(ops);
+
+      const metaTag = doc.querySelector("meta[name='monetization']");
+      expect(metaTag.content).toBe("$respec.org");
+      expect(metaTag.classList).toContain("removeOnSave");
+    });
+
+    it("allows just setting removeOnSave", async () => {
+      const ops = makeStandardOps({ monetization: { removeOnSave: false } });
+      const doc = await makeRSDoc(ops);
+
+      const metaTag = doc.querySelector("meta[name='monetization']");
+      expect(metaTag.content).toBe("$respec.org");
+      expect(metaTag.classList).not.toContain("removeOnSave");
+    });
+
+    it("allows changing payment pointer", async () => {
+      const ops = makeStandardOps({
+        monetization: {
+          paymentPointer: "$wallet.example.org",
+          removeOnSave: false,
+        },
+      });
+      const doc = await makeRSDoc(ops);
+
+      const metaTag = doc.querySelector("meta[name='monetization']");
+      expect(metaTag.content).toBe("$wallet.example.org");
+      expect(metaTag.classList).not.toContain("removeOnSave");
+    });
+  });
 });


### PR DESCRIPTION
Adds configuration:  `monetization: {paymentPointer: string, removeOnSave: boolean}`. 