### PR TITLE
fix(w3c/headers): fix broken link

### DIFF
--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -457,7 +457,7 @@ export async function run(conf) {
       const msg = docLink`Editor ${
         editor.name ? `"${editor.name}"` : `number ${i + 1}`
       } is missing their ${"[w3cid]"}.`;
-      const hint = docLink`See ${"[`w3cid`]"} for instructions for how to retrieve it and add it.`;
+      const hint = docLink`See ${"[w3cid]"} for instructions for how to retrieve it and add it.`;
       showError(msg, name, { hint });
     });
   }


### PR DESCRIPTION
Currently, it links to https://respec.org/docs/#%60w3cid%60 , which has a broken URI fragment. This PR tries to fix the issue.