### PR TITLE
fix(w3c/style): add `crossorigin` attribute to W3C logo preload

### DIFF
--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -69,8 +69,8 @@ export function createResourceHint(opts) {
       if ("as" in opts) {
         linkElem.setAttribute("as", opts.as);
       }
-      if ("crossorigin" in opts) {
-        linkElem.crossOrigin = opts.crossorigin;
+      if (opts.corsMode) {
+        linkElem.crossOrigin = opts.corsMode;
       }
       break;
   }

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -69,6 +69,9 @@ export function createResourceHint(opts) {
       if ("as" in opts) {
         linkElem.setAttribute("as", opts.as);
       }
+      if ("crossorigin" in opts) {
+        linkElem.crossOrigin = opts.crossorigin;
+      }
       break;
   }
   linkElem.href = href;

--- a/src/w3c/style.js
+++ b/src/w3c/style.js
@@ -45,6 +45,7 @@ function createResourceHints() {
       hint: "preload", // all specs show the logo.
       href: "https://www.w3.org/StyleSheets/TR/2021/logos/W3C",
       as: "image",
+      crossorigin: "",
     },
   ];
   const resourceHints = document.createDocumentFragment();

--- a/src/w3c/style.js
+++ b/src/w3c/style.js
@@ -45,7 +45,7 @@ function createResourceHints() {
       hint: "preload", // all specs show the logo.
       href: "https://www.w3.org/StyleSheets/TR/2021/logos/W3C",
       as: "image",
-      crossorigin: "",
+      corsMode: "anonymous",
     },
   ];
   const resourceHints = document.createDocumentFragment();


### PR DESCRIPTION
The W3C logo on respec source documents doesn't appear correctly on Chrome which reports the following warning/error:
* warning: A preload for 'https://www.w3.org/StyleSheets/TR/2021/logos/W3C' is found, but is not used because the request credentials mode does not match. Consider taking a look at crossorigin attribute.
* error: Access to image at 'https://www.w3.org/StyleSheets/TR/2021/logos/W3C' from origin 'https://w3c.github.io' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.

MDN describes that the [preload `link` should match the credential mode](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel/preload#cors-enabled_fetches) used to fetch the resource so I think it's missing the `crossorigin` attribute.