### PR TITLE
feat(w3c/headers): links 'kinds of documents' for W3C documents

### DIFF
--- a/src/w3c/templates/headers.js
+++ b/src/w3c/templates/headers.js
@@ -155,17 +155,7 @@ export default (conf, options) => {
   return html`<div class="head">
     ${conf.logos.map(showLogo)} ${document.querySelector("h1#title")}
     ${getSpecSubTitleElem(conf)}
-    <h2>
-      ${conf.prependW3C ? "W3C " : ""}${conf.isCR
-        ? `${conf.longStatus}`
-        : `${conf.textStatus}`}
-      <time class="dt-published" datetime="${conf.dashDate}"
-        >${conf.publishHumanDate}</time
-      >${conf.modificationDate
-        ? html`, ${l10n.edited_in_place}${" "}
-          ${inPlaceModificationDate(conf.modificationDate)}`
-        : ""}
-    </h2>
+    <h2>${renderSpecTitle(conf)}</h2>
     <dl>
       ${conf.isTagFinding || !conf.isNoTrack
         ? html`
@@ -279,6 +269,22 @@ export default (conf, options) => {
     <hr title="Separator for header" />
   </div>`;
 };
+
+function renderSpecTitle(conf) {
+  const specType = conf.isCR ? `${conf.longStatus}` : `${conf.textStatus}`;
+  const preamble = conf.prependW3C
+    ? html`<a href="https://www.w3.org/standards/types">W3C ${specType}</a
+        >${" "}`
+    : html`${specType}${" "}`;
+
+  return html`${preamble}
+    <time class="dt-published" datetime="${conf.dashDate}"
+      >${conf.publishHumanDate}</time
+    >${conf.modificationDate
+      ? html`, ${l10n.edited_in_place}${" "}
+        ${inPlaceModificationDate(conf.modificationDate)}`
+      : ""}`;
+}
 
 /**
  * @param {string} date document in-place edit date as YYYY-MM-DD

--- a/src/w3c/templates/headers.js
+++ b/src/w3c/templates/headers.js
@@ -273,11 +273,10 @@ export default (conf, options) => {
 function renderSpecTitle(conf) {
   const specType = conf.isCR ? conf.longStatus : conf.textStatus;
   const preamble = conf.prependW3C
-    ? html`<a href="https://www.w3.org/standards/types">W3C ${specType}</a
-        >${" "}`
-    : html`${specType}${" "}`;
+    ? html`<a href="https://www.w3.org/standards/types">W3C ${specType}</a>`
+    : html`${specType}`;
 
-  return html`${preamble}
+  return html`${preamble}${" "}
     <time class="dt-published" datetime="${conf.dashDate}"
       >${conf.publishHumanDate}</time
     >${conf.modificationDate

--- a/src/w3c/templates/headers.js
+++ b/src/w3c/templates/headers.js
@@ -271,7 +271,7 @@ export default (conf, options) => {
 };
 
 function renderSpecTitle(conf) {
-  const specType = conf.isCR ? `${conf.longStatus}` : `${conf.textStatus}`;
+  const specType = conf.isCR ? conf.longStatus : conf.textStatus;
   const preamble = conf.prependW3C
     ? html`<a href="https://www.w3.org/standards/types">W3C ${specType}</a
         >${" "}`

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -28,8 +28,8 @@ describe("W3C — Headers", () => {
   it("links to the 'kinds of documents' only for W3C documents", async () => {
     const statuses = ["FPWD", "LCWD", "WD", "CR", "CRD", "PR", "REC", "NOTE"];
     for (const specStatus of statuses) {
-      const w3cDoc = await makeRSDoc(makeStandardOps({ specStatus }));
-      const w3cLink = w3cDoc.querySelector(
+      const doc = await makeRSDoc(makeStandardOps({ specStatus }));
+      const w3cLink = doc.querySelector(
         ".head a[href='https://www.w3.org/standards/types']"
       );
       expect(w3cLink).withContext(`specStatus: ${specStatus}`).toBeTruthy();
@@ -40,7 +40,7 @@ describe("W3C — Headers", () => {
       const w3cLink = doc.querySelector(
         ".head a[href='https://www.w3.org/standards/types']"
       );
-      expect(w3cLink).toBeNull();
+      expect(w3cLink).withContext(`specStatus: ${specStatus}`).toBeNull();
     }
   });
 

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -25,6 +25,25 @@ describe("W3C — Headers", () => {
       collapsedTextContent(child).includes(string)
     );
   }
+  it("links to the 'kinds of documents' only for W3C documents", async () => {
+    const statuses = ["FPWD", "LCWD", "WD", "CR", "CRD", "PR", "REC", "NOTE"];
+    for (const specStatus of statuses) {
+      const w3cDoc = await makeRSDoc(makeStandardOps({ specStatus }));
+      const w3cLink = w3cDoc.querySelector(
+        ".head a[href='https://www.w3.org/standards/types']"
+      );
+      expect(w3cLink).withContext(`specStatus: ${specStatus}`).toBeTruthy();
+    }
+
+    for (const specStatus of ["unofficial", "base"]) {
+      const doc = await makeRSDoc(makeStandardOps({ specStatus }));
+      const w3cLink = doc.querySelector(
+        ".head a[href='https://www.w3.org/standards/types']"
+      );
+      expect(w3cLink).toBeNull();
+    }
+  });
+
   describe("prevRecShortname & prevRecURI", () => {
     it("takes prevRecShortname and prevRecURI into account", async () => {
       const ops = makeStandardOps();


### PR DESCRIPTION
Links to a new W3C document that describes what spec status actually are... 