### PR TITLE
fix(core/title): handle line break in title

### DIFF
--- a/src/core/title.js
+++ b/src/core/title.js
@@ -55,7 +55,6 @@ export function run(conf) {
 }
 
 function setDocumentTitle(conf, h1Elem) {
-  debugger;
   // If the h1 is newly created, it won't be connected. In this case
   // we use the <title> or a localized fallback.
   if (!h1Elem.isConnected) {

--- a/src/core/title.js
+++ b/src/core/title.js
@@ -60,7 +60,7 @@ function setDocumentTitle(conf, h1Elem) {
   if (!h1Elem.isConnected) {
     h1Elem.textContent = document.title || `${l10n.default_title}`;
   }
-  // We replace `<br>` with ":" and "-", as appropriate.
+  // We replace ":<br>" with ":", and "<br>" with "-", as appropriate.
   const tempElem = document.createElement("h1");
   tempElem.innerHTML = h1Elem.innerHTML
     .replace(/:<br>/g, ": ")

--- a/src/core/title.js
+++ b/src/core/title.js
@@ -55,13 +55,18 @@ export function run(conf) {
 }
 
 function setDocumentTitle(conf, h1Elem) {
+  debugger;
   // If the h1 is newly created, it won't be connected. In this case
   // we use the <title> or a localized fallback.
   if (!h1Elem.isConnected) {
     h1Elem.textContent = document.title || `${l10n.default_title}`;
   }
-
-  let documentTitle = norm(h1Elem.textContent);
+  // We replace `<br>` with ":" and "-", as appropriate.
+  const tempElem = document.createElement("h1");
+  tempElem.innerHTML = h1Elem.innerHTML
+    .replace(/:<br>/g, ": ")
+    .replace(/<br>/g, " - ");
+  let documentTitle = norm(tempElem.textContent);
 
   if (conf.isPreview && conf.prNumber) {
     const prUrl = conf.prUrl || `${conf.github.repoURL}pull/${conf.prNumber}`;

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -722,6 +722,18 @@ describe("W3C — Headers", () => {
       expect(h1).toBeTruthy();
       expect(h1.textContent.trim()).toBe("override!!!");
     });
+
+    it("handles special case of localized spec title by doing replacement of <br> elements", async () => {
+      const body = `
+      <title>hi</title>
+      <h1 id="title">Requirements for Chinese Text:<br/>Layout<br/><span lang="zh">中文排版需求</span></h1>
+      ${makeDefaultBody()}`;
+      const ops = makeStandardOps({}, body);
+      const doc = await makeRSDoc(ops);
+      expect(doc.title).toBe(
+        "Requirements for Chinese Text: Layout - 中文排版需求"
+      );
+    });
   });
 
   describe("precedence rules for h1#title is present and <title> is absent", () => {


### PR DESCRIPTION
closes #3798 

Title becomes: 
![Screen Shot 2021-10-05 at 3 53 39 pm](https://user-images.githubusercontent.com/870154/135962280-4bb7a14b-f316-4262-a089-a96514a72479.png)

