### PR TITLE
fix(w3c/linter-rules/required-sections): support other locales

### DIFF
--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -164,12 +164,13 @@ export function norm(str) {
 /**
  * @param {string} lang
  */
-function resolveLanguageAlias(lang) {
+export function resolveLanguageAlias(lang) {
+  const lCaseLang = lang.toLowerCase();
   const aliases = {
     "zh-hans": "zh",
     "zh-cn": "zh",
   };
-  return aliases[lang] || lang;
+  return aliases[lCaseLang] || lCaseLang;
 }
 
 /**
@@ -178,7 +179,7 @@ function resolveLanguageAlias(lang) {
  * @returns {T[keyof T]}
  */
 export function getIntlData(localizationStrings, lang = docLang) {
-  lang = resolveLanguageAlias(lang.toLowerCase());
+  lang = resolveLanguageAlias(lang);
   // Proxy return type is a known bug:
   // https://github.com/Microsoft/TypeScript/issues/20846
   // @ts-ignore

--- a/src/w3c/linter-rules/required-sections.js
+++ b/src/w3c/linter-rules/required-sections.js
@@ -13,6 +13,7 @@ import {
   showError,
   showWarning,
 } from "../../core/utils.js";
+import { lang } from "../../core/l10n.js";
 import { recTrackStatus } from "../headers.js";
 
 const ruleName = "required-sections";
@@ -28,6 +29,20 @@ const localizationStrings = {
         If the document is not intended for the W3C Recommendation track, set ${"[noRecTrack]"} to \`true\`
         or turn off the ${`[${ruleName}]`} linter rule.`;
     },
+    privacy_considerations: "Privacy Considerations",
+    security_considerations: "Security Considerations",
+  },
+  es: {
+    msg(sectionTitle) {
+      return `Documentos que van a ser "W3C Recommendation" requieren una sección "${sectionTitle}" separada.`;
+    },
+    hint(sectionTitle) {
+      return docLink`Agrega una \`<section>\` con título "${sectionTitle}". Ver los [Horizontal review guidelines](https://www.w3.org/Guide/documentreview/#how_to_get_horizontal_review).
+        Si el documento no está destinado a ser un W3C Recommendation, puedes poner ${"[noRecTrack]"} a \`true\`
+        o apaga la regla de linter ${`[${ruleName}]`}.`;
+    },
+    privacy_considerations: "Consideraciones de privacidad",
+    security_considerations: "Consideraciones de Seguridad",
   },
 };
 const l10n = getIntlData(localizationStrings);
@@ -40,6 +55,11 @@ export function run(conf) {
     return;
   }
 
+  // We can't check for headers unless we also have a translation
+  if (!localizationStrings[lang]) {
+    return;
+  }
+
   if (conf.noRecTrack || !requiresSomeSectionStatus.has(conf.specStatus)) {
     return;
   }
@@ -47,8 +67,8 @@ export function run(conf) {
   const logger = conf.lint[ruleName] === "error" ? showError : showWarning;
 
   const missingRequiredSections = new InsensitiveStringSet([
-    "Privacy Considerations",
-    "Security Considerations",
+    l10n.privacy_considerations,
+    l10n.security_considerations,
   ]);
 
   /** @type {NodeListOf<HTMLElement>} */

--- a/src/w3c/linter-rules/required-sections.js
+++ b/src/w3c/linter-rules/required-sections.js
@@ -10,6 +10,7 @@ import {
   docLink,
   getIntlData,
   norm,
+  resolveLanguageAlias,
   showError,
   showWarning,
 } from "../../core/utils.js";
@@ -56,7 +57,8 @@ export function run(conf) {
   }
 
   // We can't check for headers unless we also have a translation
-  if (!localizationStrings[lang]) {
+  if (!localizationStrings[resolveLanguageAlias(lang)]) {
+    console.warn(`Missing localization strings for ${lang}.`);
     return;
   }
 

--- a/tests/spec/w3c/linter-rules/required-sections-spec.js
+++ b/tests/spec/w3c/linter-rules/required-sections-spec.js
@@ -155,4 +155,40 @@ describe("w3c — required-sections", () => {
     const warnings = warningsFilter(doc);
     expect(warnings).toHaveSize(0);
   });
+
+  it("handles localized documents", async () => {
+    const body = `
+    <section>
+      <h2>Consideraciones de privacidad</h2>
+      <p>This is a privacy section</p>
+    </section>
+    `;
+    const conf = {
+      lint: { "required-sections": true },
+      specStatus: "WD",
+    };
+    const opts = makeStandardOps(conf, body);
+    opts.htmlAttrs = { lang: "es" };
+    const doc = await makeRSDoc(opts);
+    const errors = errorsFilter(doc);
+    expect(errors).toHaveSize(0);
+    const warnings = warningsFilter(doc);
+    expect(warnings).toHaveSize(1);
+    const [warn] = warnings;
+    expect(warn.message).toContain("Consideraciones de Seguridad");
+  });
+
+  it("gracefully handles localized documents for unknown languages", async () => {
+    const conf = {
+      lint: { "required-sections": true },
+      specStatus: "WD",
+    };
+    const opts = makeStandardOps(conf);
+    opts.htmlAttrs = { lang: "ab" }; // Abkhazian
+    const doc = await makeRSDoc(opts);
+    const errors = errorsFilter(doc);
+    expect(errors).toHaveSize(0);
+    const warnings = warningsFilter(doc);
+    expect(warnings).toHaveSize(0);
+  });
 });


### PR DESCRIPTION
Forgot that this would get upset if the document was not in English. 