### PR TITLE
fix(w3c/headers): always add History or FPWD

### DIFF
--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -735,7 +735,8 @@ async function deriveHistoryURI(conf) {
   );
 
   // If it's on the Rec Track or it's TR worthy, then allow history override.
-  if (conf.historyURI && canShowHistory) {
+  // Also make a an exception for FPWD.
+  if ((conf.historyURI && canShowHistory) || conf.specStatus === "FPWD") {
     conf.historyURI = historyURL.href;
     return;
   }

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -2505,6 +2505,23 @@ describe("W3C — Headers", () => {
       expect(historyLink.href).toBe("http://example.com/history");
     });
 
+    it("generates the history URL for FPWD without checking if it exists", async () => {
+      const ops = makeStandardOps({
+        shortName: "test",
+        specStatus: "FPWD",
+        group: "webapps",
+      });
+      const doc = await makeRSDoc(ops);
+      const [history] = contains(doc, ".head dt", "History:");
+      expect(history).toBeTruthy();
+      expect(history.nextElementSibling).toBeTruthy();
+      const historyLink = history.nextElementSibling.querySelector("a");
+      expect(historyLink).toBeTruthy();
+      expect(historyLink.href).toBe(
+        "https://www.w3.org/standards/history/test"
+      );
+    });
+
     it("allowing removing the history entirely by nulling it out", async () => {
       const ops = makeStandardOps({
         shortName: "test",


### PR DESCRIPTION
closes #4043