### PR TITLE
fix(w3c/headers): TR pub space applies to all TR statuses

### DIFF
--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -679,7 +679,7 @@ function validateIfAllowedOnTR(conf) {
 
 function derivePubSpace(conf) {
   const { specStatus, group } = conf;
-  if (recTrackStatus.includes(specStatus) || conf.groupType === "wg") {
+  if (trStatus.includes(specStatus) || conf.groupType === "wg") {
     return `/TR`;
   }
 


### PR DESCRIPTION
The "This version" link is not generated properly for a Note produced by the TAG because the publication space only takes the documents on REC track into account.
That PR includes the other types of documents for /TR.