### PR TITLE
Add a favicon option to easily control link rel=icon

### DIFF
--- a/profiles/w3c.js
+++ b/profiles/w3c.js
@@ -58,6 +58,7 @@ const modules = [
   import("../src/core/algorithms.js"),
   import("../src/core/anchor-expander.js"),
   import("../src/core/custom-elements/index.js"),
+  import("../src/core/favicon.js"),
   import("../src/core/web-monetization.js"),
   /* Linters must be the last thing to run */
   import("../src/core/linter-rules/check-charset.js"),

--- a/src/core/favicon.js
+++ b/src/core/favicon.js
@@ -4,6 +4,7 @@
  *
  */
 import { html } from "./import-maps.js";
+import { isURL } from "./utils.js";
 
 export const name = "core/favicon";
 
@@ -14,7 +15,7 @@ export function run(conf) {
 
   let favLink;
   console.log(conf.favicon ? conf.favicon.length : 0);
-  if (/^[a-z]+:/.test(conf.favicon)) {
+  if (isURL(conf.favicon)) {
     favLink = conf.favicon;
     // test single character, Unicode edition
   } else if (/^.$/u.test(conf.favicon)) {

--- a/src/core/favicon.js
+++ b/src/core/favicon.js
@@ -24,5 +24,10 @@ export function run(conf) {
     return;
   }
 
-  document.head.append(html`<link rel="icon" href="${favLink}" />`);
+  const existingIcon = document.querySelector("link[rel='icon']");
+  if (existingIcon) {
+    existingIcon.parentNode.replaceChild();
+  } else {
+    document.head.append(html`<link rel="icon" href="${favLink}" />`);
+  }
 }

--- a/src/core/favicon.js
+++ b/src/core/favicon.js
@@ -1,0 +1,27 @@
+// @ts-check
+/**
+ * This module adds a "favicon" element. It knows how to use Unicode favicons, too.
+ *
+ */
+import { html } from "./import-maps.js";
+
+export const name = "core/favicon";
+
+export function run(conf) {
+  if (!conf.favicon) {
+    return;
+  }
+
+  let favLink;
+  console.log(conf.favicon ? conf.favicon.length : 0);
+  if (/^[a-z]+:/.test(conf.favicon)) {
+    favLink = conf.favicon;
+    // test single character, Unicode edition
+  } else if (/^.$/u.test(conf.favicon)) {
+    favLink = `data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%220.9em%22 font-size=%22105%22>${conf.favicon}</text></svg>`;
+  } else {
+    return;
+  }
+
+  document.head.append(html`<link rel="icon" href="${favLink}" />`);
+}

--- a/src/core/favicon.js
+++ b/src/core/favicon.js
@@ -3,8 +3,8 @@
  * This module adds a "favicon" element. It knows how to use Unicode favicons, too.
  *
  */
+import { docLink, isURL, showWarning } from "./utils.js";
 import { html } from "./import-maps.js";
-import { isURL } from "./utils.js";
 
 export const name = "core/favicon";
 
@@ -21,6 +21,12 @@ export function run(conf) {
   } else if (/^.$/u.test(conf.favicon)) {
     favLink = `data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%220.9em%22 font-size=%22105%22>${conf.favicon}</text></svg>`;
   } else {
+    const hint = docLink`Check out ${"[favicon]"} for details.`;
+    showWarning(
+      "conf.favicon is neither a link nor a single character, ignored.",
+      name,
+      { hint }
+    );
     return;
   }
 

--- a/src/core/favicon.js
+++ b/src/core/favicon.js
@@ -25,9 +25,10 @@ export function run(conf) {
   }
 
   const existingIcon = document.querySelector("link[rel='icon']");
+  const linkEl = html`<link rel="icon" href="${favLink}" />`;
   if (existingIcon) {
-    existingIcon.parentNode.replaceChild();
+    existingIcon.parentNode.replaceChild(linkEl, existingIcon);
   } else {
-    document.head.append(html`<link rel="icon" href="${favLink}" />`);
+    document.head.append(linkEl);
   }
 }

--- a/src/core/favicon.js
+++ b/src/core/favicon.js
@@ -19,7 +19,7 @@ export function run(conf) {
     favLink = conf.favicon;
     // test single character, Unicode edition
   } else if (/^.$/u.test(conf.favicon)) {
-    favLink = `data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%220.9em%22 font-size=%22105%22>${conf.favicon}</text></svg>`;
+    favLink = `data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y="0.9em" font-size="105">${conf.favicon}</text></svg>`;
   } else {
     const hint = docLink`Check out ${"[favicon]"} for details.`;
     showWarning(

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -963,3 +963,13 @@ export function docLink(strings, ...keys) {
     })
     .join("");
 }
+
+export function isURL(str) {
+  try {
+    new URL(str);
+    return true;
+    // eslint-disable-next-line no-unused-vars
+  } catch (err) {
+    return false;
+  }
+}

--- a/tests/spec/core/favicon-spec.js
+++ b/tests/spec/core/favicon-spec.js
@@ -1,0 +1,41 @@
+import { flushIframes, makeRSDoc, makeStandardOps } from "../SpecHelper.js";
+
+describe("Core - Favicon", () => {
+  afterAll(flushIframes);
+
+  it("does not add a favicon by default", async () => {
+    const ops = makeStandardOps({});
+    const doc = await makeRSDoc(ops);
+
+    const linkTag = doc.querySelector("link[rel='icon']");
+    expect(linkTag).toBeNull();
+  });
+
+  it("does not add a favicon with a false value", async () => {
+    const ops = makeStandardOps({ favicon: false });
+    const doc = await makeRSDoc(ops);
+
+    const linkTag = doc.querySelector("link[rel='icon']");
+    expect(linkTag).toBeNull();
+  });
+
+  it("adds a favicon link", async () => {
+    const rbFavRed = "https://berjon.com/ED2B33.png";
+    const ops = makeStandardOps({ favicon: rbFavRed });
+    const doc = await makeRSDoc(ops);
+
+    const linkTag = doc.querySelector("link[rel='icon']");
+    expect(linkTag.href).toBe(rbFavRed);
+  });
+
+  it("adds a favicon using Unicode", async () => {
+    const ops = makeStandardOps({ favicon: "😻" });
+    const doc = await makeRSDoc(ops);
+
+    const linkTag = doc.querySelector("link[rel='icon']");
+    // keep this as getAttribute to avoid escaping issues
+    expect(linkTag.getAttribute("href")).toBe(
+      "data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%220.9em%22 font-size=%22105%22>😻</text></svg>"
+    );
+  });
+});

--- a/tests/spec/core/favicon-spec.js
+++ b/tests/spec/core/favicon-spec.js
@@ -35,7 +35,7 @@ describe("Core - Favicon", () => {
     const linkTag = doc.querySelector("link[rel='icon']");
     // keep this as getAttribute to avoid escaping issues
     expect(linkTag.getAttribute("href")).toBe(
-      "data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%220.9em%22 font-size=%22105%22>😻</text></svg>"
+      `data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y="0.9em" font-size="105">😻</text></svg>`
     );
   });
 });


### PR DESCRIPTION
Specs are nicer when they are prettier, and a neat way to improve them is to throw in a favicon. See:
* https://globalprivacycontrol.github.io/gpc-spec/
* https://darobin.github.io/garuda/
* https://nytimes.github.io/std-cat/
* https://darobin.github.io/pup/

This adds a `favicon` core configuration that can take either a link to an image, or a Unicode character that gets inlined as an SVG icon.