### PR TITLE
fix(w3c/seo): add canonical link for Note and Registry track docs

### DIFF
--- a/src/w3c/seo.js
+++ b/src/w3c/seo.js
@@ -2,8 +2,8 @@
 // Module w3c/seo
 // Manages SEO information for documents
 // e.g. set the canonical URL for the document if configured
+import { recTrackStatus, registryTrackStatus, W3CNotes } from "./headers.js";
 import { html } from "../core/import-maps.js";
-import { recTrackStatus, W3CNotes, registryTrackStatus } from "./headers.js";
 import { resolveRef } from "../core/biblio.js";
 import { showWarning } from "../core/utils.js";
 export const name = "w3c/seo";

--- a/src/w3c/seo.js
+++ b/src/w3c/seo.js
@@ -22,6 +22,8 @@ const status2rdf = {
 
 export const requiresCanonicalLink = new Set([
   ...recTrackStatus,
+  ...W3CNotes,
+  ...registryTrackStatus,
   "BG-FINAL",
   "CG-FINAL",
   "CRY",

--- a/src/w3c/seo.js
+++ b/src/w3c/seo.js
@@ -2,7 +2,7 @@
 // Module w3c/seo
 // Manages SEO information for documents
 // e.g. set the canonical URL for the document if configured
-import { recTrackStatus, registryTrackStatus, W3CNotes } from "./headers.js";
+import { W3CNotes, recTrackStatus, registryTrackStatus } from "./headers.js";
 import { html } from "../core/import-maps.js";
 import { resolveRef } from "../core/biblio.js";
 import { showWarning } from "../core/utils.js";
@@ -21,8 +21,8 @@ const status2rdf = {
 };
 
 export const requiresCanonicalLink = new Set([
-  ...recTrackStatus,
   ...W3CNotes,
+  ...recTrackStatus,
   ...registryTrackStatus,
   "BG-FINAL",
   "CG-FINAL",

--- a/src/w3c/seo.js
+++ b/src/w3c/seo.js
@@ -3,7 +3,7 @@
 // Manages SEO information for documents
 // e.g. set the canonical URL for the document if configured
 import { html } from "../core/import-maps.js";
-import { recTrackStatus } from "./headers.js";
+import { recTrackStatus, W3CNotes, registryTrackStatus } from "./headers.js";
 import { resolveRef } from "../core/biblio.js";
 import { showWarning } from "../core/utils.js";
 export const name = "w3c/seo";


### PR DESCRIPTION
Recent Notes don't pass pubrules as they are missing the canonical link