### PR TITLE
test(core/validators-spec): make tests less racy

### DIFF
--- a/tests/spec/core/validators-spec.js
+++ b/tests/spec/core/validators-spec.js
@@ -1,12 +1,16 @@
+import { sub, unsub } from "../../../src/core/pubsubhub.js";
 import {
   validateCommonName,
   validateDOMName,
   validateMimeType,
   validateQuotedString,
 } from "../../../src/core/dfn-validators.js";
-import { sub } from "../../../src/core/pubsubhub.js";
 
 describe("Core - Validators", () => {
+  const handle = sub("error", () => {});
+  afterAll(() => {
+    unsub(handle);
+  });
   describe("validateDOMName", () => {
     it("doesn't generate an error if the element is valid", () => {
       const elements = [
@@ -31,7 +35,6 @@ describe("Core - Validators", () => {
     it("generates an error if the element name is not valid", () => {
       const elements = ["my element", "crypto$", "🪳", "-something", ""];
       for (const element of elements) {
-        sub("error", () => {}, { once: true });
         const dfn = document.createElement("dfn");
         const context = `element name: ${element}`;
         expect(validateDOMName(element, "element", dfn, "foo/bar"))
@@ -60,7 +63,6 @@ describe("Core - Validators", () => {
     it("generates an error if the attribute name is invalid", () => {
       const attributes = ["-crossorigin", "-whatever-", "aria-😇"];
       for (const attribute of attributes) {
-        sub("error", () => {}, { once: true });
         const context = `attribute name: ${attribute}`;
         const dfn = document.createElement("dfn");
         expect(validateDOMName(attribute, "attribute", dfn, "foo/bar"))
@@ -82,7 +84,6 @@ describe("Core - Validators", () => {
         "text/plain",
       ];
       for (const mimeType of mimeTypes) {
-        sub("error", () => {}, { once: true });
         const dfn = document.createElement("dfn");
         const context = `mimeType: ${mimeType}`;
         expect(validateMimeType(mimeType, "mimetype", dfn, "foo/bar"))
@@ -137,7 +138,6 @@ describe("Core - Validators", () => {
         "-something",
       ];
       for (const name of names) {
-        sub("error", () => {}, { once: true });
         const dfn = document.createElement("dfn");
         const context = `invalid name: ${name}`;
         expect(validateQuotedString(name, "permission", dfn, "foo/bar"))
@@ -154,7 +154,6 @@ describe("Core - Validators", () => {
     it("generates no error if the name is valid", () => {
       const names = ["foo", "bar", "baz", "quux"];
       for (const name of names) {
-        sub("error", () => {}, { once: true });
         const dfn = document.createElement("dfn");
         const context = `name: ${name}`;
         expect(validateCommonName(name, "event", dfn, "foo/bar"))
@@ -169,7 +168,6 @@ describe("Core - Validators", () => {
     it("it generates an error if the name is not valid", () => {
       const names = ["my event", "crypto$", "🪳", "-something"];
       for (const name of names) {
-        sub("error", () => {}, { once: true });
         const dfn = document.createElement("dfn");
         const context = `invalid name: ${name}`;
         expect(validateCommonName(name, "event", dfn, "foo/bar"))


### PR DESCRIPTION
This should hopefully fix the random validateMIME failures. 