### PR TITLE
fix(core/dfn): add support for defining `element-attr` dfns

### DIFF
--- a/src/core/dfn-validators.js
+++ b/src/core/dfn-validators.js
@@ -24,12 +24,12 @@ export function validateMimeType(text, type, elem, pluginName) {
 
 /**
  * Validates the names of DOM attribute and elements.
- * @param {"attribute" | "element"} type
+ * @param {"element-attr" | "element"} type
  * @type {DefinitionValidator} */
 export function validateDOMName(text, type, elem, pluginName) {
   try {
     switch (type) {
-      case "attribute":
+      case "element-attr":
         document.createAttribute(text);
         return true;
       case "element":

--- a/src/core/dfn.js
+++ b/src/core/dfn.js
@@ -45,7 +45,7 @@ const knownTypesMap = new Map([
     "element-state",
     {
       requiresFor: true,
-      associateWith: "an markup attribute",
+      associateWith: "a markup attribute",
       validator: validateCommonName,
     },
   ],

--- a/src/core/dfn.js
+++ b/src/core/dfn.js
@@ -25,21 +25,27 @@ export const name = "core/dfn";
 /** @type {Map<string, { requiresFor: boolean, validator?: DefinitionValidator, associateWith?: string}>}  */
 const knownTypesMap = new Map([
   ["abstract-op", { requiresFor: false }],
-  ["attribute", { requiresFor: false, validator: validateDOMName }],
   [
     "attr-value",
     {
       requiresFor: true,
-      associateWith: "an HTML attribute",
+      associateWith: "a markup attribute",
       validator: validateCommonName,
     },
   ],
   ["element", { requiresFor: false, validator: validateDOMName }],
   [
+    "element-attr",
+    {
+      requiresFor: false,
+      validator: validateDOMName,
+    },
+  ],
+  [
     "element-state",
     {
       requiresFor: true,
-      associateWith: "an HTML attribute",
+      associateWith: "an markup attribute",
       validator: validateCommonName,
     },
   ],

--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -98,7 +98,11 @@ function inlineElementMatches(matched) {
     }
   })();
   return html`<code
-    ><a data-xref-type="${xrefType}" data-xref-for="${xrefFor}"
+    ><a
+      data-xref-type="${xrefType}"
+      data-xref-for="${xrefFor}"
+      data-link-type="${xrefType}"
+      data-link-for="${xrefFor}"
       >${textContent}</a
     ></code
   >`;

--- a/tests/spec/core/dfn-spec.js
+++ b/tests/spec/core/dfn-spec.js
@@ -405,10 +405,10 @@ describe("Core — Definitions", () => {
         <section>
           <h2>Attributes</h2>
           <p id="attributes">
-            <dfn class="attribute">some-attribute</dfn>
+            <dfn class="element-attr">some-attribute</dfn>
           </p>
           <p id="attribute-bad">
-            <dfn class="attribute">-attribute</dfn>
+            <dfn class="element-attr">-attribute</dfn>
           </p>
         </section>
       `;

--- a/tests/spec/core/dfn-spec.js
+++ b/tests/spec/core/dfn-spec.js
@@ -415,7 +415,7 @@ describe("Core — Definitions", () => {
       const ops = makeStandardOps(null, body);
       const doc = await makeRSDoc(ops);
       const dfn = doc.querySelector("#attributes dfn");
-      expect(dfn.dataset.dfnType).toBe("attribute");
+      expect(dfn.dataset.dfnType).toBe("element-attr");
       expect(dfn.dataset.export).toBe("");
 
       // Check validation error

--- a/tests/spec/core/validators-spec.js
+++ b/tests/spec/core/validators-spec.js
@@ -46,7 +46,7 @@ describe("Core - Validators", () => {
       for (const attribute of attributes) {
         const context = `attribute name: ${attribute}`;
         const dfn = document.createElement("dfn");
-        expect(validateDOMName(attribute, "attribute", dfn, "foo/bar"))
+        expect(validateDOMName(attribute, "element-attr", dfn, "foo/bar"))
           .withContext(context)
           .toBeTrue();
         expect(dfn.classList.contains("respec-offending-element"))
@@ -60,7 +60,7 @@ describe("Core - Validators", () => {
       for (const attribute of attributes) {
         const context = `attribute name: ${attribute}`;
         const dfn = document.createElement("dfn");
-        expect(validateDOMName(attribute, "attribute", dfn, "foo/bar"))
+        expect(validateDOMName(attribute, "element-attr", dfn, "foo/bar"))
           .withContext(context)
           .toBeFalse();
         expect(dfn.classList.contains("respec-offending-element"))


### PR DESCRIPTION
The code mistakenly used 'attribute' instead of 'element-attr'. It also didn't support linking to attributes defined inline in the spec.