### PR TITLE
fix(core): render UI hints/error as inline markdown

### DIFF
--- a/src/core/import-maps.js
+++ b/src/core/import-maps.js
@@ -15,8 +15,7 @@ export const webidl2 = _webidl2;
 /** @type {import("hyperhtml").default} */
 // @ts-ignore
 export const html = hyperHTML;
-/** @type {import("marked")} */
-// @ts-ignore
+/** @typeof marked */
 export const marked = _marked;
 /** @type {import("pluralize")} */
 // @ts-ignore

--- a/src/core/markdown.js
+++ b/src/core/markdown.js
@@ -18,7 +18,6 @@ export const name = "core/markdown";
 
 const gtEntity = /&gt;/gm;
 const ampEntity = /&amp;/gm;
-
 class Renderer extends marked.Renderer {
   code(code, infoString, isEscaped) {
     const { language, ...metaData } = Renderer.parseInfoString(infoString);
@@ -71,24 +70,30 @@ class Renderer extends marked.Renderer {
   }
 }
 
+const config = {
+  sanitize: false,
+  gfm: true,
+  headerIds: false,
+  langPrefix: "",
+  renderer: new Renderer(),
+};
+
 /**
  * @param {string} text
+ * @param {object} options
+ * @param {boolean} options.inline
  */
-export function markdownToHtml(text) {
+export function markdownToHtml(text, options = { inline: false }) {
   const normalizedLeftPad = reindent(text);
   // As markdown is pulled from HTML, > and & are already escaped and
   // so blockquotes aren't picked up by the parser. This fixes it.
   const potentialMarkdown = normalizedLeftPad
     .replace(gtEntity, ">")
     .replace(ampEntity, "&");
-  // @ts-ignore
-  const result = marked(potentialMarkdown, {
-    sanitize: false,
-    gfm: true,
-    headerIds: false,
-    langPrefix: "",
-    renderer: new Renderer(),
-  });
+
+  const result = options.inline
+    ? marked.parseInline(potentialMarkdown, config)
+    : marked.parse(potentialMarkdown, config);
   return result;
 }
 

--- a/src/core/ui.js
+++ b/src/core/ui.js
@@ -267,7 +267,10 @@ function rsErrorToHTML(err) {
     ? `<p class="respec-plugin">(plugin: "${err.plugin}")</p>`
     : "";
   const hint = err.hint
-    ? `\n<p class="respec-hint"><strong>How to fix:</strong> ${err.hint}\n`
+    ? `\n<p class="respec-hint"><strong>How to fix:</strong> ${markdownToHtml(
+        err.hint,
+        { inline: true }
+      )}\n`
     : "";
   const elements = Array.isArray(err.elements)
     ? `<p class="respec-occurrences">Occurred <strong>${
@@ -279,8 +282,8 @@ function rsErrorToHTML(err) {
   const details = err.details
     ? `\n\n<details>\n${err.details}\n</details>\n`
     : "";
-
-  const text = `**${err.message}**${hint}${elements}${details}${plugin}`;
+  const msg = markdownToHtml(`**${err.message}**`, { inline: true });
+  const text = `${msg}${hint}${elements}${details}${plugin}`;
   return markdownToHtml(text);
 }
 


### PR DESCRIPTION
Markdown links inside hints stopped working... now fixed. 