### PR TITLE
chore: support development with pnpm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "respec",
       "version": "29.0.4",
       "license": "W3C",
       "dependencies": {
@@ -54,6 +55,7 @@
         "rollup-plugin-minify-html-literals": "^1.2.6",
         "rollup-plugin-terser": "^7.0.2",
         "serve": "^13.0.2",
+        "serve-handler": "^6.1.3",
         "sniffy-mimetype": "^1.1.1",
         "typescript": "^4.5.5",
         "vnu-jar": "^21.10.12",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "rollup-plugin-minify-html-literals": "^1.2.6",
     "rollup-plugin-terser": "^7.0.2",
     "serve": "^13.0.2",
+    "serve-handler": "^6.1.3",
     "sniffy-mimetype": "^1.1.1",
     "typescript": "^4.5.5",
     "vnu-jar": "^21.10.12",

--- a/tests/karma.conf.base.js
+++ b/tests/karma.conf.base.js
@@ -40,6 +40,14 @@ module.exports = config => {
   /** @type {import("karma").ConfigOptions} */
   const options = {
     basePath: path.join(__dirname, ".."),
+    plugins: [
+      require("karma-jasmine"),
+      require("karma-mocha-reporter"),
+      require("karma-jasmine-html-reporter"),
+      require("karma-chrome-launcher"),
+      require("karma-firefox-launcher"),
+      require("karma-safari-launcher"),
+    ],
     frameworks: ["jasmine"],
     files,
     exclude: ["**/*.swp", "*.swp", ".DS_Store"],


### PR DESCRIPTION
pnpm uses Node's resolve algorithm, so some packages failed to resolve (npm flattens dependency tree, so all resolved fine there).

This PR is allowing development with pnpm for those who want to use it. npm will continue to work fine. If someone wants to use pnpm locally, they can:
```bash
rm -rf node_modules
pnpm import # imports package-lock.json and creates a pnpm-lock.yaml
pnpm install
# and everything works fine as is
```

When updating a dependency in `package-lock.json`, we can:
```bash
npm i --package-lock-only # this will not touch node_modules
pnpm import && pnpm install
```