### PR TITLE
feat(lint/no-unused-dfns): complain on unused dfns

### DIFF
--- a/profiles/w3c.js
+++ b/profiles/w3c.js
@@ -65,6 +65,7 @@ const modules = [
   import("../src/core/linter-rules/check-punctuation.js"),
   import("../src/core/linter-rules/check-internal-slots.js"),
   import("../src/core/linter-rules/local-refs-exist.js"),
+  import("../src/core/linter-rules/no-unused-dfns.js"),
   import("../src/core/linter-rules/no-headingless-sections.js"),
   import("../src/core/linter-rules/no-unused-vars.js"),
   import("../src/core/linter-rules/privsec-section.js"),

--- a/src/core/linter-rules/no-unused-dfns.js
+++ b/src/core/linter-rules/no-unused-dfns.js
@@ -1,0 +1,54 @@
+// @ts-check
+/**
+ * Linter rule "no-unused-dfns".
+ *
+ * Complains if an internal/un-exported definitions is not linked to.
+ */
+import {
+  docLink,
+  getIntlData,
+  norm,
+  showError,
+  showWarning,
+} from "../utils.js";
+
+const ruleName = "no-unused-dfns";
+export const name = "core/linter-rules/no-unused-dfns";
+
+const localizationStrings = {
+  en: {
+    msg(text) {
+      return `Found definition for "${text}", but nothing links to it. This is usually a spec bug!`;
+    },
+    get hint() {
+      return docLink`Either remove the definition, or add the \`"lint-ignore"\` CSS class. Or did you want to ${"[export|#data-export]"} it? If yes, add the "export" CSS to it.`;
+    },
+  },
+};
+const l10n = getIntlData(localizationStrings);
+
+export function run(conf) {
+  if (!conf.lint?.[ruleName]) return;
+  const logger = conf.lint[ruleName] === "warn" ? showWarning : showError;
+  /** @type NodeListOf<HTMLElement> */
+  const definitions = document.querySelectorAll(
+    "dfn[id]:not(.lint-ignore, [data-export], [data-cite])"
+  );
+
+  const elements = [...definitions].filter(dfnFilter);
+
+  // These are usually bad spec bugs, so best shown individually.
+  elements.forEach(element => {
+    const elements = [element];
+    const text = norm(element.textContent);
+    logger(l10n.msg(text), name, { elements, hint: l10n.hint });
+  });
+}
+
+function dfnFilter(dfn) {
+  // Not in the index
+  // and not the "self-link" box
+  return !document.querySelector(
+    `a[href="#${dfn.id}"]:not(.index-term, .self-link)`
+  );
+}

--- a/src/core/linter-rules/no-unused-dfns.js
+++ b/src/core/linter-rules/no-unused-dfns.js
@@ -32,10 +32,10 @@ export function run(conf) {
   const logger = conf.lint[ruleName] === "error" ? showError : showWarning;
   /** @type NodeListOf<HTMLElement> */
   const definitions = document.querySelectorAll(
-    "dfn[id]:not(.lint-ignore, [data-export], [data-cite])"
+    "dfn:not(.lint-ignore, [data-export], [data-cite])"
   );
 
-  const elements = [...definitions].filter(dfnFilter);
+  const elements = [...definitions].filter(isDfnUnused);
 
   // These are usually bad spec bugs, so best shown individually.
   elements.forEach(element => {
@@ -45,7 +45,7 @@ export function run(conf) {
   });
 }
 
-function dfnFilter(dfn) {
+function isDfnUnused(dfn) {
   // Not in the index
   // and not the "self-link" box
   return !document.querySelector(

--- a/src/core/linter-rules/no-unused-dfns.js
+++ b/src/core/linter-rules/no-unused-dfns.js
@@ -29,7 +29,7 @@ const l10n = getIntlData(localizationStrings);
 
 export function run(conf) {
   if (!conf.lint?.[ruleName]) return;
-  const logger = conf.lint[ruleName] === "warn" ? showWarning : showError;
+  const logger = conf.lint[ruleName] === "error" ? showError : showWarning;
   /** @type NodeListOf<HTMLElement> */
   const definitions = document.querySelectorAll(
     "dfn[id]:not(.lint-ignore, [data-export], [data-cite])"

--- a/src/core/linter-rules/no-unused-dfns.js
+++ b/src/core/linter-rules/no-unused-dfns.js
@@ -21,7 +21,7 @@ const localizationStrings = {
       return `Found definition for "${text}", but nothing links to it. This is usually a spec bug!`;
     },
     get hint() {
-      return docLink`Either remove the definition, or add the \`"lint-ignore"\` CSS class. Or did you want to ${"[export|#data-export]"} it? If yes, add the "export" CSS to it.`;
+      return docLink`Either remove the definition, or add a  \`"lint-ignore"\` CSS class. Or did you want to ${"[export|#data-export]"} it? If yes, add the "export" CSS to it.`;
     },
   },
 };

--- a/src/core/linter-rules/no-unused-dfns.js
+++ b/src/core/linter-rules/no-unused-dfns.js
@@ -21,7 +21,7 @@ const localizationStrings = {
       return `Found definition for "${text}", but nothing links to it. This is usually a spec bug!`;
     },
     get hint() {
-      return docLink`Either remove the definition, or add a  \`"lint-ignore"\` CSS class. Or did you want to ${"[export|#data-export]"} it? If yes, add the "export" CSS to it.`;
+      return docLink`Either remove the definition, or add a \`"lint-ignore"\` CSS class. Or did you want to ${"[export|#data-export]"} it? If yes, add the "export" CSS to it.`;
     },
   },
 };

--- a/src/core/linter-rules/no-unused-dfns.js
+++ b/src/core/linter-rules/no-unused-dfns.js
@@ -21,7 +21,7 @@ const localizationStrings = {
       return `Found definition for "${text}", but nothing links to it. This is usually a spec bug!`;
     },
     get hint() {
-      return docLink`Either remove the definition, or add a \`"lint-ignore"\` CSS class. Or did you want to ${"[export|#data-export]"} it? If yes, add the "export" CSS to it.`;
+      return docLink`Either remove the definition, or add a \`"lint-ignore"\` CSS class. If you meant to export it, add the ${"[export|#data-export]"} CSS.`;
     },
   },
 };

--- a/src/w3c/defaults.js
+++ b/src/w3c/defaults.js
@@ -26,6 +26,7 @@ const w3cDefaults = {
   lint: {
     "privsec-section": true,
     "wpt-tests-exist": false,
+    "no-unused-dfns": "warn",
     a11y: false,
   },
   doJsonLd: false,

--- a/tests/spec/core/linter-rules/no-unused-dfns-spec.js
+++ b/tests/spec/core/linter-rules/no-unused-dfns-spec.js
@@ -86,6 +86,30 @@ describe("Core — linter-rules - no-unused-dfns", () => {
     expect(warnings).toHaveSize(0);
   });
 
+  it("complains even when the definitions are linked from the index", async () => {
+    const body = `
+      <section>
+        <h2>Heading</h2>
+        <p><dfn>foo</dfn></p>
+        <p><dfn>bar</dfn></p>
+      </section>
+      <section class="index"></section>
+    `;
+    const ops = makeStandardOps(
+      {
+        lint: {
+          "no-unused-dfns": true,
+        },
+      },
+      body
+    );
+    const doc = await makeRSDoc(ops);
+    const errors = lintErrors(doc);
+    const warnings = lintWarnings(doc);
+    expect(errors).toHaveSize(2);
+    expect(warnings).toHaveSize(0);
+  });
+
   it("warnings when the rule is set to 'warn'", async () => {
     const body = `
       <section>

--- a/tests/spec/core/linter-rules/no-unused-dfns-spec.js
+++ b/tests/spec/core/linter-rules/no-unused-dfns-spec.js
@@ -110,7 +110,7 @@ describe("Core — linter-rules - no-unused-dfns", () => {
     expect(warnings).toHaveSize(0);
   });
 
-  it("warnings when the rule is set to 'warn'", async () => {
+  it("warns when the rule is set to 'warn'", async () => {
     const body = `
       <section>
         <h2>Heading</h2>

--- a/tests/spec/core/linter-rules/no-unused-dfns-spec.js
+++ b/tests/spec/core/linter-rules/no-unused-dfns-spec.js
@@ -42,14 +42,8 @@ describe("Core — linter-rules - no-unused-dfns", () => {
         <p><dfn data-dfn-for="Test">baz</dfn> [=Test/baz=]</p>
       </section>
     `;
-    const ops = makeStandardOps(
-      {
-        lint: {
-          "no-unused-dfns": true,
-        },
-      },
-      body
-    );
+    const config = { lint: { "no-unused-dfns": true } };
+    const ops = makeStandardOps(config, body);
     const doc = await makeRSDoc(ops);
     const errors = lintErrors(doc);
     const warnings = lintWarnings(doc);
@@ -57,7 +51,7 @@ describe("Core — linter-rules - no-unused-dfns", () => {
     expect(warnings).toHaveSize(0);
   });
 
-  it("complains as an error by default", async () => {
+  it("defaults to warning", async () => {
     const body = `
       <section>
         <h2>Heading</h2>
@@ -65,19 +59,13 @@ describe("Core — linter-rules - no-unused-dfns", () => {
         <p><dfn>bar</dfn></p>
       </section>
     `;
-    const ops = makeStandardOps(
-      {
-        lint: {
-          "no-unused-dfns": true,
-        },
-      },
-      body
-    );
+    const config = { lint: { "no-unused-dfns": true } };
+    const ops = makeStandardOps(config, body);
     const doc = await makeRSDoc(ops);
     const errors = lintErrors(doc);
     const warnings = lintWarnings(doc);
-    expect(errors).toHaveSize(2);
-    expect(warnings).toHaveSize(0);
+    expect(errors).toHaveSize(0);
+    expect(warnings).toHaveSize(2);
   });
 
   it("complains even when the definitions are linked from the index", async () => {
@@ -89,19 +77,13 @@ describe("Core — linter-rules - no-unused-dfns", () => {
       </section>
       <section class="index"></section>
     `;
-    const ops = makeStandardOps(
-      {
-        lint: {
-          "no-unused-dfns": true,
-        },
-      },
-      body
-    );
+    const config = { lint: { "no-unused-dfns": true } };
+    const ops = makeStandardOps(config, body);
     const doc = await makeRSDoc(ops);
     const errors = lintErrors(doc);
     const warnings = lintWarnings(doc);
-    expect(errors).toHaveSize(2);
-    expect(warnings).toHaveSize(0);
+    expect(errors).toHaveSize(0);
+    expect(warnings).toHaveSize(2);
   });
 
   it("warns when the rule is set to 'warn'", async () => {
@@ -112,14 +94,8 @@ describe("Core — linter-rules - no-unused-dfns", () => {
         <p><dfn>bar</dfn></p>
       </section>
     `;
-    const ops = makeStandardOps(
-      {
-        lint: {
-          "no-unused-dfns": "warn",
-        },
-      },
-      body
-    );
+    const config = { lint: { "no-unused-dfns": "warn" } };
+    const ops = makeStandardOps(config, body);
     const doc = await makeRSDoc(ops);
     const errors = lintErrors(doc);
     const warnings = lintWarnings(doc);
@@ -134,14 +110,8 @@ describe("Core — linter-rules - no-unused-dfns", () => {
         <p><dfn>foo</dfn></p>
       </section>
     `;
-    const ops = makeStandardOps(
-      {
-        lint: {
-          "no-unused-dfns": "error",
-        },
-      },
-      body
-    );
+    const config = { lint: { "no-unused-dfns": "error" } };
+    const ops = makeStandardOps(config, body);
     const doc = await makeRSDoc(ops);
     const errors = lintErrors(doc);
     const warnings = lintWarnings(doc);
@@ -161,14 +131,8 @@ describe("Core — linter-rules - no-unused-dfns", () => {
         </pre>
       </section>
     `;
-    const ops = makeStandardOps(
-      {
-        lint: {
-          "no-unused-dfns": true,
-        },
-      },
-      body
-    );
+    const config = { lint: { "no-unused-dfns": true } };
+    const ops = makeStandardOps(config, body);
     const doc = await makeRSDoc(ops);
     const errors = lintErrors(doc);
     const warnings = lintWarnings(doc);
@@ -184,21 +148,15 @@ describe("Core — linter-rules - no-unused-dfns", () => {
         <p><dfn>bar</dfn></p>
       </section>
     `;
-    const ops = makeStandardOps(
-      {
-        lint: {
-          "no-unused-dfns": true,
-        },
-      },
-      body
-    );
+    const config = { lint: { "no-unused-dfns": true } };
+    const ops = makeStandardOps(config, body);
     const doc = await makeRSDoc(ops);
     const errors = lintErrors(doc);
     const warnings = lintWarnings(doc);
-    expect(errors).toHaveSize(1);
-    expect(warnings).toHaveSize(0);
-    const [error] = errors;
-    expect(error.message).toContain('"bar"');
+    expect(errors).toHaveSize(0);
+    expect(warnings).toHaveSize(1);
+    const [warning] = warnings;
+    expect(warning.message).toContain('"bar"');
   });
 
   it("ignores definitions that use legacy 'data-cite'", async () => {
@@ -208,14 +166,8 @@ describe("Core — linter-rules - no-unused-dfns", () => {
         <p><dfn data-cite="html#bar">bar</dfn></p>
       </section>
     `;
-    const ops = makeStandardOps(
-      {
-        lint: {
-          "no-unused-dfns": true,
-        },
-      },
-      body
-    );
+    const config = { lint: { "no-unused-dfns": true } };
+    const ops = makeStandardOps(config, body);
     const doc = await makeRSDoc(ops);
     const errors = lintErrors(doc);
     const warnings = lintWarnings(doc);
@@ -230,14 +182,8 @@ describe("Core — linter-rules - no-unused-dfns", () => {
         <p><dfn data-export="foo">bar</dfn></p>
       </section>
     `;
-    const ops = makeStandardOps(
-      {
-        lint: {
-          "no-unused-dfns": true,
-        },
-      },
-      body
-    );
+    const config = { lint: { "no-unused-dfns": true } };
+    const ops = makeStandardOps(config, body);
     const doc = await makeRSDoc(ops);
     const errors = lintErrors(doc);
     const warnings = lintWarnings(doc);

--- a/tests/spec/core/linter-rules/no-unused-dfns-spec.js
+++ b/tests/spec/core/linter-rules/no-unused-dfns-spec.js
@@ -24,14 +24,8 @@ describe("Core — linter-rules - no-unused-dfns", () => {
         <p><dfn>bar</dfn></p>
       </section>
     `;
-    const ops = makeStandardOps(
-      {
-        lint: {
-          "no-unused-dfns": false,
-        },
-      },
-      body
-    );
+    const config = { lint: { "no-unused-dfns": false } };
+    const ops = makeStandardOps(config, body);
     const doc = await makeRSDoc(ops);
     const errors = lintErrors(doc);
     const warnings = lintWarnings(doc);
@@ -133,7 +127,7 @@ describe("Core — linter-rules - no-unused-dfns", () => {
     expect(warnings).toHaveSize(2);
   });
 
-  it("shows an error when the rule is set to 'error'", async () => {
+  it("shows as error when the rule is set to 'error'", async () => {
     const body = `
       <section>
         <h2>Heading</h2>

--- a/tests/spec/core/linter-rules/no-unused-dfns-spec.js
+++ b/tests/spec/core/linter-rules/no-unused-dfns-spec.js
@@ -1,0 +1,229 @@
+"use strict";
+
+import {
+  errorFilters,
+  flushIframes,
+  makeRSDoc,
+  makeStandardOps,
+  warningFilters,
+} from "../../SpecHelper.js";
+
+describe("Core — linter-rules - no-unused-dfns", () => {
+  afterAll(() => {
+    flushIframes();
+  });
+  const name = "core/linter-rules/no-unused-dfns";
+  const lintErrors = errorFilters.filter(name);
+  const lintWarnings = warningFilters.filter(name);
+
+  it("doesn't complain if the rule is turned off", async () => {
+    const body = `
+      <section>
+        <h2>Heading</h2>
+        <p><dfn>foo</dfn></p>
+        <p><dfn>bar</dfn></p>
+      </section>
+    `;
+    const ops = makeStandardOps(
+      {
+        lint: {
+          "no-unused-dfns": false,
+        },
+      },
+      body
+    );
+    const doc = await makeRSDoc(ops);
+    const errors = lintErrors(doc);
+    const warnings = lintWarnings(doc);
+    expect(errors).toHaveSize(0);
+    expect(warnings).toHaveSize(0);
+  });
+
+  it("doesn't complain when there is a matching anchor element", async () => {
+    const body = `
+      <section>
+        <h2>Heading</h2>
+        <p><dfn>foo</dfn> [=bar=]</p>
+        <p><dfn>bar</dfn> <a>foo</a></p>
+        <p><dfn data-dfn-for="Test">baz</dfn> [=Test/baz=]</p>
+      </section>
+    `;
+    const ops = makeStandardOps(
+      {
+        lint: {
+          "no-unused-dfns": true,
+        },
+      },
+      body
+    );
+    const doc = await makeRSDoc(ops);
+    const errors = lintErrors(doc);
+    const warnings = lintWarnings(doc);
+    expect(errors).toHaveSize(0);
+    expect(warnings).toHaveSize(0);
+  });
+
+  it("complains as an error by default", async () => {
+    const body = `
+      <section>
+        <h2>Heading</h2>
+        <p><dfn>foo</dfn></p>
+        <p><dfn>bar</dfn></p>
+      </section>
+    `;
+    const ops = makeStandardOps(
+      {
+        lint: {
+          "no-unused-dfns": true,
+        },
+      },
+      body
+    );
+    const doc = await makeRSDoc(ops);
+    const errors = lintErrors(doc);
+    const warnings = lintWarnings(doc);
+    expect(errors).toHaveSize(2);
+    expect(warnings).toHaveSize(0);
+  });
+
+  it("warnings when the rule is set to 'warn'", async () => {
+    const body = `
+      <section>
+        <h2>Heading</h2>
+        <p><dfn>foo</dfn></p>
+        <p><dfn>bar</dfn></p>
+      </section>
+    `;
+    const ops = makeStandardOps(
+      {
+        lint: {
+          "no-unused-dfns": "warn",
+        },
+      },
+      body
+    );
+    const doc = await makeRSDoc(ops);
+    const errors = lintErrors(doc);
+    const warnings = lintWarnings(doc);
+    expect(errors).toHaveSize(0);
+    expect(warnings).toHaveSize(2);
+  });
+
+  it("shows an error when the rule is set to 'error'", async () => {
+    const body = `
+      <section>
+        <h2>Heading</h2>
+        <p><dfn>foo</dfn></p>
+      </section>
+    `;
+    const ops = makeStandardOps(
+      {
+        lint: {
+          "no-unused-dfns": "error",
+        },
+      },
+      body
+    );
+    const doc = await makeRSDoc(ops);
+    const errors = lintErrors(doc);
+    const warnings = lintWarnings(doc);
+    expect(errors).toHaveSize(1);
+    expect(warnings).toHaveSize(0);
+  });
+
+  it("ignores self-defined WebIDL types", async () => {
+    const body = `
+      <section>
+        <h2>Heading</h2>
+        <pre class="idl">
+          interface Foo {
+            void bar();
+            readonly attribute DOMString baz;
+          };
+        </pre>
+      </section>
+    `;
+    const ops = makeStandardOps(
+      {
+        lint: {
+          "no-unused-dfns": true,
+        },
+      },
+      body
+    );
+    const doc = await makeRSDoc(ops);
+    const errors = lintErrors(doc);
+    const warnings = lintWarnings(doc);
+    expect(errors).toHaveSize(0);
+    expect(warnings).toHaveSize(0);
+  });
+
+  it("ignores definitions that use CSS class 'lint-ignore'", async () => {
+    const body = `
+      <section>
+        <h2>Heading</h2>
+        <p><dfn class="lint-ignore">foo</dfn></p>
+        <p><dfn>bar</dfn></p>
+      </section>
+    `;
+    const ops = makeStandardOps(
+      {
+        lint: {
+          "no-unused-dfns": true,
+        },
+      },
+      body
+    );
+    const doc = await makeRSDoc(ops);
+    const errors = lintErrors(doc);
+    const warnings = lintWarnings(doc);
+    expect(errors).toHaveSize(1);
+    expect(warnings).toHaveSize(0);
+    const [error] = errors;
+    expect(error.message).toContain('"bar"');
+  });
+
+  it("ignores definitions that use legacy 'data-cite'", async () => {
+    const body = `
+      <section>
+        <h2>Heading</h2>
+        <p><dfn data-cite="html#bar">bar</dfn></p>
+      </section>
+    `;
+    const ops = makeStandardOps(
+      {
+        lint: {
+          "no-unused-dfns": true,
+        },
+      },
+      body
+    );
+    const doc = await makeRSDoc(ops);
+    const errors = lintErrors(doc);
+    const warnings = lintWarnings(doc);
+    expect(errors).toHaveSize(0);
+    expect(warnings).toHaveSize(0);
+  });
+
+  it("ignores definitions that use data-export", async () => {
+    const body = `
+      <section>
+        <h2>Heading</h2>
+        <p><dfn data-export="foo">bar</dfn></p>
+      </section>
+    `;
+    const ops = makeStandardOps(
+      {
+        lint: {
+          "no-unused-dfns": true,
+        },
+      },
+      body
+    );
+    const doc = await makeRSDoc(ops);
+    const errors = lintErrors(doc);
+    const warnings = lintWarnings(doc);
+    expect(errors).toHaveSize(0);
+    expect(warnings).toHaveSize(0);
+  });
+});

--- a/tests/spec/w3c/defaults-spec.js
+++ b/tests/spec/w3c/defaults-spec.js
@@ -21,6 +21,7 @@ describe("W3C — Defaults", () => {
       "check-internal-slots": false,
       "check-charset": false,
       "wpt-tests-exist": false,
+      "no-unused-dfns": "warn",
       a11y: false,
     });
     expect(rsConf.highlightVars).toBe(true);
@@ -41,6 +42,7 @@ describe("W3C — Defaults", () => {
           "check-punctuation": false,
           "fake-linter-rule": "foo",
           "check-internal-slots": true,
+          "no-unused-dfns": "error",
         },
         license: "c0",
         specStatus: "ED",
@@ -62,6 +64,7 @@ describe("W3C — Defaults", () => {
       "check-internal-slots": true,
       "check-charset": false,
       "wpt-tests-exist": false,
+      "no-unused-dfns": "error",
       a11y: false,
     });
     expect(rsConf.highlightVars).toBe(false);


### PR DESCRIPTION
closes #904

Complains when something is defined but not used. Should have added this years ago. I already found a bugs in Payment Request. 