### PR TITLE
chore(ci/push): don't fail if failed to PUT size

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -37,8 +37,9 @@ jobs:
           npx brrr builds/respec-w3c.js -o builds
           file_size=$(stat -c%s "builds/respec-w3c.js")
           xfer_file_size=$(stat -c%s "builds/respec-w3c.js.br")
-          curl --fail -L -X PUT "https://respec.org/respec/size" \
+          curl -L -X PUT "https://respec.org/respec/size" \
             -H "Authorization: $RESPEC_SECRET" \
+            -s -w "HTTP Response Code: %{http_code}\n" \
             -d "size=$file_size" -d "xferSize=$xfer_file_size "\
             -d "sha=$GITHUB_SHA" -d "timestamp=$timestamp"
         env:


### PR DESCRIPTION
Instead of exiting with error code, this will just print the status code. It'll still fail if server is down or if network fails etc.

This has been annoying as we couldn't re-run CI in case of intermittent failures. We can safely re-run CI on failure now.