### PR TITLE
fix(core/utils): ensure `ISODate` formats date correctly

### DIFF
--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -23,7 +23,8 @@ function hashString(text) {
   return String(hash);
 }
 
-export const ISODate = new Intl.DateTimeFormat(["en-ca-iso8601"], {
+// https://stackoverflow.com/a/58633686
+export const ISODate = new Intl.DateTimeFormat(["sv-SE"], {
   timeZone: "UTC",
   year: "numeric",
   month: "2-digit",


### PR DESCRIPTION
While releasing, HTML validator shouted at me saying `datetime` isn't the right format. In fact, on my computer, the generated HTML was:
```html
<time class="dt-published" datetime="01/22/2023">22 January 2023</time>
```

This change is based on https://stackoverflow.com/a/58633686