### PR TITLE
fix(w3c): allow trStatus specStatus for TAG

### DIFF
--- a/src/w3c/defaults.js
+++ b/src/w3c/defaults.js
@@ -103,7 +103,7 @@ function processLogos(conf) {
 }
 
 function validateStatusForGroup(conf) {
-  const { specStatus, groupType } = conf;
+  const { specStatus, groupType, group } = conf;
 
   if (!specStatus) {
     const msg = docLink`The ${"[specStatus]"} configuration option is required.`;
@@ -152,6 +152,18 @@ function validateStatusForGroup(conf) {
       break;
     }
     case "other":
+      if (
+        group === "tag" &&
+        ![...trStatus, ...tagStatus].includes(specStatus)
+      ) {
+        const msg = docLink`The W3C Technical Architecture Group's documents can't use \`"${specStatus}"\` for the ${"[specStatus]"} configuration option.`;
+        const supportedStatus = codedJoinOr([...trStatus, ...tagStatus], {
+          quotes: true,
+        });
+        const hint = `Please use one of: ${supportedStatus}. Automatically falling back to \`"unofficial"\`.`;
+        showError(msg, name, { hint });
+        conf.specStatus = "unofficial";
+      }
       break;
     default:
       if (

--- a/src/w3c/defaults.js
+++ b/src/w3c/defaults.js
@@ -103,7 +103,7 @@ function processLogos(conf) {
 }
 
 function validateStatusForGroup(conf) {
-  const { specStatus, groupType, group } = conf;
+  const { specStatus, groupType } = conf;
 
   if (!specStatus) {
     const msg = docLink`The ${"[specStatus]"} configuration option is required.`;

--- a/src/w3c/defaults.js
+++ b/src/w3c/defaults.js
@@ -152,13 +152,6 @@ function validateStatusForGroup(conf) {
       break;
     }
     case "other":
-      if (group === "tag" && !tagStatus.includes(specStatus)) {
-        const msg = docLink`The W3C Technical Architecture Group's documents can't use \`"${specStatus}"\` for the ${"[specStatus]"} configuration option.`;
-        const supportedStatus = codedJoinOr(tagStatus, { quotes: true });
-        const hint = `Please use one of: ${supportedStatus}. Automatically falling back to \`"unofficial"\`.`;
-        showError(msg, name, { hint });
-        conf.specStatus = "unofficial";
-      }
       break;
     default:
       if (


### PR DESCRIPTION
The TAG can now publish in TR, and intends to do so relatively regularly. This PR removes the restriction. This is blocking publication of an FPWD.