### PR TITLE
fix(core/figures): don't add width/height to `.svg` images

### DIFF
--- a/src/core/figures.js
+++ b/src/core/figures.js
@@ -123,7 +123,7 @@ function getTableOfFiguresListItem(figureId, caption) {
 function normalizeImages(doc) {
   doc
     .querySelectorAll(
-      ":not(picture)>img:not([width]):not([height]):not([srcset])"
+      ":not(picture)>img:not([width]):not([height]):not([srcset]):not([src*='.svg'])"
     )
     .forEach(img => {
       if (img.naturalHeight === 0 || img.naturalWidth === 0) return;


### PR DESCRIPTION
Fixes https://github.com/w3c/respec/issues/3435