### PR TITLE
fix(core/dfn-index): escape HTML/XML tags

### DIFF
--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -174,9 +174,7 @@ export function xmlEscape(str) {
  * @param {string} str
  */
 export function norm(str) {
-  return str
-    .trim()
-    .replace(/\s+/g, " ");
+  return str.trim().replace(/\s+/g, " ");
 }
 
 /**

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -174,7 +174,11 @@ export function xmlEscape(str) {
  * @param {string} str
  */
 export function norm(str) {
-  return str.trim().replace(/\s+/g, " ").replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  return str
+      .trim()
+      .replace(/\s+/g, " ")
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
 }
 
 /**

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -174,7 +174,7 @@ export function xmlEscape(str) {
  * @param {string} str
  */
 export function norm(str) {
-  return str.trim().replace(/\s+/g, " ");
+  return str.trim().replace(/\s+/g, " ").replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
 /**

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -175,10 +175,10 @@ export function xmlEscape(str) {
  */
 export function norm(str) {
   return str
-      .trim()
-      .replace(/\s+/g, " ")
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;');
+    .trim()
+    .replace(/\s+/g, " ")
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
 }
 
 /**

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -176,9 +176,7 @@ export function xmlEscape(str) {
 export function norm(str) {
   return str
     .trim()
-    .replace(/\s+/g, " ")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
+    .replace(/\s+/g, " ");
 }
 
 /**

--- a/src/core/utils.js
+++ b/src/core/utils.js
@@ -177,8 +177,8 @@ export function norm(str) {
   return str
     .trim()
     .replace(/\s+/g, " ")
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }
 
 /**

--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -25,6 +25,7 @@ import {
   nonNormativeSelector,
   norm as normalize,
   showError,
+  xmlEscape,
 } from "./utils.js";
 import { possibleExternalLinks } from "./link-to-dfn.js";
 import { sub } from "./pubsubhub.js";
@@ -189,7 +190,7 @@ function getRequestEntry(elem) {
 export function getTermFromElement(elem) {
   const { lt: linkingText } = elem.dataset;
   let term = linkingText ? linkingText.split("|", 1)[0] : elem.textContent;
-  term = normalize(term);
+  term = xmlEscape(normalize(term));
   return term === "the-empty-string" ? "" : term;
 }
 

--- a/tests/spec/core/dfn-index-spec.js
+++ b/tests/spec/core/dfn-index-spec.js
@@ -255,7 +255,7 @@ describe("Core — dfn-index", () => {
 
     it("lists terms grouped by specs", () => {
       const bySpecs = index.querySelectorAll("ul.index > li");
-      expect(bySpecs).toHaveSize(6);
+      expect(bySpecs).toHaveSize(7);
       expect(bySpecs[0].textContent.trim()).toMatch(
         /\[DOM\] defines the following:/
       );

--- a/tests/spec/core/dfn-index-spec.js
+++ b/tests/spec/core/dfn-index-spec.js
@@ -175,6 +175,7 @@ describe("Core — dfn-index", () => {
           </pre>
           <dfn id="local-idl-1">name</dfn>
           <dfn id="local-idl-2">onpay</dfn>
+          <dfn data-cite="ttml2#profile-vocabulary-feature"><code>&lt;ttp:feature&gt;</code></dfn>
         </div>
         <p class="test" data-link-for="Employee">
           {{ name }} {{ onpay }}
@@ -201,6 +202,7 @@ describe("Core — dfn-index", () => {
             <dfn data-cite="ECMASCRIPT/#sec-json.stringify">JSON.stringify</dfn>
           </li>
           <li><a>JSON.stringify</a></li>
+          <li><a><code>&lt;ttp:feature&gt;</code></a></li>
         </ul>
         <ul class="test" data-testid="possible-duplicate-id">
         <li><a data-cite="ECMASCRIPT#sec-json.parse">parsing</a></li>
@@ -238,6 +240,7 @@ describe("Core — dfn-index", () => {
         "iframe element",
         "ASCII uppercase",
         "origin",
+        "<ttp:feature>",
         "AbortError exception",
         "boolean type",
         "[Default] extended attribute",
@@ -266,6 +269,7 @@ describe("Core — dfn-index", () => {
         "HTML",
         "INFRA",
         "RFC6454",
+        "TTML2",
         "WEBIDL",
       ]);
 


### PR DESCRIPTION
A fix for #4430 : when the normalized text is rendered as html e.g. in `dfn-index.js` line 298 within `renderExternalTermEntry` using `html: text` this prevents creation of what the UA thinks are HTML elements from terms defined with angle brackets at the start and end.

An alternative fix could be to replace `html: text` with `text: text` but I think that would break cases where code blocks are deliberately put around the term in the index.

This fix seems to pass all the tests.

---

- Fixes #4430
- Fixes https://github.com/w3c/respec/issues/4324