### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -5,8 +5,14 @@ on:
     branches:
       - gh-pages
 
+permissions:
+  contents: read
+
 jobs:
   changelog:
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
     name: Update Changelog
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,6 +16,9 @@ env:
   LC_ALL: en_US.UTF-8
   FORCE_COLOR: 1
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Check linting issues

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,6 +18,9 @@ env:
   # See https://github.com/w3c/respec/pull/3306
   LC_ALL: en_US.UTF-8
 
+permissions:
+  contents: read
+
 jobs:
   test-headless:
     name: Headless Tests


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
