### PR TITLE
hotfix(core/inline-idl-parser): use WebIDL in lowercase

### DIFF
--- a/src/core/inline-idl-parser.js
+++ b/src/core/inline-idl-parser.js
@@ -282,7 +282,7 @@ function renderException(details) {
   const { identifier } = details;
   const element = html`"<a
       data-link-type="idl"
-      data-cite="WebIDL"
+      data-cite="webidl"
       data-xref-type="exception"
       ><code>${identifier}</code></a
     >"`;
@@ -298,7 +298,7 @@ function renderIdlPrimitiveType(details) {
   const { identifier, nullable } = details;
   const element = html`<a
     data-link-type="idl"
-    data-cite="WebIDL"
+    data-cite="webidl"
     data-xref-type="interface"
     data-lt="${identifier}"
     ><code>${identifier + (nullable ? "?" : "")}</code></a


### PR DESCRIPTION
Otherwise, respec complains about unknown 'WebIDL' reference

See https://w3c.github.io/mediacapture-region/ where this manifests itself (cf https://github.com/w3c/mediacapture-region/pull/39#pullrequestreview-928481678)