### PR TITLE
chore(deps): update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "28.1.0",
       "license": "W3C",
       "dependencies": {
-        "colors": "^1.4.0",
+        "colors": "1.4.0",
         "finalhandler": "^1.1.2",
-        "marked": "^4.0.8",
+        "marked": "^4.0.9",
         "puppeteer": "^13.0.1",
-        "sade": "^1.8.0",
+        "sade": "^1.8.1",
         "serve-static": "^1.14.2"
       },
       "bin": {
@@ -23,7 +23,7 @@
       "devDependencies": {
         "@rollup/plugin-alias": "^3.1.9",
         "@rollup/plugin-commonjs": "^21.0.1",
-        "@rollup/plugin-node-resolve": "^13.1.2",
+        "@rollup/plugin-node-resolve": "^13.1.3",
         "@types/marked": "^4.0.1",
         "@types/pluralize": "0.0.29",
         "boxen": "^6.2.1",
@@ -35,12 +35,12 @@
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-jasmine": "^4.1.3",
         "eslint-plugin-prettier": "^4.0.0",
-        "highlight.js": "^11.3.1",
+        "highlight.js": "^11.4.0",
         "hyperhtml": "^2.34.0",
         "idb": "^7.0.0",
-        "jasmine": "^4.0.0",
+        "jasmine": "^4.0.1",
         "jasmine-core": "^4.0.0",
-        "karma": "^6.3.9",
+        "karma": "^6.3.10",
         "karma-chrome-launcher": "^3.1.0",
         "karma-firefox-launcher": "^2.1.2",
         "karma-jasmine": "^4.0.1",
@@ -51,7 +51,7 @@
         "pluralize": "^8.0.0",
         "prettier": "^2.5.1",
         "prompt": "^1.2.0",
-        "rollup": "^2.62.0",
+        "rollup": "^2.63.0",
         "rollup-plugin-minify-html-literals": "^1.2.6",
         "rollup-plugin-terser": "^7.0.2",
         "serve": "^13.0.2",
@@ -192,9 +192,9 @@
       }
     },
     "node_modules/@rollup/plugin-node-resolve": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.1.2.tgz",
-      "integrity": "sha512-xyqbuf1vyOPC60jEKhx3DBHunymnCJswzjNTKfX4Jz7zCPar1UqbRZCNY1u5QaXh97beaFTWdoUUWiV4qX8o/g==",
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.1.3.tgz",
+      "integrity": "sha512-BdxNk+LtmElRo5d06MGY4zoepyrXX1tkzX2hrnPEZ53k78GuOMWLqmJDGIIOPwVRIFZrLQOo+Yr6KtCuLIA0AQ==",
       "dev": true,
       "dependencies": {
         "@rollup/pluginutils": "^3.1.0",
@@ -2509,9 +2509,9 @@
       }
     },
     "node_modules/highlight.js": {
-      "version": "11.3.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.3.1.tgz",
-      "integrity": "sha512-PUhCRnPjLtiLHZAQ5A/Dt5F8cWZeMyj9KRsACsWT+OD6OP0x6dp5OmT5jdx0JgEyPxPZZIPQpRN2TciUT7occw==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.4.0.tgz",
+      "integrity": "sha512-nawlpCBCSASs7EdvZOYOYVkJpGmAOKMYZgZtUqSRqodZE0GRVcFKwo1RcpeOemqh9hyttTdd5wDBwHkuSyUfnA==",
       "dev": true,
       "engines": {
         "node": ">=12.0.0"
@@ -2966,9 +2966,9 @@
       "dev": true
     },
     "node_modules/jasmine": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-4.0.0.tgz",
-      "integrity": "sha512-7htNYss1Bd6Dc3bPMWCFH17kaQyfau7cSOALco6RympKLLBFINW6Io4xNJqNGgU2ZYlqNmiXS1W+mjFTqa09xQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-4.0.1.tgz",
+      "integrity": "sha512-NAf9b80ie0pAXLW2l+Fxc8s0Q6SjVgi81jOyHJRQuZ+fPjbVAnXNfN2nIwf5yoRjoSTROyRiETjr9Cr+nNBTVw==",
       "dev": true,
       "dependencies": {
         "glob": "^7.1.6",
@@ -3088,9 +3088,9 @@
       }
     },
     "node_modules/karma": {
-      "version": "6.3.9",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.9.tgz",
-      "integrity": "sha512-E/MqdLM9uVIhfuyVnrhlGBu4miafBdXEAEqCmwdEMh3n17C7UWC/8Kvm3AYKr91gc7scutekZ0xv6rxRaUCtnw==",
+      "version": "6.3.10",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.10.tgz",
+      "integrity": "sha512-Ofv+sgrkT8Czo6bzzQCvrwVyRSG8/3e7RbawEuxjfsINony+IR/S2csNRUFgPNfmWvju+dqi/MzQGOJ2LnlmfQ==",
       "dev": true,
       "dependencies": {
         "body-parser": "^1.19.0",
@@ -3353,9 +3353,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.8.tgz",
-      "integrity": "sha512-dkpJMIlJpc833hbjjg8jraw1t51e/eKDoG8TFOgc5O0Z77zaYKigYekTDop5AplRoKFGIaoazhYEhGkMtU3IeA==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.9.tgz",
+      "integrity": "sha512-HmoFvQwFLxNESeGupeOC+6CLb5WzcCWQmqvVetsErmrI3vrZ6gBumty5IP0ynLPR0zYSoVY7ITC1GffsYIGkog==",
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -4202,9 +4202,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "2.62.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.62.0.tgz",
-      "integrity": "sha512-cJEQq2gwB0GWMD3rYImefQTSjrPYaC6s4J9pYqnstVLJ1CHa/aZNVkD4Epuvg4iLeMA4KRiq7UM7awKK6j7jcw==",
+      "version": "2.63.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.63.0.tgz",
+      "integrity": "sha512-nps0idjmD+NXl6OREfyYXMn/dar3WGcyKn+KBzPdaLecub3x/LrId0wUcthcr8oZUAcZAR8NKcfGGFlNgGL1kQ==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -4248,9 +4248,9 @@
       }
     },
     "node_modules/sade": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.0.tgz",
-      "integrity": "sha512-NRfCA8AVYuAA7Hu8bs18od6J4BdcXXwOv6OJuNgwbw8LcLK8JKwaM3WckLZ+MGyPJUS/ivVgK3twltrOIJJnug==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
       "dependencies": {
         "mri": "^1.1.0"
       },
@@ -5584,9 +5584,9 @@
       }
     },
     "@rollup/plugin-node-resolve": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.1.2.tgz",
-      "integrity": "sha512-xyqbuf1vyOPC60jEKhx3DBHunymnCJswzjNTKfX4Jz7zCPar1UqbRZCNY1u5QaXh97beaFTWdoUUWiV4qX8o/g==",
+      "version": "13.1.3",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-13.1.3.tgz",
+      "integrity": "sha512-BdxNk+LtmElRo5d06MGY4zoepyrXX1tkzX2hrnPEZ53k78GuOMWLqmJDGIIOPwVRIFZrLQOo+Yr6KtCuLIA0AQ==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^3.1.0",
@@ -7452,9 +7452,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "11.3.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.3.1.tgz",
-      "integrity": "sha512-PUhCRnPjLtiLHZAQ5A/Dt5F8cWZeMyj9KRsACsWT+OD6OP0x6dp5OmT5jdx0JgEyPxPZZIPQpRN2TciUT7occw==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.4.0.tgz",
+      "integrity": "sha512-nawlpCBCSASs7EdvZOYOYVkJpGmAOKMYZgZtUqSRqodZE0GRVcFKwo1RcpeOemqh9hyttTdd5wDBwHkuSyUfnA==",
       "dev": true
     },
     "html-minifier": {
@@ -7807,9 +7807,9 @@
       "dev": true
     },
     "jasmine": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-4.0.0.tgz",
-      "integrity": "sha512-7htNYss1Bd6Dc3bPMWCFH17kaQyfau7cSOALco6RympKLLBFINW6Io4xNJqNGgU2ZYlqNmiXS1W+mjFTqa09xQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-4.0.1.tgz",
+      "integrity": "sha512-NAf9b80ie0pAXLW2l+Fxc8s0Q6SjVgi81jOyHJRQuZ+fPjbVAnXNfN2nIwf5yoRjoSTROyRiETjr9Cr+nNBTVw==",
       "dev": true,
       "requires": {
         "glob": "^7.1.6",
@@ -7912,9 +7912,9 @@
       }
     },
     "karma": {
-      "version": "6.3.9",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.9.tgz",
-      "integrity": "sha512-E/MqdLM9uVIhfuyVnrhlGBu4miafBdXEAEqCmwdEMh3n17C7UWC/8Kvm3AYKr91gc7scutekZ0xv6rxRaUCtnw==",
+      "version": "6.3.10",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.10.tgz",
+      "integrity": "sha512-Ofv+sgrkT8Czo6bzzQCvrwVyRSG8/3e7RbawEuxjfsINony+IR/S2csNRUFgPNfmWvju+dqi/MzQGOJ2LnlmfQ==",
       "dev": true,
       "requires": {
         "body-parser": "^1.19.0",
@@ -8142,9 +8142,9 @@
       }
     },
     "marked": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.8.tgz",
-      "integrity": "sha512-dkpJMIlJpc833hbjjg8jraw1t51e/eKDoG8TFOgc5O0Z77zaYKigYekTDop5AplRoKFGIaoazhYEhGkMtU3IeA=="
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.9.tgz",
+      "integrity": "sha512-HmoFvQwFLxNESeGupeOC+6CLb5WzcCWQmqvVetsErmrI3vrZ6gBumty5IP0ynLPR0zYSoVY7ITC1GffsYIGkog=="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -8800,9 +8800,9 @@
       }
     },
     "rollup": {
-      "version": "2.62.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.62.0.tgz",
-      "integrity": "sha512-cJEQq2gwB0GWMD3rYImefQTSjrPYaC6s4J9pYqnstVLJ1CHa/aZNVkD4Epuvg4iLeMA4KRiq7UM7awKK6j7jcw==",
+      "version": "2.63.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.63.0.tgz",
+      "integrity": "sha512-nps0idjmD+NXl6OREfyYXMn/dar3WGcyKn+KBzPdaLecub3x/LrId0wUcthcr8oZUAcZAR8NKcfGGFlNgGL1kQ==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -8840,9 +8840,9 @@
       }
     },
     "sade": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.0.tgz",
-      "integrity": "sha512-NRfCA8AVYuAA7Hu8bs18od6J4BdcXXwOv6OJuNgwbw8LcLK8JKwaM3WckLZ+MGyPJUS/ivVgK3twltrOIJJnug==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+      "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
       "requires": {
         "mri": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "@rollup/plugin-alias": "^3.1.9",
     "@rollup/plugin-commonjs": "^21.0.1",
-    "@rollup/plugin-node-resolve": "^13.1.2",
+    "@rollup/plugin-node-resolve": "^13.1.3",
     "@types/marked": "^4.0.1",
     "@types/pluralize": "0.0.29",
     "boxen": "^6.2.1",
@@ -37,12 +37,12 @@
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jasmine": "^4.1.3",
     "eslint-plugin-prettier": "^4.0.0",
-    "highlight.js": "^11.3.1",
+    "highlight.js": "^11.4.0",
     "hyperhtml": "^2.34.0",
     "idb": "^7.0.0",
-    "jasmine": "^4.0.0",
+    "jasmine": "^4.0.1",
     "jasmine-core": "^4.0.0",
-    "karma": "^6.3.9",
+    "karma": "^6.3.10",
     "karma-chrome-launcher": "^3.1.0",
     "karma-firefox-launcher": "^2.1.2",
     "karma-jasmine": "^4.0.1",
@@ -53,7 +53,7 @@
     "pluralize": "^8.0.0",
     "prettier": "^2.5.1",
     "prompt": "^1.2.0",
-    "rollup": "^2.62.0",
+    "rollup": "^2.63.0",
     "rollup-plugin-minify-html-literals": "^1.2.6",
     "rollup-plugin-terser": "^7.0.2",
     "serve": "^13.0.2",
@@ -84,11 +84,11 @@
     "test:integration": "karma start ./tests/spec/karma.conf.js --single-run"
   },
   "dependencies": {
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "finalhandler": "^1.1.2",
-    "marked": "^4.0.8",
+    "marked": "^4.0.9",
     "puppeteer": "^13.0.1",
-    "sade": "^1.8.0",
+    "sade": "^1.8.1",
     "serve-static": "^1.14.2"
   },
   "files": [


### PR DESCRIPTION
- Fixes #3951 (lock `colors` to 1.4.0)
- Closes #3944
- Closes #3945 
- Closes #3946 
- Closes #3947 
- Closes #3948 
- Closes #3949 
- Closes #3950 