### PR TITLE
fix(w3c/sotd): remove spaces in Chinese

### DIFF
--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -21,9 +21,8 @@ const localizationStrings = {
   },
   zh: {
     sotd: "关于本文档",
-    status_at_publication: html`本章节描述了本文档的发布状态。W3C的文档列
-      表和最新版本可通过<a href="https://www.w3.org/TR/">W3C技术报告</a
-      >索引访问。`,
+    // eslint-disable-next-line prettier/prettier
+    status_at_publication: html`本章节描述了本文档的发布状态。W3C的文档列表和最新版本可通过<a href="https://www.w3.org/TR/">W3C技术报告</a>索引访问。`,
   },
   ja: {
     sotd: "この文書の位置付け",


### PR DESCRIPTION
In languages that have no word separators, such as Chinese, the CSS [segment break transformation rules](https://www.w3.org/TR/css-text/#line-break-transform) can transform the segment break into a space, which might make the reader uncomfortable.

I also let ESLint and Prettier ignore this line, lest they think it's too long.