### PR TITLE
fix(core/issues-notes): ignore svg descendents from processing

### DIFF
--- a/src/core/issues-notes.js
+++ b/src/core/issues-notes.js
@@ -94,7 +94,7 @@ const l10n = getIntlData(localizationStrings);
  * @property {string} bodyHTML
  * @property {GitHubLabel[]} labels
 
- * @param {NodeListOf<HTMLElement>} ins
+ * @param {HTMLElement[]} ins
  * @param {Map<string, GitHubIssue>} ghIssues
  * @param {*} conf
  */
@@ -371,9 +371,8 @@ export async function run(conf) {
   const allEls = document.querySelectorAll(query);
 
   const issuesAndNotes = Array.from(allEls).filter(itm => {
-    // Ignores any elements that were selected that is an ancestor of the
-    // <svg> element.
-    return !itm.closest("svg");
+    // Removes any elements that are not HTML Elements (e.g., SVG nodes)
+    return itm instanceof HTMLElement;
   });
 
   if (!issuesAndNotes.length) {

--- a/src/core/issues-notes.js
+++ b/src/core/issues-notes.js
@@ -368,7 +368,14 @@ async function fetchAndStoreGithubIssues(github) {
 export async function run(conf) {
   const query = ".issue, .note, .warning, .ednote";
   /** @type {NodeListOf<HTMLElement>} */
-  const issuesAndNotes = document.querySelectorAll(query);
+  const allEls = document.querySelectorAll(query);
+
+  const issuesAndNotes = Array.from(allEls).filter(itm => {
+    // Ignores any elements that were selected that is an ancestor of the
+    // <svg> element.
+    return !itm.closest("svg");
+  });
+
   if (!issuesAndNotes.length) {
     return; // nothing to do.
   }

--- a/tests/spec/core/issues-notes-spec.js
+++ b/tests/spec/core/issues-notes-spec.js
@@ -420,4 +420,22 @@ describe("Core — Issues and Notes", () => {
     const h3 = doc.querySelector("#issue-summary section h3");
     expect(h3.innerText).toContain("This is not the heading of issue-summary");
   });
+  it("should not produce HTML embedded within SVG", async () => {
+    const ops = {
+      config: makeBasicConfig(),
+      body: `
+      <p class="note">This is a note that should be selected</p>
+      <svg version="1.1"
+           width="300" height="200"
+           xmlns="http://www.w3.org/2000/svg">
+        <!-- this element should not be selected even with the "note" class -->
+        <rect width="100%" height="100%" fill="red" class="note" />
+      </svg>`,
+    };
+
+    const doc = await makeRSDoc(ops);
+    // <div> is not a valid child of <svg>, so if it appears there it means ReSpec has added it.
+    const svgNote = doc.querySelector("svg div");
+    expect(svgNote).toBeNull();
+  });
 });


### PR DESCRIPTION
This changes the behaviour of the issues and notes selector to ignore any elements that have an SVG element as an ancestor. It does this by filtering the selected elements and looking to see if the `.closest` method returns null; if it is null, it means that the element is not within an SVG block; if it is not null, it is filtered out of the list of elements for further processing.

A simple unit test is included that checks to see if there are any `<div>` elements that are within an `<svg>` element (`<div>` is not a valid child of `<svg>`). If the selector is null it means the test passed.

Fixes #4238.