### PR TITLE
feat(linter-rules/informative-dfn): warn on refs to informative dfns

### DIFF
--- a/profiles/w3c.js
+++ b/profiles/w3c.js
@@ -74,6 +74,7 @@ const modules = [
   import("../src/core/linter-rules/wpt-tests-exist.js"),
   import("../src/core/linter-rules/no-http-props.js"),
   import("../src/core/linter-rules/a11y.js"),
+  import("../src/core/linter-rules/informative-dfn.js"),
 ];
 
 Promise.all(modules)

--- a/src/core/linter-rules/informative-dfn.js
+++ b/src/core/linter-rules/informative-dfn.js
@@ -1,0 +1,45 @@
+// @ts-check
+/**
+ * Linter rule "informative-dfn".
+ *
+ * Complains if an informative definition is referenced from a normative section.
+ */
+import { docLink, getIntlData, showError, showWarning } from "../utils.js";
+
+import { informativeRefsInNormative } from "../xref.js";
+
+const ruleName = "informative-dfn";
+export const name = "core/linter-rules/informative-dfn";
+
+const localizationStrings = {
+  en: {
+    msg(term, cite) {
+      return `Normative reference to "${term}" found but term is defined "informatively" in "${cite}".`;
+    },
+    get hint() {
+      return docLink`
+        You can do one of the following...
+
+          * Get the source definition to be made normative
+          * Add a \`class="lint-ignore"\` attribute to the link.
+          * Use a local normative proxy for the definition à la \`<dfn data-cite="spec">term</dfn>\`
+
+        To silence this warning entirely, set \`lint: { "${ruleName}": false }\` in your \`respecConfig\`.`;
+    },
+  },
+};
+const l10n = getIntlData(localizationStrings);
+
+export function run(conf) {
+  if (!conf.lint?.[ruleName]) return;
+  const logger = conf.lint[ruleName] === "error" ? showError : showWarning;
+
+  informativeRefsInNormative.forEach(({ term, cite, element }) => {
+    if (element.classList.contains("lint-ignore")) return;
+    logger(l10n.msg(term, cite), name, {
+      title: "Normative reference to non-normative term.",
+      elements: [element],
+      hint: l10n.hint,
+    });
+  });
+}

--- a/src/core/linter-rules/informative-dfn.js
+++ b/src/core/linter-rules/informative-dfn.js
@@ -34,9 +34,9 @@ export function run(conf) {
   if (!conf.lint?.[ruleName]) return;
   const logger = conf.lint[ruleName] === "error" ? showError : showWarning;
 
-  informativeRefsInNormative.forEach(({ term, cite, element }) => {
+  informativeRefsInNormative.forEach(({ term, spec, element }) => {
     if (element.classList.contains("lint-ignore")) return;
-    logger(l10n.msg(term, cite), name, {
+    logger(l10n.msg(term, spec), name, {
       title: "Normative reference to non-normative term.",
       elements: [element],
       hint: l10n.hint,

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -25,7 +25,6 @@ import {
   nonNormativeSelector,
   norm as normalize,
   showError,
-  showWarning,
 } from "./utils.js";
 import { possibleExternalLinks } from "./link-to-dfn.js";
 import { sub } from "./pubsubhub.js";
@@ -37,6 +36,8 @@ const profiles = {
 };
 
 export const API_URL = "https://respec.org/xref/";
+
+export const informativeRefsInNormative = [];
 
 if (
   !document.querySelector("link[rel='preconnect'][href='https://respec.org']")
@@ -439,9 +440,8 @@ function addToReferences(elem, cite, normative, term, conf) {
     return;
   }
 
-  const msg = `Normative reference to "${term}" found but term is defined "informatively" in "${cite}".`;
-  const title = "Normative reference to non-normative term.";
-  showWarning(msg, name, { title, elements: [elem] });
+  // This is used by the informative-dfn linter
+  informativeRefsInNormative.push({ term, cite, element: elem });
 }
 
 /** @param {Errors} errors */

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -37,7 +37,7 @@ const profiles = {
 
 export const API_URL = "https://respec.org/xref/";
 
-/** @type {{ term: string; spec: string; element: HTMLAnchorElement }[]} */
+/** @type {{ term: string; spec: string; element: HTMLElement }[]} */
 export const informativeRefsInNormative = [];
 
 if (

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -37,6 +37,7 @@ const profiles = {
 
 export const API_URL = "https://respec.org/xref/";
 
+/** @type {{ term: string; spec: string; element: HTMLAnchorElement }[]} */
 export const informativeRefsInNormative = [];
 
 if (
@@ -441,7 +442,7 @@ function addToReferences(elem, cite, normative, term, conf) {
   }
 
   // This is used by the informative-dfn linter
-  informativeRefsInNormative.push({ term, cite, element: elem });
+  informativeRefsInNormative.push({ term, spec: cite, element: elem });
 }
 
 /** @param {Errors} errors */

--- a/src/w3c/defaults.js
+++ b/src/w3c/defaults.js
@@ -37,6 +37,7 @@ const w3cDefaults = {
     "privsec-section": false,
     "required-sections": true,
     "wpt-tests-exist": false,
+    "informative-dfn": "warn",
     "no-unused-dfns": "warn",
     a11y: false,
   },

--- a/tests/spec/core/linter-rules/informative-dfn-spec.js
+++ b/tests/spec/core/linter-rules/informative-dfn-spec.js
@@ -1,0 +1,79 @@
+"use strict";
+
+import {
+  errorFilters,
+  flushIframes,
+  makeRSDoc,
+  makeStandardOps,
+  warningFilters,
+} from "../../SpecHelper.js";
+
+const body = (firstLinkClass = "") => `
+      <section class=normative>
+        <h2>Heading</h2>
+        <p><a class="${firstLinkClass}" data-cite="rdf11-concepts">resources</a></p>
+        <p><a data-cite="rdf11-concepts">denotes</a></p>
+      </section>
+    `;
+
+describe("Core — linter-rules - informative-dfn", () => {
+  const name = "core/linter-rules/informative-dfn";
+  const lintErrors = errorFilters.filter(name);
+  const lintWarnings = warningFilters.filter(name);
+
+  afterAll(() => {
+    flushIframes();
+  });
+
+  it("doesn't complain if the rule is turned off", async () => {
+    const config = { lint: { "informative-dfn": false } };
+    const ops = makeStandardOps(config, body());
+    const doc = await makeRSDoc(ops);
+    const errors = lintErrors(doc);
+    const warnings = lintWarnings(doc);
+    expect(errors).toHaveSize(0);
+    expect(warnings).toHaveSize(0);
+  });
+
+  it("defaults to warning", async () => {
+    const config = { lint: { "informative-dfn": true } };
+    const ops = makeStandardOps(config, body());
+    const doc = await makeRSDoc(ops);
+    const errors = lintErrors(doc);
+    const warnings = lintWarnings(doc);
+    expect(errors).toHaveSize(0);
+    expect(warnings).toHaveSize(2);
+  });
+
+  it("warns when the rule is set to 'warn'", async () => {
+    const config = { lint: { "informative-dfn": "warn" } };
+    const ops = makeStandardOps(config, body());
+    const doc = await makeRSDoc(ops);
+    const errors = lintErrors(doc);
+    const warnings = lintWarnings(doc);
+    expect(errors).toHaveSize(0);
+    expect(warnings).toHaveSize(2);
+  });
+
+  it("shows as error when the rule is set to 'error'", async () => {
+    const config = { lint: { "informative-dfn": "error" } };
+    const ops = makeStandardOps(config, body());
+    const doc = await makeRSDoc(ops);
+    const errors = lintErrors(doc);
+    const warnings = lintWarnings(doc);
+    expect(errors).toHaveSize(2);
+    expect(warnings).toHaveSize(0);
+  });
+
+  it("ignores links that use CSS class 'lint-ignore'", async () => {
+    const config = { lint: { "informative-dfn": true } };
+    const ops = makeStandardOps(config, body("lint-ignore"));
+    const doc = await makeRSDoc(ops);
+    const errors = lintErrors(doc);
+    const warnings = lintWarnings(doc);
+    expect(errors).toHaveSize(0);
+    expect(warnings).toHaveSize(1);
+    const [warning] = warnings;
+    expect(warning.message).toContain('"denotes"');
+  });
+});

--- a/tests/spec/core/xref-spec.js
+++ b/tests/spec/core/xref-spec.js
@@ -520,8 +520,6 @@ describe("Core — xref", () => {
     expect(badLink.href).toBe(
       "https://www.w3.org/TR/css-values-4/#bearing-angle"
     );
-    expect(badLink.classList).toContain("respec-offending-element");
-    expect(badLink.title).toBe("Normative reference to non-normative term.");
 
     const normRefs = [...doc.querySelectorAll("#normative-references dt")];
     expect(normRefs).toHaveSize(1); // excludes `css-values` of `#invalid`

--- a/tests/spec/w3c/defaults-spec.js
+++ b/tests/spec/w3c/defaults-spec.js
@@ -32,6 +32,7 @@ describe("W3C — Defaults", () => {
       "wpt-tests-exist": false,
       "no-unused-dfns": "warn",
       "required-sections": true,
+      "informative-dfn": "warn",
       a11y: false,
     });
     expect(rsConf.highlightVars).toBe(true);
@@ -53,6 +54,7 @@ describe("W3C — Defaults", () => {
           "fake-linter-rule": "foo",
           "check-internal-slots": true,
           "no-unused-dfns": "error",
+          "informative-dfn": false,
           "required-sections": "warn",
         },
         license: "c0",
@@ -71,6 +73,7 @@ describe("W3C — Defaults", () => {
       "no-unused-vars": false,
       "local-refs-exist": true,
       "check-punctuation": false,
+      "informative-dfn": false,
       "fake-linter-rule": "foo",
       "check-internal-slots": true,
       "check-charset": false,


### PR DESCRIPTION
There are situations where making a normative reference to a definition in an informative section is either OK or unavoidable (e.g. because updating the referenced spec is unlikely to be possible). Moving the relevant check in a linter make it easier to silence either individual or all instances of the warning.

see also #4295