### PR TITLE
feat(w3c): support specStatus "ED" for the TAG

### DIFF
--- a/src/w3c/defaults.js
+++ b/src/w3c/defaults.js
@@ -155,10 +155,10 @@ function validateStatusForGroup(conf) {
     case "other":
       if (
         group === "tag" &&
-        ![...trStatus, ...tagStatus].includes(specStatus)
+        !["ED", ...trStatus, ...tagStatus].includes(specStatus)
       ) {
         const msg = docLink`The W3C Technical Architecture Group's documents can't use \`"${specStatus}"\` for the ${"[specStatus]"} configuration option.`;
-        const supportedStatus = codedJoinOr([...trStatus, ...tagStatus], {
+        const supportedStatus = codedJoinOr(["ED", ...trStatus, ...tagStatus], {
           quotes: true,
         });
         const hint = `Please use one of: ${supportedStatus}. Automatically falling back to \`"unofficial"\`.`;

--- a/tests/spec/w3c/defaults-spec.js
+++ b/tests/spec/w3c/defaults-spec.js
@@ -112,7 +112,7 @@ describe("W3C — Defaults", () => {
   });
 
   it("allows W3C TAG to show logos", async () => {
-    for (const specStatus of tagStatus) {
+    for (const specStatus of [...tagStatus, "ED"]) {
       const ops = makeStandardOps({
         specStatus,
         group: "tag",


### PR DESCRIPTION
The TAG can now produce REC-track docs, and in general tends to use a different method of drafting compared to what things were like ten years ago.

I added `ED` in this way rather than by adding it to eg. `tagStatus` or `trStatus` as that would break other things that those are used for.