### PR TITLE
fix(core/mdn-annotation): use logos from cdn.w3.org

### DIFF
--- a/src/core/mdn-annotation.js
+++ b/src/core/mdn-annotation.js
@@ -17,7 +17,6 @@ const MDN_BROWSERS = {
   edge_mobile: "Edge Mobile",
   firefox: "Firefox",
   firefox_android: "Firefox Android",
-  ie: "Internet Explorer",
   // nodejs: "Node.js", // no data for features in HTML
   opera: "Opera",
   opera_android: "Opera Android",

--- a/src/styles/mdn-annotation.css.js
+++ b/src/styles/mdn-annotation.css.js
@@ -102,41 +102,37 @@ export default css`
 
 .mdn .chrome::before,
 .mdn .chrome_android::before {
-  background-image: url(https://resources.whatwg.org/browser-logos/chrome.svg);
+  background-image: url(https://cdn.w3.org/assets/logos/browser-logos/chrome/chrome.svg);
 }
 
 .mdn .edge::before,
 .mdn .edge_mobile::before {
-  background-image: url(https://resources.whatwg.org/browser-logos/edge.svg);
+  background-image: url(https://cdn.w3.org/assets/logos/browser-logos/edge/edge.svg);
 }
 
 .mdn .firefox::before,
 .mdn .firefox_android::before {
-  background-image: url(https://resources.whatwg.org/browser-logos/firefox.png);
-}
-
-.mdn .ie::before {
-  background-image: url(https://resources.whatwg.org/browser-logos/ie.png);
+  background-image: url(https://cdn.w3.org/assets/logos/browser-logos/firefox/firefox.svg);
 }
 
 .mdn .opera::before,
 .mdn .opera_android::before {
-  background-image: url(https://resources.whatwg.org/browser-logos/opera.svg);
+  background-image: url(https://cdn.w3.org/assets/logos/browser-logos/opera/opera.svg);
 }
 
 .mdn .safari::before {
-  background-image: url(https://resources.whatwg.org/browser-logos/safari.png);
+  background-image: url(https://cdn.w3.org/assets/logos/browser-logos/safari/safari.svgg);
 }
 
 .mdn .safari_ios::before {
-  background-image: url(https://resources.whatwg.org/browser-logos/safari-ios.svg);
+  background-image: url(https://cdn.w3.org/assets/logos/browser-logos/safari-ios/safari-ios.svg);
 }
 
 .mdn .samsunginternet_android::before {
-  background-image: url(https://resources.whatwg.org/browser-logos/samsung.svg);
+  background-image: url(https://cdn.w3.org/assets/logos/browser-logos/samsung-internet/samsung-internet.svg);
 }
 
 .mdn .webview_android::before {
-  background-image: url(https://resources.whatwg.org/browser-logos/android-webview.png);
+  background-image: url(https://cdn.w3.org/assets/logos/browser-logos/android-webview/android-webview.png);
 }
 `;

--- a/src/styles/mdn-annotation.css.js
+++ b/src/styles/mdn-annotation.css.js
@@ -121,7 +121,7 @@ export default css`
 }
 
 .mdn .safari::before {
-  background-image: url(https://cdn.w3.org/assets/logos/browser-logos/safari/safari.svgg);
+  background-image: url(https://cdn.w3.org/assets/logos/browser-logos/safari/safari.svg);
 }
 
 .mdn .safari_ios::before {


### PR DESCRIPTION
Closes https://github.com/w3c/respec/issues/4109

and remove IE 🎉 

---
`issueCount--`