### PR TITLE
fix(w3c/headers): W3CNotes are /TR/ docs

### DIFF
--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -177,15 +177,16 @@ export const status2track = {
 };
 export const W3CNotes = ["DNOTE", "NOTE", "STMT"];
 export const recTrackStatus = [
-  "FPWD",
-  "WD",
   "CR",
   "CRD",
-  "PR",
-  "PER",
-  "REC",
   "DISC",
+  "FPWD",
+  "PER",
+  "PR",
+  "REC",
   "RSCND",
+  "WD",
+  ...W3CNotes,
 ];
 export const registryTrackStatus = ["DRY", "CRY", "CRYD", "RY"];
 export const tagStatus = ["draft-finding", "finding", "editor-draft-finding"];

--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -186,7 +186,6 @@ export const recTrackStatus = [
   "REC",
   "RSCND",
   "WD",
-  ...W3CNotes,
 ];
 export const registryTrackStatus = ["DRY", "CRY", "CRYD", "RY"];
 export const tagStatus = ["draft-finding", "finding", "editor-draft-finding"];
@@ -389,7 +388,7 @@ export async function run(conf) {
     const { shortName, publishDate } = conf;
     const date = concatDate(publishDate);
     const docVersion = `${maturity}-${shortName}-${date}`;
-    const year = [...recTrackStatus, "Member-SUBM"].includes(conf.specStatus)
+    const year = [...trStatus, "Member-SUBM"].includes(conf.specStatus)
       ? `${publishDate.getUTCFullYear()}/`
       : "";
     conf.thisVersion = w3Url(`${pubSpace}/${year}${docVersion}/`);

--- a/src/w3c/linter-rules/required-sections.js
+++ b/src/w3c/linter-rules/required-sections.js
@@ -14,8 +14,8 @@ import {
   showError,
   showWarning,
 } from "../../core/utils.js";
+import { W3CNotes, recTrackStatus } from "../headers.js";
 import { lang } from "../../core/l10n.js";
-import { recTrackStatus, W3CNotes } from "../headers.js";
 
 const ruleName = "required-sections";
 export const name = "w3c/linter-rules/required-sections";

--- a/src/w3c/linter-rules/required-sections.js
+++ b/src/w3c/linter-rules/required-sections.js
@@ -15,7 +15,7 @@ import {
   showWarning,
 } from "../../core/utils.js";
 import { lang } from "../../core/l10n.js";
-import { recTrackStatus } from "../headers.js";
+import { recTrackStatus, W3CNotes } from "../headers.js";
 
 const ruleName = "required-sections";
 export const name = "w3c/linter-rules/required-sections";
@@ -50,6 +50,8 @@ const l10n = getIntlData(localizationStrings);
 
 export const requiresSomeSectionStatus = new Set([...recTrackStatus]);
 requiresSomeSectionStatus.delete("DISC"); // "Discontinued Draft"
+// W3C notes do not require privacy or security considerations sections.
+W3CNotes.forEach(note => requiresSomeSectionStatus.delete(note));
 
 export function run(conf) {
   if (!conf.lint?.[ruleName]) {

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -5,7 +5,7 @@ import {
   cgbgStatus,
   licenses,
   noTrackStatus,
-  recTrackStatus,
+  trStatus,
 } from "../../../src/w3c/headers.js";
 
 import {
@@ -1380,7 +1380,7 @@ describe("W3C — Headers", () => {
   });
 
   describe("thisVersion", () => {
-    for (let specStatus of recTrackStatus) {
+    for (let specStatus of trStatus) {
       it(`computes thisVersion for correctly for TR doc with status "${specStatus}"`, async () => {
         const ops = makeStandardOps({
           specStatus,
@@ -2572,8 +2572,8 @@ describe("W3C — Headers", () => {
       );
     });
 
-    it("includes the history for all rec-track status docs", async () => {
-      for (const specStatus of recTrackStatus) {
+    for (const specStatus of trStatus) {
+      it(`includes the history for "${specStatus}" rec-track status`, async () => {
         const shortName = `push-api`;
         const ops = makeStandardOps({
           shortName,
@@ -2585,12 +2585,12 @@ describe("W3C — Headers", () => {
         expect(history).withContext(specStatus).toBeTruthy();
         expect(history.nextElementSibling).withContext(specStatus).toBeTruthy();
         const historyLink = history.nextElementSibling.querySelector("a");
-        expect(historyLink).withContext(specStatus).toBeTruthy();
-        expect(historyLink.href)
-          .withContext(specStatus)
-          .toBe(`https://www.w3.org/standards/history/${shortName}`);
-      }
-    });
+        expect(historyLink).toBeTruthy();
+        expect(historyLink.href).toBe(
+          `https://www.w3.org/standards/history/${shortName}`
+        );
+      });
+    }
   });
 
   describe("Add Preview Status in title", () => {

--- a/tests/spec/w3c/linter-rules/required-sections-spec.js
+++ b/tests/spec/w3c/linter-rules/required-sections-spec.js
@@ -1,5 +1,6 @@
 "use strict";
 
+import { W3CNotes, noTrackStatus } from "../../../../src/w3c/headers.js";
 import {
   errorFilters,
   flushIframes,
@@ -7,7 +8,6 @@ import {
   makeStandardOps,
   warningFilters,
 } from "../../SpecHelper.js";
-import { noTrackStatus } from "../../../../src/w3c/headers.js";
 import { requiresSomeSectionStatus } from "../../../../src/w3c/linter-rules/required-sections.js";
 
 describe("w3c — required-sections", () => {
@@ -61,8 +61,8 @@ describe("w3c — required-sections", () => {
     expect(warnings).toHaveSize(2);
   });
 
-  it("doesn't lint non-rec-track docs", async () => {
-    for (const specStatus of [...noTrackStatus, "ED"]) {
+  for (const specStatus of [...noTrackStatus, "ED"]) {
+    it(`doesn't lint non-rec-track docs with status ${specStatus}`, async () => {
       const ops = makeStandardOps({
         lint: { "required-sections": true },
         specStatus,
@@ -71,10 +71,10 @@ describe("w3c — required-sections", () => {
       const doc = await makeRSDoc(ops);
       const errors = errorsFilter(doc);
       const warnings = warningsFilter(doc);
-      expect(errors).withContext(specStatus).toHaveSize(0);
-      expect(warnings).withContext(specStatus).toHaveSize(0);
-    }
-  });
+      expect(errors).toHaveSize(0);
+      expect(warnings).toHaveSize(0);
+    });
+  }
 
   it("doesn't lint for when explicitly marked as noRecTrack", async () => {
     const ops = makeStandardOps({
@@ -90,8 +90,8 @@ describe("w3c — required-sections", () => {
     expect(warnings).toHaveSize(0);
   });
 
-  it("generates warning by default when its a rec track document and both privacy and security sections are missing", async () => {
-    for (const specStatus of requiresSomeSectionStatus) {
+  for (const specStatus of requiresSomeSectionStatus) {
+    it(`generates warning by default when it's a rec track document "${specStatus}" and both privacy and security sections are missing`, async () => {
       const ops = makeStandardOps({
         lint: { "required-sections": true },
         specStatus,
@@ -100,10 +100,10 @@ describe("w3c — required-sections", () => {
       const doc = await makeRSDoc(ops);
       const errors = errorsFilter(doc);
       const warnings = warningsFilter(doc);
-      expect(errors).withContext(specStatus).toHaveSize(0);
-      expect(warnings).withContext(specStatus).toHaveSize(2);
-    }
-  });
+      expect(errors).toHaveSize(0);
+      expect(warnings).toHaveSize(2);
+    });
+  }
 
   it("generates an error if privacy section if present, but security is missing", async () => {
     const body = `
@@ -211,4 +211,19 @@ describe("w3c — required-sections", () => {
     const warnings = warningsFilter(doc);
     expect(warnings).toHaveSize(0);
   });
+
+  for (const specStatus of W3CNotes) {
+    it(`doesn't generate a warning if the privacy and security sections are missing from W3C Notes of status ${specStatus}`, async () => {
+      const ops = makeStandardOps({
+        lint: { "required-sections": true },
+        specStatus,
+        group: "webapps",
+      });
+      const doc = await makeRSDoc(ops);
+      const errors = errorsFilter(doc);
+      const warnings = warningsFilter(doc);
+      expect(errors).toHaveSize(0);
+      expect(warnings).toHaveSize(0);
+    });
+  }
 });


### PR DESCRIPTION
Also notes don't need a privacy and security considerations section. Only "specs" do.  

fixes #4064 