### PR TITLE
BREAKING CHANGE: don't show logo or allow usage of W3C status if not in a W3C WG

### DIFF
--- a/src/w3c/defaults.js
+++ b/src/w3c/defaults.js
@@ -72,21 +72,20 @@ export function run(conf) {
 }
 
 function processLogos(conf) {
+  const { specStatus: status } = conf;
   // Only include the W3C logo and license for W3C Recommendation track
   // that have an actual working group.
   // Excludes "ED" status
   if (
     conf.wg?.length &&
-    [...recTrackStatus, ...registryTrackStatus, ...W3CNotes].includes(
-      conf.specStatus
-    )
+    [...recTrackStatus, ...registryTrackStatus, ...W3CNotes].includes(status)
   ) {
     conf.logos?.unshift(w3cLogo);
   }
 
   // Special case for "ED" status...
   // Allow overriding the logos, otherwise include the w3c logo.
-  if (conf.specStatus === "ED" && conf.logos?.length === 0) {
+  if (status === "ED" && conf.logos?.length === 0) {
     conf.logos.push(w3cLogo);
   }
 }

--- a/src/w3c/group.js
+++ b/src/w3c/group.js
@@ -6,37 +6,14 @@
  * `wgURI`, and `wgPatentURI` options.
  */
 
-import {
-  codedJoinAnd,
-  docLink,
-  fetchAndCache,
-  showError,
-  showWarning,
-} from "../core/utils.js";
+import { docLink, fetchAndCache, showError } from "../core/utils.js";
 
 export const name = "w3c/group";
 
 const W3C_GROUPS_API = "https://respec.org/w3c/groups/";
-const LEGACY_OPTIONS = ["wg", "wgURI", "wgId", "wgPatentURI", "wgPatentPolicy"];
-
 export async function run(conf) {
-  const usedLegacyOptions = LEGACY_OPTIONS.filter(opt => conf[opt]);
-
   if (!conf.group) {
-    if (usedLegacyOptions.length) {
-      const outdatedOptionsStr = codedJoinAnd(LEGACY_OPTIONS);
-      const msg = `Configuration options ${outdatedOptionsStr} are deprecated.`;
-      const hint = docLink`Please use the ${"[group]"} configuration option instead.`;
-      showWarning(msg, name, { hint });
-    }
     return;
-  }
-
-  if (usedLegacyOptions.length) {
-    const outdatedOptionsStr = codedJoinAnd(usedLegacyOptions);
-    const msg = docLink`Configuration options ${outdatedOptionsStr} are superseded by ${"[group]"} and will be overridden by ReSpec.`;
-    const hint = docLink`Remove them from the document's ${"[respecConfig]"} to silence this warning.`;
-    showWarning(msg, name, { hint });
   }
 
   const { group } = conf;

--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -198,6 +198,7 @@ export const recTrackStatus = [
   "PER",
   "REC",
   "DISC",
+  "RSCND",
 ];
 export const registryTrackStatus = ["DRY", "CRY", "CRYD", "RY"];
 export const cgStatus = ["CG-DRAFT", "CG-FINAL"];

--- a/src/w3c/style.js
+++ b/src/w3c/style.js
@@ -107,7 +107,7 @@ export function run(conf) {
       break;
     case "UD":
     case "UNOFFICIAL":
-      styleFile += "UD";
+      styleFile = "W3C-UD";
       break;
     case "FINDING":
     case "DRAFT-FINDING":

--- a/src/w3c/style.js
+++ b/src/w3c/style.js
@@ -5,12 +5,7 @@
 //  - specStatus: the short code for the specification's maturity level or type (required)
 
 import { W3CNotes, recTrackStatus, registryTrackStatus } from "./headers.js";
-import {
-  createResourceHint,
-  docLink,
-  linkCSS,
-  showWarning,
-} from "../core/utils.js";
+import { createResourceHint, linkCSS } from "../core/utils.js";
 import { html } from "../core/import-maps.js";
 import { sub } from "../core/pubsubhub.js";
 export const name = "w3c/style";

--- a/src/w3c/style.js
+++ b/src/w3c/style.js
@@ -88,7 +88,7 @@ function styleMover(linkURL) {
 
 export function run(conf) {
   const canonicalStatus = conf.specStatus?.toUpperCase() ?? "";
-  let styleFile = "W3C-";
+  let styleFile = "";
   const canUseW3CStyle =
     [
       ...recTrackStatus,

--- a/src/w3c/style.js
+++ b/src/w3c/style.js
@@ -112,7 +112,7 @@ export function run(conf) {
       break;
     case "UD":
     case "UNOFFICIAL":
-      styleFile = "W3C-UD";
+      styleFile += "UD";
       break;
     case "FINDING":
     case "DRAFT-FINDING":

--- a/src/w3c/style.js
+++ b/src/w3c/style.js
@@ -4,7 +4,13 @@
 // CONFIGURATION
 //  - specStatus: the short code for the specification's maturity level or type (required)
 
-import { createResourceHint, linkCSS, showWarning } from "../core/utils.js";
+import { W3CNotes, recTrackStatus, registryTrackStatus } from "./headers.js";
+import {
+  createResourceHint,
+  docLink,
+  linkCSS,
+  showWarning,
+} from "../core/utils.js";
 import { html } from "../core/import-maps.js";
 import { sub } from "../core/pubsubhub.js";
 export const name = "w3c/style";
@@ -81,28 +87,32 @@ function styleMover(linkURL) {
 }
 
 export function run(conf) {
-  if (!conf.specStatus) {
-    const msg = "`respecConfig.specStatus` missing. Defaulting to 'base'.";
-    conf.specStatus = "base";
-    showWarning(msg, name);
-  }
-
+  const canonicalStatus = conf.specStatus?.toUpperCase() ?? "";
   let styleFile = "W3C-";
+  const canUseW3CStyle =
+    [
+      ...recTrackStatus,
+      ...registryTrackStatus,
+      ...W3CNotes,
+      "ED",
+      "MEMBER-SUBM",
+    ].includes(canonicalStatus) && conf.wgId;
 
   // Figure out which style file to use.
-  switch (conf.specStatus.toUpperCase()) {
+  switch (canonicalStatus) {
     case "WD":
     case "FPWD":
-      styleFile = "W3C-WD";
+      styleFile = canUseW3CStyle ? "W3C-WD" : "base.css";
       break;
     case "CG-DRAFT":
     case "CG-FINAL":
     case "BG-DRAFT":
     case "BG-FINAL":
-      styleFile = conf.specStatus.toLowerCase();
+      styleFile = canonicalStatus.toLowerCase();
       break;
+    case "UD":
     case "UNOFFICIAL":
-      styleFile += "UD";
+      styleFile = "W3C-UD";
       break;
     case "FINDING":
     case "DRAFT-FINDING":
@@ -111,7 +121,7 @@ export function run(conf) {
       styleFile = "base.css";
       break;
     default:
-      styleFile += conf.specStatus;
+      styleFile = canUseW3CStyle ? `W3C-${conf.specStatus}` : "base.css";
   }
 
   // Attach W3C fixup script after we are done.

--- a/tests/spec/core/exporter-spec.js
+++ b/tests/spec/core/exporter-spec.js
@@ -76,7 +76,7 @@ describe("Core - exporter", () => {
   });
 
   it("moves the W3C style sheet to be last thing in documents head", async () => {
-    const ops = makeStandardOps();
+    const ops = makeStandardOps({ specStatus: "ED", group: "webapps" });
     ops.body = `
       <!-- add WebIDL style -->
       <pre class="idl">

--- a/tests/spec/core/override-configuration-spec.js
+++ b/tests/spec/core/override-configuration-spec.js
@@ -14,6 +14,7 @@ describe("Core — Override Configuration", () => {
       "additionalCopyrightHolders",
       "Internet Engineering Task Force"
     );
+    url.searchParams.set("group", "webapps");
     const doc = await makeRSDoc(makeStandardOps(), url);
     const { respecConfig: conf } = doc.defaultView;
     const { textContent } = doc.querySelector(".head p");

--- a/tests/spec/w3c/defaults-spec.js
+++ b/tests/spec/w3c/defaults-spec.js
@@ -85,7 +85,9 @@ describe("W3C — Defaults", () => {
     const ops = makeStandardOps({ specStatus: "WD" });
     const docNoGroup = await makeRSDoc(ops);
     expect(docNoGroup.querySelector("img[alt='W3C']")).toBeNull();
+  });
 
+  it("doesn't show the W3C logo an unknown group is specified", async () => {
     const opsBadGroup = makeStandardOps({
       specStatus: "WD",
       group: "not a real group",

--- a/tests/spec/w3c/defaults-spec.js
+++ b/tests/spec/w3c/defaults-spec.js
@@ -88,12 +88,12 @@ describe("W3C — Defaults", () => {
   });
 
   it("doesn't show the W3C logo an unknown group is specified", async () => {
-    const opsBadGroup = makeStandardOps({
+    const ops = makeStandardOps({
       specStatus: "WD",
       group: "not a real group",
     });
-    const docBadGroup = await makeRSDoc(opsBadGroup);
-    expect(docBadGroup.querySelector("img[alt='W3C']")).toBeNull();
+    const doc = await makeRSDoc(ops);
+    expect(doc.querySelector("img[alt='W3C']")).toBeNull();
   });
 
   it("shows the W3C logo if a valid group and specStatus is specified", async () => {

--- a/tests/spec/w3c/defaults-spec.js
+++ b/tests/spec/w3c/defaults-spec.js
@@ -1,6 +1,12 @@
 "use strict";
 
-import { flushIframes, makeDefaultBody, makeRSDoc } from "../SpecHelper.js";
+import {
+  flushIframes,
+  makeDefaultBody,
+  makeRSDoc,
+  makeStandardOps,
+  warningFilters,
+} from "../SpecHelper.js";
 
 describe("W3C — Defaults", () => {
   afterAll(flushIframes);
@@ -73,5 +79,62 @@ describe("W3C — Defaults", () => {
     expect(rsConf.highlightVars).toBe(false);
     expect(rsConf.license).toBe("c0");
     expect(rsConf.specStatus).toBe("ED");
+  });
+
+  it("doesn't show the W3C logo if no group or an invalid group is specified", async () => {
+    const ops = makeStandardOps({
+      specStatus: "WD",
+    });
+    const docNoGroup = await makeRSDoc(ops);
+    expect(docNoGroup.querySelector("img[alt='W3C']")).toBeNull();
+
+    const opsBadGroup = makeStandardOps({
+      specStatus: "WD",
+      group: "not a real group",
+    });
+    const docBadGroup = await makeRSDoc(opsBadGroup);
+    expect(docBadGroup.querySelector("img[alt='W3C']")).toBeNull();
+  });
+
+  it("shows the W3C logo if a valid group and specStatus is specified", async () => {
+    const ops = makeStandardOps({
+      specStatus: "WD",
+      group: "css",
+    });
+    const doc = await makeRSDoc(ops);
+    expect(doc.querySelector("img[alt='W3C']")).not.toBeNull();
+  });
+
+  it("warns when using a W3C specStatus, but no group is configured and defaults to 'base'", async () => {
+    const warningFilter = warningFilters.filter("w3c/defaults");
+    const ops = makeStandardOps({
+      specStatus: "WD",
+    });
+    const doc = await makeRSDoc(ops);
+    const warnings = warningFilter(doc);
+    expect(warnings).toHaveSize(1);
+    expect(warnings[0].message).toContain(
+      "Document is not associated with a [W3C group]"
+    );
+    const config = doc.defaultView.respecConfig;
+    expect(config.specStatus).toBe("base");
+  });
+
+  it("warns when specStatus is missing, and defaults to 'base' for the specStatus", async () => {
+    const warningFilter = warningFilters.filter("w3c/defaults");
+    const ops = makeStandardOps({
+      config: {
+        editors: [{ name: "foo" }],
+      },
+      specStatus: "",
+    });
+    const doc = await makeRSDoc(ops);
+    const warnings = warningFilter(doc);
+    expect(warnings).toHaveSize(1);
+    expect(warnings[0].message).toContain(
+      "#specStatus) configuration option is required"
+    );
+    const config = doc.defaultView.respecConfig;
+    expect(config.specStatus).toBe("base");
   });
 });

--- a/tests/spec/w3c/defaults-spec.js
+++ b/tests/spec/w3c/defaults-spec.js
@@ -107,9 +107,7 @@ describe("W3C — Defaults", () => {
 
   it("warns when using a W3C specStatus, but no group is configured and defaults to 'base'", async () => {
     const warningFilter = warningFilters.filter("w3c/defaults");
-    const ops = makeStandardOps({
-      specStatus: "WD",
-    });
+    const ops = makeStandardOps({ specStatus: "WD" });
     const doc = await makeRSDoc(ops);
     const warnings = warningFilter(doc);
     expect(warnings).toHaveSize(1);

--- a/tests/spec/w3c/defaults-spec.js
+++ b/tests/spec/w3c/defaults-spec.js
@@ -82,9 +82,7 @@ describe("W3C — Defaults", () => {
   });
 
   it("doesn't show the W3C logo if no group or an invalid group is specified", async () => {
-    const ops = makeStandardOps({
-      specStatus: "WD",
-    });
+    const ops = makeStandardOps({ specStatus: "WD" });
     const docNoGroup = await makeRSDoc(ops);
     expect(docNoGroup.querySelector("img[alt='W3C']")).toBeNull();
 

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -54,7 +54,9 @@ describe("W3C — Headers", () => {
   it("links to the 'kinds of documents' only for W3C documents", async () => {
     const statuses = ["FPWD", "WD", "CR", "CRD", "PR", "REC", "NOTE"];
     for (const specStatus of statuses) {
-      const doc = await makeRSDoc(makeStandardOps({ specStatus }));
+      const doc = await makeRSDoc(
+        makeStandardOps({ specStatus, group: "webapps" })
+      );
       const w3cLink = doc.querySelector(
         `.head a[href='https://www.w3.org/standards/types#${specStatus}']`
       );
@@ -105,6 +107,7 @@ describe("W3C — Headers", () => {
       const ops = makeStandardOps();
       const newProps = {
         specStatus: "REC",
+        group: "webapps",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -119,6 +122,7 @@ describe("W3C — Headers", () => {
       const ops = makeStandardOps({
         shortName: "test",
         specStatus: "draft-finding",
+        group: "tag",
       });
       const doc = await makeRSDoc(ops);
       const definitions = doc.querySelectorAll(".head dt");
@@ -192,6 +196,7 @@ describe("W3C — Headers", () => {
       const newProps = {
         specStatus: "REC",
         shortName: "xxx",
+        group: "webapps",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -225,6 +230,7 @@ describe("W3C — Headers", () => {
               retiredDate: "2020-03-01",
             },
           ],
+          group: "webapps",
         };
         Object.assign(ops.config, newProps);
         const doc = await makeRSDoc(ops);
@@ -248,6 +254,7 @@ describe("W3C — Headers", () => {
               retiredDate: "2020-03-01",
             },
           ],
+          group: "webapps",
         };
         Object.assign(ops.config, newProps);
         const doc = await makeRSDoc(ops);
@@ -269,6 +276,7 @@ describe("W3C — Headers", () => {
               name: "FORMER EDITOR 1",
             },
           ],
+          group: "webapps",
         };
         Object.assign(ops.config, newProps);
         const doc = await makeRSDoc(ops);
@@ -295,6 +303,7 @@ describe("W3C — Headers", () => {
               retiredDate: "2020-03-01",
             },
           ],
+          group: "webapps",
         };
         Object.assign(ops.config, newProps);
         const doc = await makeRSDoc(ops);
@@ -328,6 +337,7 @@ describe("W3C — Headers", () => {
               name: "FORMER EDITOR 1",
             },
           ],
+          group: "webapps",
         };
         Object.assign(ops.config, newProps);
         const doc = await makeRSDoc(ops);
@@ -360,6 +370,7 @@ describe("W3C — Headers", () => {
             orcid: "https://orcid.org/0000-0002-1694-233X",
           },
         ],
+        group: "webapps",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -399,6 +410,7 @@ describe("W3C — Headers", () => {
             name: "NAME2",
           },
         ],
+        group: "webapps",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -427,6 +439,7 @@ describe("W3C — Headers", () => {
             ],
           },
         ],
+        group: "webapps",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -451,6 +464,7 @@ describe("W3C — Headers", () => {
             company: "<span lang='ja'>マイクロソフト</span> (Microsoft)",
           },
         ],
+        group: "webapps",
       };
       const ops = makeStandardOps(config);
       const doc = await makeRSDoc(ops);
@@ -477,6 +491,7 @@ describe("W3C — Headers", () => {
       const newProps = {
         specStatus: "REC",
         formerEditors: [],
+        group: "webapps",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -503,6 +518,7 @@ describe("W3C — Headers", () => {
             w3cid: "1234",
           },
         ],
+        group: "webapps",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -547,6 +563,7 @@ describe("W3C — Headers", () => {
             name: "NAME2",
           },
         ],
+        group: "webapps",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -575,6 +592,7 @@ describe("W3C — Headers", () => {
             company: "Microsoft",
           },
         ],
+        group: "webapps",
       };
       const ops = makeStandardOps(config);
       const doc = await makeRSDoc(ops);
@@ -601,6 +619,7 @@ describe("W3C — Headers", () => {
             name: "NAME1",
           },
         ],
+        group: "webapps",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -624,6 +643,7 @@ describe("W3C — Headers", () => {
             name: "NAME2",
           },
         ],
+        group: "webapps",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -647,7 +667,7 @@ describe("W3C — Headers", () => {
       const body = `
         <h1 id="title">Spec <code>Marked</code> Up</h1>${makeDefaultBody()}`;
       const ops = makeStandardOps(
-        { level: 0, specStatus: "REC", shortName: "abc" },
+        { level: 0, specStatus: "REC", shortName: "abc", group: "webapps" },
         body
       );
 
@@ -672,7 +692,7 @@ describe("W3C — Headers", () => {
       const body = `
       <h1 id="title">Spec <code>Marked</code> Up</h1>${makeDefaultBody()}`;
       const ops = makeStandardOps(
-        { level: 9870, specStatus: "REC", shortName: "xyz" },
+        { level: 9870, specStatus: "REC", shortName: "xyz", group: "webapps" },
         body
       );
 
@@ -699,7 +719,7 @@ describe("W3C — Headers", () => {
       const body = `
       <h1 id="title">Spec <code>Marked</code> Up</h1>${makeDefaultBody()}`;
       const ops = makeStandardOps(
-        { level: "a1", specStatus: "REC", shortName: "xxx" },
+        { level: "a1", specStatus: "REC", shortName: "xxx", group: "webapps" },
         body
       );
 
@@ -1046,6 +1066,7 @@ describe("W3C — Headers", () => {
         publishDate: "2017-03-15",
         previousPublishDate: "1977-03-15",
         previousMaturity: "CR",
+        group: "tag",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -1081,6 +1102,7 @@ describe("W3C — Headers", () => {
         specStatus: "WD",
         license: "unknown",
         github: "w3c/respec",
+        group: "webapps",
       });
       const doc = await makeRSDoc(ops, simpleSpecURL);
       expect(doc.respec.errors).toHaveSize(1);
@@ -1130,6 +1152,7 @@ describe("W3C — Headers", () => {
           license,
           shortName: "whatever",
           editors: [{ name: "foo" }],
+          group: "webapps",
         });
         const doc = await makeRSDoc(ops);
         const licenseLinks = doc.querySelectorAll("div.head a[rel=license]");
@@ -1300,6 +1323,7 @@ describe("W3C — Headers", () => {
       const ops = makeStandardOps({
         specStatus: "WD",
         edDraftURI: "URI",
+        group: "webapps",
       });
 
       const doc = await makeRSDoc(ops);
@@ -1349,6 +1373,7 @@ describe("W3C — Headers", () => {
         shortName: "spec",
         specStatus: "CR",
         latestVersion: "https://somewhere.else/",
+        group: "webapps",
       });
       const doc = await makeRSDoc(ops);
 
@@ -1371,6 +1396,7 @@ describe("W3C — Headers", () => {
         level: 3,
         specStatus: "CR",
         latestVersion: "TR/its-here",
+        group: "webapps",
       });
       const doc = await makeRSDoc(ops);
 
@@ -1410,6 +1436,7 @@ describe("W3C — Headers", () => {
       const newProps = {
         specStatus: "REC",
         additionalCopyrightHolders: "XXX",
+        group: "webapps",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -1422,6 +1449,7 @@ describe("W3C — Headers", () => {
       const newProps = {
         specStatus: "CG-DRAFT",
         additionalCopyrightHolders: "XXX",
+        group: "wicg",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -1434,6 +1462,7 @@ describe("W3C — Headers", () => {
       const newProps = {
         specStatus: "CG-FINAL",
         additionalCopyrightHolders: "XXX",
+        group: "wicg",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -1446,6 +1475,7 @@ describe("W3C — Headers", () => {
       const newProps = {
         specStatus: "BG-DRAFT",
         additionalCopyrightHolders: "XXX",
+        group: "publishingbg",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -1458,6 +1488,7 @@ describe("W3C — Headers", () => {
       const newProps = {
         specStatus: "BG-FINAL",
         additionalCopyrightHolders: "XXX",
+        group: "publishingbg",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -1471,6 +1502,7 @@ describe("W3C — Headers", () => {
         specStatus: "CG-DRAFT",
         additionalCopyrightHolders: "<span class='test'>XXX</span>",
         level: 99,
+        group: "wicg",
       });
 
       const doc = await makeRSDoc(ops);
@@ -1607,25 +1639,11 @@ describe("W3C — Headers", () => {
   });
 
   describe("wgId, data-deliverer, and isNote", () => {
-    it("gracefully handles missing wgPatentURI", async () => {
+    it("only doesn't add data-deliverer for non-notes", async () => {
       const ops = makeStandardOps();
       const newProps = {
-        specStatus: "NOTE",
-      };
-      Object.assign(ops.config, newProps);
-      const doc = await makeRSDoc(ops, simpleSpecURL);
-      const elem = doc.querySelector("p[data-deliverer]");
-      const { wgId, isNote } = doc.defaultView.respecConfig;
-      expect(isNote).toBe(true);
-      expect(wgId).toBe("");
-      expect(elem).toBeTruthy();
-      expect(elem.dataset.deliverer).toBe("");
-    });
-    it("only doesn't data-deliverer for non-notes", async () => {
-      const ops = makeStandardOps();
-      const newProps = {
-        group: "webapps",
         specStatus: "WD",
+        group: "webapps",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops, simpleSpecURL);
@@ -1638,7 +1656,7 @@ describe("W3C — Headers", () => {
     it("excludes the long patent text for note types", async () => {
       const noteTypes = ["DNOTE", "NOTE"];
       for (const specStatus of noteTypes) {
-        const opts = makeStandardOps({ specStatus });
+        const opts = makeStandardOps({ specStatus, group: "webapps" });
         const doc = await makeRSDoc(opts);
         const sotd = doc.querySelector("#sotd");
         const [p] = contains(sotd, "p", "Patent Policy");
@@ -1661,9 +1679,9 @@ describe("W3C — Headers", () => {
         perEnd: "2014-12-01",
         specStatus: "PER",
         wg: "WGNAME",
-        wgURI: "WGURI",
         wgPublicList: "WGLIST",
         subjectPrefix: "[The Prefix]",
+        group: "webapps",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -1685,7 +1703,6 @@ describe("W3C — Headers", () => {
       const newProps = {
         sotdAfterWGinfo: true,
         wg: "WGNAME",
-        wgURI: "WGURI",
         wgPublicList: "WGLIST",
         subjectPrefix: "[The Prefix]",
         implementationReportURI: "",
@@ -1735,16 +1752,19 @@ describe("W3C — Headers", () => {
       const ops = makeStandardOps();
       const newProps = {
         specStatus: "CG-DRAFT",
-        wg: "WGNAME",
-        wgURI: "http://WG",
         wgPublicList: "WGLIST",
         subjectPrefix: "[The Prefix]",
+        group: "wicg",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
       const c = doc.querySelector(".head .copyright");
-      expect(c.querySelectorAll("a[href='http://WG']")).toHaveSize(1);
-      expect(contains(c, "a", "WGNAME")).toHaveSize(1);
+      expect(
+        c.querySelectorAll("a[href='https://www.w3.org/groups/cg/wicg']")
+      ).toHaveSize(1);
+      expect(
+        contains(c, "a", "Web Platform Incubator Community Group")
+      ).toHaveSize(1);
       expect(
         c.querySelectorAll(
           "a[href='https://www.w3.org/community/about/agreements/cla/']"
@@ -1754,8 +1774,12 @@ describe("W3C — Headers", () => {
         "Draft Community Group Report"
       );
       const sotd = doc.getElementById("sotd");
-      expect(sotd.querySelectorAll("a[href='http://WG']")).toHaveSize(1);
-      expect(contains(sotd, "a", "WGNAME")).toHaveSize(1);
+      expect(
+        sotd.querySelectorAll("a[href='https://www.w3.org/groups/cg/wicg']")
+      ).toHaveSize(1);
+      expect(
+        contains(sotd, "a", "Web Platform Incubator Community Group")
+      ).toHaveSize(1);
       expect(
         sotd.querySelectorAll(
           "a[href='https://www.w3.org/community/about/agreements/cla/']"
@@ -1831,10 +1855,9 @@ describe("W3C — Headers", () => {
       const ops = makeStandardOps();
       const newProps = {
         specStatus: "BG-FINAL",
-        wg: "WGNAME",
-        wgURI: "http://WG",
         thisVersion: "http://THIS",
         latestVersion: "https://some.places/LATEST",
+        group: "publishingbg",
       };
       Object.assign(ops.config, newProps);
       const doc = await makeRSDoc(ops);
@@ -1856,8 +1879,12 @@ describe("W3C — Headers", () => {
         "https://some.places/LATEST"
       );
       const sotd = doc.getElementById("sotd");
-      expect(sotd.querySelectorAll("a[href='http://WG']")).toHaveSize(1);
-      expect(contains(sotd, "a", "WGNAME")).toHaveSize(1);
+      expect(
+        sotd.querySelectorAll(
+          "a[href='https://www.w3.org/groups/bg/publishingbg']"
+        )
+      ).toHaveSize(1);
+      expect(contains(sotd, "a", "Publishing Business Group")).toHaveSize(1);
       expect(
         sotd.querySelectorAll(
           "a[href='https://www.w3.org/community/about/agreements/final/']"
@@ -1867,7 +1894,7 @@ describe("W3C — Headers", () => {
 
     it("handles the spec title in the copyright section correctly when the h1#title has markup", async () => {
       const body = `<h1 id="title">Spec with <code>markup</code>!</h1>${makeDefaultBody()}`;
-      const props = { specStatus: "BG-FINAL" };
+      const props = { specStatus: "BG-FINAL", group: "publishingbg" };
       const ops = makeStandardOps(props, body);
       const doc = await makeRSDoc(ops);
 
@@ -1889,6 +1916,7 @@ describe("W3C — Headers", () => {
         submissionCommentNumber: "01",
         publishDate: "2018-05-25",
         shortName: "yolo",
+        group: "webapps",
       };
       Object.assign(ops.config, newProps);
       doc = await makeRSDoc(ops);
@@ -2028,6 +2056,7 @@ describe("W3C — Headers", () => {
     const newProps = {
       specStatus: "REC",
       shortName: "PASS",
+      group: "webapps",
     };
     Object.assign(ops.config, newProps);
     const doc = await makeRSDoc(ops);
@@ -2107,7 +2136,7 @@ describe("W3C — Headers", () => {
     it("adds W3C logo for status W3C Notes", async () => {
       const notes = ["DNOTE", "NOTE"];
       for (const specStatus of notes) {
-        const ops = makeStandardOps({ specStatus });
+        const ops = makeStandardOps({ specStatus, group: "webapps" });
         const doc = await makeRSDoc(ops);
         const logo = doc.querySelector("a.logo");
         expect(logo.href)
@@ -2158,7 +2187,11 @@ describe("W3C — Headers", () => {
           url: "http://shiny/",
         },
       ];
-      const ops = makeStandardOps({ specStatus: "WD", logos });
+      const ops = makeStandardOps({
+        group: "webapps",
+        specStatus: "WD",
+        logos,
+      });
       const doc = await makeRSDoc(ops);
       // get logos
       const logosAnchors = [...doc.querySelectorAll(".logo")];
@@ -2258,7 +2291,11 @@ describe("W3C — Headers", () => {
 
   describe("History", () => {
     it("shows the publication history of the spec", async () => {
-      const ops = makeStandardOps({ shortName: "test", specStatus: "WD" });
+      const ops = makeStandardOps({
+        shortName: "test",
+        specStatus: "WD",
+        group: "webapps",
+      });
       const doc = await makeRSDoc(ops);
       const [history] = contains(doc, ".head dt", "History:");
       expect(history).toBeTruthy();
@@ -2278,6 +2315,7 @@ describe("W3C — Headers", () => {
         github: "w3c/respec",
         shortName: "test",
         specStatus: "WD",
+        group: "webapps",
       });
       const doc = await makeRSDoc(ops);
       const commitHistory = doc.querySelector(
@@ -2359,6 +2397,7 @@ describe("W3C — Headers", () => {
         const ops = makeStandardOps({
           shortName,
           specStatus,
+          group: "webapps",
         });
         const doc = await makeRSDoc(ops);
         const [history] = contains(doc, ".head dt", "History:");

--- a/tests/spec/w3c/linter-rules/required-sections-spec.js
+++ b/tests/spec/w3c/linter-rules/required-sections-spec.js
@@ -54,6 +54,7 @@ describe("w3c — required-sections", () => {
       const ops = makeStandardOps({
         lint: { "required-sections": true },
         specStatus,
+        group: "wicg",
       });
       const doc = await makeRSDoc(ops);
       const errors = errorsFilter(doc);
@@ -81,6 +82,7 @@ describe("w3c — required-sections", () => {
       const ops = makeStandardOps({
         lint: { "required-sections": true },
         specStatus,
+        group: "webapps",
       });
       const doc = await makeRSDoc(ops);
       const errors = errorsFilter(doc);
@@ -100,6 +102,7 @@ describe("w3c — required-sections", () => {
     const conf = {
       lint: { "required-sections": "error" },
       specStatus: "WD",
+      group: "webapps",
     };
     const doc = await makeRSDoc(makeStandardOps(conf, body));
     const errors = errorsFilter(doc);
@@ -122,6 +125,7 @@ describe("w3c — required-sections", () => {
     const conf = {
       lint: { "required-sections": "error" },
       specStatus: "WD",
+      group: "webapps",
     };
     const doc = await makeRSDoc(makeStandardOps(conf, body));
     const errors = errorsFilter(doc);
@@ -148,6 +152,7 @@ describe("w3c — required-sections", () => {
     const conf = {
       lint: { "required-sections": true },
       specStatus: "WD",
+      group: "webapps",
     };
     const doc = await makeRSDoc(makeStandardOps(conf, body));
     const errors = errorsFilter(doc);
@@ -166,6 +171,7 @@ describe("w3c — required-sections", () => {
     const conf = {
       lint: { "required-sections": true },
       specStatus: "WD",
+      group: "webapps",
     };
     const opts = makeStandardOps(conf, body);
     opts.htmlAttrs = { lang: "es" };
@@ -182,6 +188,7 @@ describe("w3c — required-sections", () => {
     const conf = {
       lint: { "required-sections": true },
       specStatus: "WD",
+      group: "webapps",
     };
     const opts = makeStandardOps(conf);
     opts.htmlAttrs = { lang: "ab" }; // Abkhazian

--- a/tests/spec/w3c/seo-spec.js
+++ b/tests/spec/w3c/seo-spec.js
@@ -8,7 +8,9 @@ describe("W3C - SEO", () => {
   afterAll(flushIframes);
 
   it("defaults to TR as canonical URI", async () => {
-    const doc = await makeRSDoc(makeStandardOps({ specStatus: "REC" }));
+    const doc = await makeRSDoc(
+      makeStandardOps({ specStatus: "REC", group: "webapps" })
+    );
     const href = "https://www.w3.org/TR/Foo/";
     expect(
       doc.querySelector(`link[rel='canonical'][href='${href}']`)
@@ -17,7 +19,7 @@ describe("W3C - SEO", () => {
 
   it("sets the canonical URI to TR URI when so configured", async () => {
     const href = "https://www.w3.org/TR/Foo/";
-    const ops = makeStandardOps({ canonicalURI: "TR" });
+    const ops = makeStandardOps({ canonicalURI: "TR", group: "webapps" });
     const doc = await makeRSDoc(ops);
     expect(
       doc.querySelector(`link[rel='canonical'][href='${href}']`)
@@ -26,7 +28,7 @@ describe("W3C - SEO", () => {
 
   it("sets the canonical URI to editors draft when configured with 'edDraft'", async () => {
     const href = "https://foo.com/";
-    const ops = makeStandardOps({ canonicalURI: "edDraft" });
+    const ops = makeStandardOps({ canonicalURI: "edDraft", group: "webapps" });
     const doc = await makeRSDoc(ops);
     expect(
       doc.querySelector(`link[rel='canonical'][href='${href}']`)
@@ -63,7 +65,7 @@ describe("W3C - SEO", () => {
 
   it("handles tag documents correctly", async () => {
     for (const specStatus of ["finding", "draft-finding"]) {
-      const ops = makeStandardOps({ specStatus });
+      const ops = makeStandardOps({ specStatus, group: "tag" });
       const doc = await makeRSDoc(ops);
       const path = publicationSpaces[specStatus];
       const link = doc.querySelector("link[rel='canonical']");
@@ -82,7 +84,7 @@ describe("W3C - SEO", () => {
 
   it("adds canonicalURI links for types that require them", async () => {
     for (const specStatus of requiresCanonicalLink) {
-      const ops = makeStandardOps({ specStatus });
+      const ops = makeStandardOps({ specStatus, group: "webapps" });
       const doc = await makeRSDoc(ops);
       expect(doc.querySelector("link[rel='canonical']"))
         .withContext(specStatus)
@@ -117,6 +119,7 @@ describe("W3C - SEO", () => {
         name: "Shane McCarron",
       },
     ],
+    group: "webapps",
     shortName: "some-spec",
     publishDate: "2013-06-25",
     previousPublishDate: "2012-06-07",

--- a/tests/spec/w3c/style-spec.js
+++ b/tests/spec/w3c/style-spec.js
@@ -2,155 +2,164 @@
 
 import { flushIframes, makeRSDoc, makeStandardOps } from "../SpecHelper.js";
 
-const specStatus = [
+const statuses = [
   {
-    status: "FPWD",
+    specStatus: undefined,
+    expectedURL: "https://www.w3.org/StyleSheets/TR/2021/base.css",
+    group: "webapps",
+  },
+  {
+    specStatus: "FPWD",
     expectedURL: "https://www.w3.org/StyleSheets/TR/2021/W3C-WD",
+    group: "webapps",
   },
   {
-    status: "NOTE",
+    specStatus: "NOTE",
     expectedURL: "https://www.w3.org/StyleSheets/TR/2021/W3C-NOTE",
+    group: "webapps",
   },
   {
-    status: "finding",
+    specStatus: "finding",
     expectedURL: "https://www.w3.org/StyleSheets/TR/2021/base.css",
+    group: "tag",
   },
   {
-    status: "draft-finding",
+    specStatus: "draft-finding",
     expectedURL: "https://www.w3.org/StyleSheets/TR/2021/base.css",
+    group: "tag",
   },
   {
-    status: "editor-draft-finding",
+    specStatus: "editor-draft-finding",
     expectedURL: "https://www.w3.org/StyleSheets/TR/2021/base.css",
+    group: "tag",
   },
   {
-    status: "unofficial",
+    specStatus: "unofficial",
     expectedURL: "https://www.w3.org/StyleSheets/TR/2021/W3C-UD",
   },
   {
-    status: "base",
+    specStatus: "base",
     expectedURL: "https://www.w3.org/StyleSheets/TR/2021/base.css",
   },
   {
-    status: "RSCND",
+    specStatus: "RSCND",
     expectedURL: "https://www.w3.org/StyleSheets/TR/2021/W3C-RSCND",
+    group: "webapps",
   },
   {
-    status: "FAKE-TEST-TYPE",
-    expectedURL: "https://www.w3.org/StyleSheets/TR/2021/W3C-FAKE-TEST-TYPE",
+    specStatus: "FAKE-TEST-TYPE",
+    expectedURL: "https://www.w3.org/StyleSheets/TR/2021/base.css",
   },
   {
-    status: "CG-FINAL",
+    specStatus: "CG-FINAL",
     expectedURL: "https://www.w3.org/StyleSheets/TR/2021/cg-final",
+    group: "wicg",
   },
   {
-    status: "CG-DRAFT",
+    specStatus: "CG-DRAFT",
     expectedURL: "https://www.w3.org/StyleSheets/TR/2021/cg-draft",
+    group: "wicg",
   },
   {
-    status: "BG-FINAL",
+    specStatus: "BG-FINAL",
     expectedURL: "https://www.w3.org/StyleSheets/TR/2021/bg-final",
+    group: "wicg",
   },
   {
-    status: "BG-DRAFT",
+    specStatus: "BG-DRAFT",
     expectedURL: "https://www.w3.org/StyleSheets/TR/2021/bg-draft",
+    group: "wicg",
   },
   {
-    status: "CR",
+    specStatus: "CR",
     expectedURL: "https://www.w3.org/StyleSheets/TR/2021/W3C-CR",
+    group: "webapps",
   },
   {
-    status: "CRD",
+    specStatus: "CRD",
     expectedURL: "https://www.w3.org/StyleSheets/TR/2021/W3C-CRD",
+    group: "webapps",
   },
   {
-    status: "CRY",
+    specStatus: "CRY",
     expectedURL: "https://www.w3.org/StyleSheets/TR/2021/W3C-CRY",
+    group: "webapps",
   },
   {
-    status: "CRYD",
+    specStatus: "CRYD",
     expectedURL: "https://www.w3.org/StyleSheets/TR/2021/W3C-CRYD",
+    group: "webapps",
   },
   {
-    status: "DISC",
+    specStatus: "DISC",
     expectedURL: "https://www.w3.org/StyleSheets/TR/2021/W3C-DISC",
+    group: "webapps",
   },
   {
-    status: "DNOTE",
+    specStatus: "DNOTE",
     expectedURL: "https://www.w3.org/StyleSheets/TR/2021/W3C-DNOTE",
+    group: "webapps",
   },
   {
-    status: "DRY",
+    specStatus: "DRY",
     expectedURL: "https://www.w3.org/StyleSheets/TR/2021/W3C-DRY",
+    group: "webapps",
   },
   {
-    status: "ED",
+    specStatus: "ED",
     expectedURL: "https://www.w3.org/StyleSheets/TR/2021/W3C-ED",
+    group: "webapps",
   },
   {
-    status: "LC",
-    expectedURL: "https://www.w3.org/StyleSheets/TR/2021/W3C-LC",
-  },
-  {
-    status: "Member-SUBM",
+    specStatus: "Member-SUBM",
     expectedURL: "https://www.w3.org/StyleSheets/TR/2021/W3C-Member-SUBM",
+    group: "webapps",
   },
   {
-    status: "NOTE",
+    specStatus: "NOTE",
     expectedURL: "https://www.w3.org/StyleSheets/TR/2021/W3C-NOTE",
+    group: "webapps",
   },
   {
-    status: "PER",
+    specStatus: "PER",
     expectedURL: "https://www.w3.org/StyleSheets/TR/2021/W3C-PER",
+    group: "webapps",
   },
   {
-    status: "PR",
+    specStatus: "PR",
     expectedURL: "https://www.w3.org/StyleSheets/TR/2021/W3C-PR",
+    group: "webapps",
   },
   {
-    status: "REC",
+    specStatus: "REC",
     expectedURL: "https://www.w3.org/StyleSheets/TR/2021/W3C-REC",
+    group: "webapps",
   },
   {
-    status: "RSCND",
+    specStatus: "RSCND",
     expectedURL: "https://www.w3.org/StyleSheets/TR/2021/W3C-RSCND",
+    group: "webapps",
   },
   {
-    status: "RY",
+    specStatus: "RY",
     expectedURL: "https://www.w3.org/StyleSheets/TR/2021/W3C-RY",
+    group: "webapps",
   },
   {
-    status: "STMT",
+    specStatus: "STMT",
     expectedURL: "https://www.w3.org/StyleSheets/TR/2021/W3C-STMT",
+    group: "webapps",
   },
   {
-    status: "Team-SUBM",
-    expectedURL: "https://www.w3.org/StyleSheets/TR/2021/W3C-Team-SUBM",
-  },
-  {
-    status: "UD",
+    specStatus: "UD",
     expectedURL: "https://www.w3.org/StyleSheets/TR/2021/W3C-UD",
   },
   {
-    status: "WD",
+    specStatus: "WD",
     expectedURL: "https://www.w3.org/StyleSheets/TR/2021/W3C-WD",
-  },
-  {
-    status: "WG-NOTE",
-    expectedURL: "https://www.w3.org/StyleSheets/TR/2021/W3C-WG-NOTE",
+    group: "webapps",
   },
 ];
-
-async function loadWithStatus(status, expectedURL) {
-  const ops = makeStandardOps({
-    specStatus: status,
-  });
-  const doc = await makeRSDoc(ops);
-  const query = `link[href^='${expectedURL}']`;
-  const elem = doc.querySelector(query);
-  expect(elem).withContext(specStatus).toBeTruthy();
-  expect(elem.href).withContext(specStatus).toBe(expectedURL);
-}
 
 describe("W3C - Style", () => {
   afterAll(flushIframes);
@@ -172,15 +181,25 @@ describe("W3C - Style", () => {
     expect(elem.content).toBe(expectedStr);
   });
 
-  it("should default to base when specStatus is missing", async () => {
-    await loadWithStatus("", "https://www.w3.org/StyleSheets/TR/2021/base.css");
-  });
-
-  specStatus.forEach(test => {
-    it(`should style according to spec status ${test.status}`, async () => {
-      await loadWithStatus(test.status, test.expectedURL);
-    });
-  });
+  it(
+    "styles according to specStatus and group",
+    async () => {
+      for (const { specStatus, expectedURL, group } of statuses) {
+        const conf = {
+          specStatus,
+          group,
+        };
+        const ops = makeStandardOps(conf);
+        const doc = await makeRSDoc(ops);
+        const query = `link[href^='${expectedURL}']`;
+        const elem = doc.querySelector(query);
+        const context = JSON.stringify(conf);
+        expect(elem).withContext(context).toBeTruthy();
+        expect(elem.href).withContext(context).toBe(expectedURL);
+      }
+    },
+    jasmine.DEFAULT_TIMEOUT_INTERVAL * 3
+  );
 
   it("shouldn't include fixup.js when noToc is set", async () => {
     const ops = makeStandardOps();

--- a/tests/spec/w3c/style-spec.js
+++ b/tests/spec/w3c/style-spec.js
@@ -181,25 +181,20 @@ describe("W3C - Style", () => {
     expect(elem.content).toBe(expectedStr);
   });
 
-  it(
-    "styles according to specStatus and group",
-    async () => {
-      for (const { specStatus, expectedURL, group } of statuses) {
-        const conf = {
-          specStatus,
-          group,
-        };
-        const ops = makeStandardOps(conf);
-        const doc = await makeRSDoc(ops);
-        const query = `link[href^='${expectedURL}']`;
-        const elem = doc.querySelector(query);
-        const context = JSON.stringify(conf);
-        expect(elem).withContext(context).toBeTruthy();
-        expect(elem.href).withContext(context).toBe(expectedURL);
-      }
-    },
-    jasmine.DEFAULT_TIMEOUT_INTERVAL * 3
-  );
+  for (const { specStatus, expectedURL, group } of statuses) {
+    it(`styles with specStatus: ${specStatus}; group: ${group}`, async () => {
+      const conf = {
+        specStatus,
+        group,
+      };
+      const ops = makeStandardOps(conf);
+      const doc = await makeRSDoc(ops);
+      const query = `link[href^='${expectedURL}']`;
+      const elem = doc.querySelector(query);
+      expect(elem).toBeTruthy();
+      expect(elem.href).toBe(expectedURL);
+    });
+  }
 
   it("shouldn't include fixup.js when noToc is set", async () => {
     const ops = makeStandardOps();


### PR DESCRIPTION
closes #3965

This prevents usage of W3C Rec Track status and W3C logo on documents that are not attached to a working group. 

The only exception is for "ED", which some groups sometimes use as "unofficial" before publishing. 

It means that everyone now needs to specify a `group` if they want to edit a Rec Track document. 
