### PR TITLE
pubrules-compliant uri for document license

### DIFF
--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -252,7 +252,7 @@ export const licenses = new Map([
     {
       name: "W3C Document License",
       short: "document use",
-      url: "https://www.w3.org/Consortium/Legal/2015/doc-license",
+      url: "https://www.w3.org/Consortium/Legal/copyright-documents",
     },
   ],
   [


### PR DESCRIPTION
Pubrules is reporting that it expects https://www.w3.org/Consortium/Legal/copyright-documents when "document use" is used in the copyright.