### PR TITLE
fix(styles/respec): don't give different color to `<code>`

### DIFF
--- a/src/styles/respec.css.js
+++ b/src/styles/respec.css.js
@@ -70,14 +70,6 @@ cite .bibref {
   font-style: normal;
 }
 
-code {
-  color: #c63501;
-}
-
-th code {
-  color: inherit;
-}
-
 a[href].orcid {
   padding-left: 4px;
   padding-right: 4px;


### PR DESCRIPTION
Fixes #4163
Matches examples on tr-design, as well as Bikeshed. Monospace font is enough to distinguish code from rest of the content, different color is indeed distracting.