### PR TITLE
fix(core/link-to-dfn): better disambiguation b/w dfns of different types

### DIFF
--- a/src/core/inline-idl-parser.js
+++ b/src/core/inline-idl-parser.js
@@ -200,6 +200,7 @@ function renderInternalSlot(details) {
   const lt = `[[${identifier}]]${textArgs}`;
   const element = html`${parent && renderParent ? "." : ""}<a
       data-xref-type="${slotType}"
+      data-link-type="${slotType}"
       data-link-for="${linkFor}"
       data-xref-for="${linkFor}"
       data-lt="${lt}"

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -140,11 +140,15 @@ function collectDfns(title) {
         continue;
       }
     }
-    const type = "idl" in dfn.dataset || dfnType !== "dfn" ? "idl" : "dfn";
     if (!result.has(dfnFor)) {
       result.set(dfnFor, new Map());
     }
-    result.get(dfnFor).set(type, dfn);
+    result.get(dfnFor).set(dfnType, dfn);
+    // We register non-dfn terms under the generic "idl" type as well
+    // for backwards-compatibility
+    if ("idl" in dfn.dataset || dfnType !== "dfn") {
+      result.get(dfnFor).set("idl", dfn);
+    }
     addId(dfn, "dfn", title);
   }
 
@@ -168,8 +172,7 @@ function findMatchingDfn(anchor, titleToDfns) {
   const dfnsByType = titleToDfns.get(target.title).get(target.for);
   const { linkType } = anchor.dataset;
   if (linkType) {
-    const type = linkType === "dfn" ? "dfn" : "idl";
-    return dfnsByType.get(type) || dfnsByType.get("dfn");
+    return dfnsByType.get(linkType) || dfnsByType.get("dfn");
   } else {
     // Assumption: if it's for something, it's more likely IDL.
     const type = target.for ? "idl" : "dfn";

--- a/src/core/link-to-dfn.js
+++ b/src/core/link-to-dfn.js
@@ -70,6 +70,10 @@ export async function run(conf) {
     "a[data-cite=''], a:not([href]):not([data-cite]):not(.logo):not(.externalDFN)"
   );
   for (const anchor of localAnchors) {
+    if (!anchor.dataset?.linkType && anchor.dataset?.xrefType) {
+      possibleExternalLinks.push(anchor);
+      continue;
+    }
     const dfn = findMatchingDfn(anchor, titleToDfns);
     if (dfn) {
       const foundLocalMatch = processAnchor(anchor, dfn, titleToDfns);

--- a/src/core/webidl.js
+++ b/src/core/webidl.js
@@ -58,7 +58,11 @@ const templates = {
         cite = "WEBIDL";
         break;
     }
-    return html`<a data-xref-type="${type}" data-cite="${cite}" data-lt="${lt}"
+    return html`<a
+      data-link-type="${type === "_IDL_" ? "idl" : type}"
+      data-xref-type="${type}"
+      data-cite="${cite}"
+      data-lt="${lt}"
       >${wrapped}</a
     >`;
   },


### PR DESCRIPTION
* Skip searching in local definitions for links marked with data-xref-
* Be strict when looking for local definitions when the data-link-type is set