### PR TITLE
fix: move permalink after the header text

### DIFF
--- a/src/core/id-headers.js
+++ b/src/core/id-headers.js
@@ -41,7 +41,7 @@ export function run(conf) {
       h.closest(".appendix") ? "Appendix" : "Section",
       h.querySelector(":scope > bdi.secno")
     );
-    h.prepend(html`
+    h.append(html`
       <a href="${`#${id}`}" class="self-link" aria-label="${label}"></a>
     `);
   }


### PR DESCRIPTION
Moves the permalink to the end of the heading for screen readers. This makes the relevant information up-front and makes the document much more useful for screen reader users.
Does not fully resolve https://github.com/w3c/respec/issues/3898 but it does make the result much better with a very small change