### PR TITLE
fix(w3c/sotd): update stability tempate for NOTEs

### DIFF
--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -548,10 +548,6 @@ export async function run(conf) {
   }
   if (Array.isArray(conf.wg)) {
     conf.multipleWGs = conf.wg.length > 1;
-    conf.wgHTML = htmlJoinAnd(conf.wg, (wg, idx) => {
-      return html`the <a href="${conf.wgURI[idx]}">${wg}</a>`;
-    });
-
     conf.wgPatentHTML = htmlJoinAnd(conf.wg, (wg, i) => {
       return html`a
         <a href="${conf.wgPatentURI[i]}" rel="disclosure"
@@ -560,9 +556,6 @@ export async function run(conf) {
     });
   } else {
     conf.multipleWGs = false;
-    if (conf.wg) {
-      conf.wgHTML = html`the <a href="${conf.wgURI}">${conf.wg}</a>`;
-    }
   }
   if (conf.isPR && !conf.crEnd) {
     const msg = docLink`${"[specStatus]"} is "PR" but no ${"[crEnd]"} is specified in the ${"[respecConfig]"} (needed to indicate end of previous CR).`;

--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -255,9 +255,12 @@ function renderNotRec(conf) {
     case "DNOTE":
       endorsement = html`${conf.textStatus}s are not endorsed by
         <abbr title="World Wide Web Consortium">W3C</abbr> nor its Members.`;
+      break;
     case "NOTE":
-      endorsement = html`This ${conf.textStatus} is endorsed by ${conf.wgHTML}, but is not endorsed by <abbr title="World Wide Web Consortium">W3C</abbr> itself nor its Members.`;
-
+      endorsement = html`This ${conf.textStatus} is endorsed by ${conf.wgHTML},
+        but is not endorsed by
+        <abbr title="World Wide Web Consortium">W3C</abbr> itself nor its
+        Members.`;
       break;
   }
   return html`<p>${endorsement} ${statusExplanation}</p>

--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -1,5 +1,5 @@
 // @ts-check
-import { W3CDate, getIntlData } from "../../core/utils.js";
+import { W3CDate, getIntlData, htmlJoinAnd } from "../../core/utils.js";
 import { html } from "../../core/import-maps.js";
 import { status2track } from "../headers.js";
 const localizationStrings = {
@@ -257,8 +257,8 @@ function renderNotRec(conf) {
         <abbr title="World Wide Web Consortium">W3C</abbr> nor its Members.`;
       break;
     case "NOTE":
-      endorsement = html`This ${conf.textStatus} is endorsed by ${conf.wgHTML},
-        but is not endorsed by
+      endorsement = html`This ${conf.textStatus} is endorsed by
+        ${getWgHTML(conf)}, but is not endorsed by
         <abbr title="World Wide Web Consortium">W3C</abbr> itself nor its
         Members.`;
       break;
@@ -497,9 +497,19 @@ function linkToWorkingGroup(conf) {
         >`
     : "";
   return html`<p>
-    This document was published by ${conf.wgHTML} as
+    This document was published by ${getWgHTML(conf)} as
     ${prefix(conf.longStatus)}${track}. ${changes}
   </p>`;
+}
+
+function getWgHTML(conf) {
+  if (Array.isArray(conf.wg)) {
+    return htmlJoinAnd(conf.wg, (wg, idx) => {
+      return html`the <a href="${conf.wgURI[idx]}">${wg}</a>`;
+    });
+  } else if (conf.wg) {
+    return html`the <a href="${conf.wgURI}">${conf.wg}</a>`;
+  }
 }
 
 export function linkToCommunity(conf, opts) {

--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -253,9 +253,11 @@ function renderNotRec(conf) {
       </p>`;
       break;
     case "DNOTE":
-    case "NOTE":
       endorsement = html`${conf.textStatus}s are not endorsed by
         <abbr title="World Wide Web Consortium">W3C</abbr> nor its Members.`;
+    case "NOTE":
+      endorsement = html`This ${conf.textStatus} is endorsed by ${conf.wgHTML}, but is not endorsed by <abbr title="World Wide Web Consortium">W3C</abbr> itself nor its Members.`;
+
       break;
   }
   return html`<p>${endorsement} ${statusExplanation}</p>


### PR DESCRIPTION
For **Notes**, use:

```
This Group Note is endorsed by the XXX Group, but is not endorsed by W3C itself nor its Members.
```

...resolves https://github.com/w3c/respec/issues/4425