### PR TITLE
fix(styles/respec): don't override hljs style

### DIFF
--- a/src/styles/respec.css.js
+++ b/src/styles/respec.css.js
@@ -17,11 +17,6 @@ export default css`
   }
 }
 
-/* Override code highlighter background */
-.hljs {
-  background: transparent !important;
-}
-
 /* --- INLINES --- */
 :is(h1, h2, h3, h4, h5, h6, a) abbr {
   border: none;


### PR DESCRIPTION
fixes #3849

Renders as:

<img width="574" alt="Screen Shot 2021-12-22 at 8 19 34 pm" src="https://user-images.githubusercontent.com/870154/147068537-1c299fb6-68a1-4316-b0cc-199ec06a4df2.png">

Can def live with that... getting a little bored with the current style tho. We should check if there is something more 2022. 