### PR TITLE
fix(w3c/headers): remove doubled "in" in German translation

### DIFF
--- a/src/w3c/templates/headers.js
+++ b/src/w3c/templates/headers.js
@@ -154,7 +154,7 @@ const localizationStrings = {
       return `Dieses Dokument ist ebenfalls in ${
         plural
           ? "diesen nicht-normativen Formaten verfügbar"
-          : "in diesem nicht-normativen Format verfügbar"
+          : "diesem nicht-normativen Format verfügbar"
       }:`;
     },
     prev_editor_draft: "Vorheriger Entwurf:",


### PR DESCRIPTION
Sorry, I missed this before.