### PR TITLE
feat(core/link-to-dfn): support multiple `dfnFor`

### DIFF
--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -121,7 +121,7 @@ function collectDfns(title) {
   const duplicates = [];
   for (const dfn of definitionMap.get(title)) {
     const { dfnType = "dfn" } = dfn.dataset;
-    for (const dfnFor of dfn.dataset.dfnFor?.split(",")) {
+    for (const dfnFor of dfn.dataset.dfnFor?.split(",").map(s => s.trim())) {
       // check for potential duplicate definition
       if (result.has(dfnFor) && result.get(dfnFor).has(dfnType)) {
         const oldDfn = result.get(dfnFor).get(dfnType);

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -131,9 +131,7 @@ function collectDfns(title) {
         const oldIsDfn = oldDfn.localName === "dfn";
         const newIsDfn = dfn.localName === "dfn";
         const isSameDfnType = dfnType === (oldDfn.dataset.dfnType || "dfn");
-        const isSameDfnFor = (oldDfn.dataset.dfnFor || "")
-          .split(",")
-          .includes(dfnFor);
+        const isSameDfnFor = oldDfn.dataset.dfnFor?.split(",").includes(dfnFor);
         if (oldIsDfn && newIsDfn && isSameDfnType && isSameDfnFor) {
           duplicates.push(dfn);
           continue;

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -120,11 +120,11 @@ function collectDfns(title) {
   const result = new Map();
   const duplicates = [];
   for (const dfn of definitionMap.get(title)) {
-    const { dfnFor = "", dfnType = "dfn" } = dfn.dataset;
-    for (const _for of dfnFor.split(",")) {
+    const { dfnType = "dfn" } = dfn.dataset;
+    for (const dfnFor of dfn.dataset.dfnFor?.split(",")) {
       // check for potential duplicate definition
-      if (result.has(_for) && result.get(_for).has(dfnType)) {
-        const oldDfn = result.get(_for).get(dfnType);
+      if (result.has(dfnFor) && result.get(dfnFor).has(dfnType)) {
+        const oldDfn = result.get(dfnFor).get(dfnType);
         // We want <dfn> definitions to take precedence over
         // definitions from WebIDL. WebIDL definitions wind
         // up as <span>s instead of <dfn>.
@@ -133,17 +133,17 @@ function collectDfns(title) {
         const isSameDfnType = dfnType === (oldDfn.dataset.dfnType || "dfn");
         const isSameDfnFor = (oldDfn.dataset.dfnFor || "")
           .split(",")
-          .includes(_for);
+          .includes(dfnFor);
         if (oldIsDfn && newIsDfn && isSameDfnType && isSameDfnFor) {
           duplicates.push(dfn);
           continue;
         }
       }
       const type = "idl" in dfn.dataset || dfnType !== "dfn" ? "idl" : "dfn";
-      if (!result.has(_for)) {
-        result.set(_for, new Map());
+      if (!result.has(dfnFor)) {
+        result.set(dfnFor, new Map());
       }
-      result.get(_for).set(type, dfn);
+      result.get(dfnFor).set(type, dfn);
       addId(dfn, "dfn", title);
     }
   }

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -121,8 +121,8 @@ function collectDfns(title) {
   const duplicates = [];
   for (const dfn of definitionMap.get(title)) {
     const { dfnType = "dfn" } = dfn.dataset;
-    for (const dfnFor of dfn.dataset.dfnFor?.split(",").map(s => s.trim()) ??
-      []) {
+    const dfnFors = dfn.dataset.dfnFor?.split(",").map(s => s.trim()) ?? [];
+    for (const dfnFor of dfnFors) {
       // check for potential duplicate definition
       if (result.has(dfnFor) && result.get(dfnFor).has(dfnType)) {
         const oldDfn = result.get(dfnFor).get(dfnType);

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -121,7 +121,7 @@ function collectDfns(title) {
   const duplicates = [];
   for (const dfn of definitionMap.get(title)) {
     const { dfnType = "dfn" } = dfn.dataset;
-    const dfnFors = dfn.dataset.dfnFor?.split(",").map(s => s.trim()) ?? [];
+    const dfnFors = dfn.dataset.dfnFor?.split(",").map(s => s.trim()) ?? [""];
     for (const dfnFor of dfnFors) {
       // check for potential duplicate definition
       if (result.has(dfnFor) && result.get(dfnFor).has(dfnType)) {
@@ -132,7 +132,12 @@ function collectDfns(title) {
         const oldIsDfn = oldDfn.localName === "dfn";
         const newIsDfn = dfn.localName === "dfn";
         const isSameDfnType = dfnType === (oldDfn.dataset.dfnType || "dfn");
-        const isSameDfnFor = oldDfn.dataset.dfnFor?.split(",").map(s => s.trim()).includes(dfnFor);
+        const isSameDfnFor =
+          (!dfnFor && !oldDfn.dataset.dfnFor) ||
+          oldDfn.dataset.dfnFor
+            ?.split(",")
+            .map(s => s.trim())
+            .includes(dfnFor);
         if (oldIsDfn && newIsDfn && isSameDfnType && isSameDfnFor) {
           duplicates.push(dfn);
           continue;
@@ -191,7 +196,10 @@ function processAnchor(anchor, dfn, titleToDfns) {
     linkFor &&
     !titleToDfns.get(linkFor) &&
     dfnFor &&
-    !dfnFor.split(",").map(s => s.trim()).includes(linkFor)
+    !dfnFor
+      .split(",")
+      .map(s => s.trim())
+      .includes(linkFor)
   ) {
     noLocalMatch = true;
   } else if (dfn.classList.contains("externalDFN")) {

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -121,7 +121,8 @@ function collectDfns(title) {
   const duplicates = [];
   for (const dfn of definitionMap.get(title)) {
     const { dfnType = "dfn" } = dfn.dataset;
-    for (const dfnFor of dfn.dataset.dfnFor?.split(",").map(s => s.trim())) {
+    for (const dfnFor of dfn.dataset.dfnFor?.split(",").map(s => s.trim()) ??
+      []) {
       // check for potential duplicate definition
       if (result.has(dfnFor) && result.get(dfnFor).has(dfnType)) {
         const oldDfn = result.get(dfnFor).get(dfnType);

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -132,7 +132,7 @@ function collectDfns(title) {
         const oldIsDfn = oldDfn.localName === "dfn";
         const newIsDfn = dfn.localName === "dfn";
         const isSameDfnType = dfnType === (oldDfn.dataset.dfnType || "dfn");
-        const isSameDfnFor = oldDfn.dataset.dfnFor?.split(",").includes(dfnFor);
+        const isSameDfnFor = oldDfn.dataset.dfnFor?.split(",").map(s => s.trim()).includes(dfnFor);
         if (oldIsDfn && newIsDfn && isSameDfnType && isSameDfnFor) {
           duplicates.push(dfn);
           continue;
@@ -191,7 +191,7 @@ function processAnchor(anchor, dfn, titleToDfns) {
     linkFor &&
     !titleToDfns.get(linkFor) &&
     dfnFor &&
-    !dfnFor.split(",").includes(linkFor)
+    !dfnFor.split(",").map(s => s.trim()).includes(linkFor)
   ) {
     noLocalMatch = true;
   } else if (dfn.classList.contains("externalDFN")) {

--- a/tests/spec/core/link-to-dfn-spec.js
+++ b/tests/spec/core/link-to-dfn-spec.js
@@ -114,6 +114,21 @@ describe("Core — Link to definitions", () => {
     expect(dfn.dataset.dfnFor).toBe("Foo");
   });
 
+  it("recognizes data-dfn-for with multiple targets and accepts matching micro-syntax links", async () => {
+    const bodyText = `
+      <section>
+        <h2>Test Section</h2>
+        <p>There are 2 elements: <dfn class="element">foo</dfn> and <dfn class="element">bar</dfn></p>
+        <p>They both accept a <dfn class="element-attr" id=baz data-dfn-for="foo,bar">baz</dfn> attribute.</p>
+        <p id="dfn-link">[^ foo/bar ^] takes integer values.</p>
+      </section>`;
+    const ops = makeStandardOps(null, bodyText);
+    const doc = await makeRSDoc(ops);
+    const attrLink = doc.querySelector("#dfn-link a");
+    expect(attrLink.dataset.linkType).toBe("element-attr");
+    expect(attrLink.hash).toBe("#baz");
+  });
+
   it("uses data-dfn-type in linking", async () => {
     const body = `
       <section>

--- a/tests/spec/core/link-to-dfn-spec.js
+++ b/tests/spec/core/link-to-dfn-spec.js
@@ -120,7 +120,7 @@ describe("Core — Link to definitions", () => {
         <h2>Test Section</h2>
         <p>There are 2 elements: <dfn class="element">foo</dfn> and <dfn class="element">bar</dfn></p>
         <p>They both accept a <dfn class="element-attr" id=baz data-dfn-for="foo,bar">baz</dfn> attribute.</p>
-        <p id="dfn-link">[^ foo/bar ^] takes integer values.</p>
+        <p id="dfn-link">[^ foo/baz ^] takes integer values.</p>
       </section>`;
     const ops = makeStandardOps(null, bodyText);
     const doc = await makeRSDoc(ops);


### PR DESCRIPTION
When a dfn has a comma-separated values of targets, any of the targets should be recognized as valid for an autolink; this is particularly important for links that use a microsyntax where it is not possible to list all the possible targets.