### PR TITLE
Adding German Translations for rfc2119Keywords

### DIFF
--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -42,13 +42,17 @@ const localizationStrings = {
     rfc2119Keywords() {
       return joinRegex([
         /\bMUSS\b/,
+        /\bMÜSSEN\b/,
         /\bERFORDERLICH\b/,
         /\b(?:NICHT\s+)?NÖTIG\b/,
         /\bDARF(?:\s+NICHT)?\b/,
+        /\bDÜRFEN(?:\s+NICHT)?\b/,
         /\bVERBOTEN\b/,
         /\bSOLL(?:\s+NICHT)?\b/,
+        /\bSOLLEN(?:\s+NICHT)?\b/,
         /\b(?:NICHT\s+)?EMPFOHLEN\b/,
         /\bKANN\b/,
+        /\bKÖNNEN\b/,
         /\bOPTIONAL\b/,
       ]);
     },


### PR DESCRIPTION
In German, the words KANN, SOLL and MUSS are different in plural, so I had to add them to the list.
I hope the umlaute are not a problem.