### PR TITLE
fix(core/utils:`getIntlData`): match language subtag too

### DIFF
--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -174,37 +174,38 @@ export function norm(str) {
 }
 
 /**
- * @param {string} lang
- */
-export function resolveLanguageAlias(lang) {
-  const lCaseLang = lang.toLowerCase();
-  const aliases = {
-    "zh-hans": "zh",
-    "zh-cn": "zh",
-  };
-  return aliases[lCaseLang] || lCaseLang;
-}
-
-/**
  * @template {Record<string, Record<string, string|Function>>} T
  * @param {T} localizationStrings
  * @returns {T[keyof T]}
  */
 export function getIntlData(localizationStrings, lang = docLang) {
-  lang = resolveLanguageAlias(lang);
+  lang = lang.toLowerCase();
   // Proxy return type is a known bug:
   // https://github.com/Microsoft/TypeScript/issues/20846
-  // @ts-ignore
+  // @ts-expect-error
   return new Proxy(localizationStrings, {
     /** @param {string} key */
     get(data, key) {
-      const result = (data[lang] && data[lang][key]) || data.en[key];
+      const result = getIntlDataForKey(data, key, lang) || data.en[key];
       if (!result) {
         throw new Error(`No l10n data for key: "${key}"`);
       }
       return result;
     },
   });
+}
+
+/**
+ * @template {Record<string, Record<string, string|Function>>} T
+ * @param {T} localizationStrings
+ * @param {string} key
+ */
+export function getIntlDataForKey(localizationStrings, key, lang = docLang) {
+  lang = lang.toLowerCase();
+  return (
+    localizationStrings[lang]?.[key] ||
+    localizationStrings[lang.split("-", 2)[0]]?.[key]
+  );
 }
 
 // --- DATE HELPERS -------------------------------------------------------------------------------

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -204,7 +204,7 @@ export function getIntlDataForKey(localizationStrings, key, lang = docLang) {
   lang = lang.toLowerCase();
   return (
     localizationStrings[lang]?.[key] ||
-    localizationStrings[lang.split("-", 2)[0]]?.[key]
+    localizationStrings[lang.match(/^(\w{2,3})-.+$/)?.[1]]?.[key]
   );
 }
 

--- a/src/w3c/linter-rules/required-sections.js
+++ b/src/w3c/linter-rules/required-sections.js
@@ -9,13 +9,12 @@ import {
   InsensitiveStringSet,
   docLink,
   getIntlData,
+  getIntlDataForKey,
   norm,
-  resolveLanguageAlias,
   showError,
   showWarning,
 } from "../../core/utils.js";
 import { W3CNotes, recTrackStatus } from "../headers.js";
-import { lang } from "../../core/l10n.js";
 
 const ruleName = "required-sections";
 export const name = "w3c/linter-rules/required-sections";
@@ -59,8 +58,10 @@ export function run(conf) {
   }
 
   // We can't check for headers unless we also have a translation
-  if (!localizationStrings[resolveLanguageAlias(lang)]) {
-    console.warn(`Missing localization strings for ${lang}.`);
+  if (!getIntlDataForKey(localizationStrings, "privacy_considerations")) {
+    const msg = `Cannot check for required sections as translations are not available.`;
+    const hint = `File an issue to add translations or use a supported language.`;
+    showWarning(msg, name, { hint });
     return;
   }
 

--- a/src/w3c/linter-rules/required-sections.js
+++ b/src/w3c/linter-rules/required-sections.js
@@ -59,6 +59,7 @@ export function run(conf) {
 
   // We can't check for headers unless we also have a translation
   if (!getIntlDataForKey(localizationStrings, "privacy_considerations")) {
+    // We can't check for headers unless we also have a translation
     const msg = `Cannot check for required sections as translations are not available.`;
     const hint = `File an issue to add translations or use a supported language.`;
     showWarning(msg, name, { hint });

--- a/tests/spec/core/utils-spec.js
+++ b/tests/spec/core/utils-spec.js
@@ -279,6 +279,7 @@ describe("Core - Utils", () => {
     const localizationStrings = {
       en: { foo: "EN Foo", bar: "EN Bar" },
       ko: { foo: "KO Foo" },
+      "en-us": { foo: "EN-US Foo" },
     };
 
     it("returns localized string in given language", () => {
@@ -287,6 +288,9 @@ describe("Core - Utils", () => {
 
       const intlEn = getIntlData(localizationStrings, "EN");
       expect(intlEn.foo).toBe("EN Foo");
+
+      const intlEnUs = getIntlData(localizationStrings, "en-US");
+      expect(intlEnUs.foo).toBe(localizationStrings["en-us"].foo);
     });
 
     it("falls back to English string if key does not exist in language", () => {
@@ -299,9 +303,42 @@ describe("Core - Utils", () => {
       expect(intl.bar).toBe("EN Bar");
     });
 
+    it("falls back to primary language subtag", () => {
+      const intl = getIntlData(localizationStrings, "en-US");
+      expect(intl.bar).toBe(localizationStrings.en.bar);
+      expect(() => intl.baz).toThrowError(/No l10n data for key/);
+    });
+
     it("throws error if key doesn't exist in either doc lang and English", () => {
       const intl = getIntlData(localizationStrings, "de");
       expect(() => intl.baz).toThrowError(/No l10n data for key/);
+    });
+  });
+
+  describe("getIntlDataForKey", () => {
+    const { getIntlDataForKey } = utils;
+    const localizationStrings = {
+      en: { foo: "EN Foo", bar: "EN Bar" },
+      zh: { foo: "KO Foo" },
+      "zh-hans": { foo: "EN-US Foo" },
+    };
+    const get = (key, lang) =>
+      getIntlDataForKey(localizationStrings, key, lang);
+
+    it("uses lang or subtag only; never falls back to `en`", () => {
+      expect(get("foo", "zh-hans")).toBe(localizationStrings["zh-hans"].foo);
+      expect(get("foo", "zh")).toBe(localizationStrings.zh.foo);
+
+      expect(get("bar", "zh-hans")).toBe(localizationStrings.zh.bar);
+      expect(get("bar", "zh")).toBe(localizationStrings.zh.bar);
+
+      expect(get("baz", "zh-hans")).toBeUndefined();
+      expect(get("baz", "zh")).toBeUndefined();
+
+      expect(get("foo", "en-US")).toBe(localizationStrings.en.foo);
+      expect(get("baz", "en-US")).toBeUndefined();
+
+      expect(get("foo", "ko")).toBeUndefined();
     });
   });
 

--- a/tests/spec/w3c/linter-rules/required-sections-spec.js
+++ b/tests/spec/w3c/linter-rules/required-sections-spec.js
@@ -209,7 +209,8 @@ describe("w3c — required-sections", () => {
     const errors = errorsFilter(doc);
     expect(errors).toHaveSize(0);
     const warnings = warningsFilter(doc);
-    expect(warnings).toHaveSize(0);
+    expect(warnings).toHaveSize(1);
+    expect(warnings[0]).toMatch(/translations are not available/);
   });
 
   for (const specStatus of W3CNotes) {


### PR DESCRIPTION
Fixes https://github.com/w3c/respec/issues/4156

A full BCP 47 checker might be too much here.

Also add `getIntlDataForKey` util to test for translation availability.