### PR TITLE
fix(core/caniuse, core/mdn): host browser logos on `www.w3.org`

### DIFF
--- a/src/core/caniuse.js
+++ b/src/core/caniuse.js
@@ -64,7 +64,7 @@ export function prepare(conf) {
  */
 function getLogoSrc(browser) {
   const path = BROWSERS.get(browser).path ?? browser;
-  return `https://cdn.w3.org/assets/logos/browser-logos/${path}/${path}.svg`;
+  return `https://www.w3.org/assets/logos/browser-logos/${path}/${path}.svg`;
 }
 
 export async function run(conf) {

--- a/src/styles/mdn-annotation.css.js
+++ b/src/styles/mdn-annotation.css.js
@@ -102,37 +102,37 @@ export default css`
 
 .mdn .chrome::before,
 .mdn .chrome_android::before {
-  background-image: url(https://cdn.w3.org/assets/logos/browser-logos/chrome/chrome.svg);
+  background-image: url(https://www.w3.org/assets/logos/browser-logos/chrome/chrome.svg);
 }
 
 .mdn .edge::before,
 .mdn .edge_mobile::before {
-  background-image: url(https://cdn.w3.org/assets/logos/browser-logos/edge/edge.svg);
+  background-image: url(https://www.w3.org/assets/logos/browser-logos/edge/edge.svg);
 }
 
 .mdn .firefox::before,
 .mdn .firefox_android::before {
-  background-image: url(https://cdn.w3.org/assets/logos/browser-logos/firefox/firefox.svg);
+  background-image: url(https://www.w3.org/assets/logos/browser-logos/firefox/firefox.svg);
 }
 
 .mdn .opera::before,
 .mdn .opera_android::before {
-  background-image: url(https://cdn.w3.org/assets/logos/browser-logos/opera/opera.svg);
+  background-image: url(https://www.w3.org/assets/logos/browser-logos/opera/opera.svg);
 }
 
 .mdn .safari::before {
-  background-image: url(https://cdn.w3.org/assets/logos/browser-logos/safari/safari.svg);
+  background-image: url(https://www.w3.org/assets/logos/browser-logos/safari/safari.svg);
 }
 
 .mdn .safari_ios::before {
-  background-image: url(https://cdn.w3.org/assets/logos/browser-logos/safari-ios/safari-ios.svg);
+  background-image: url(https://www.w3.org/assets/logos/browser-logos/safari-ios/safari-ios.svg);
 }
 
 .mdn .samsunginternet_android::before {
-  background-image: url(https://cdn.w3.org/assets/logos/browser-logos/samsung-internet/samsung-internet.svg);
+  background-image: url(https://www.w3.org/assets/logos/browser-logos/samsung-internet/samsung-internet.svg);
 }
 
 .mdn .webview_android::before {
-  background-image: url(https://cdn.w3.org/assets/logos/browser-logos/android-webview/android-webview.png);
+  background-image: url(https://www.w3.org/assets/logos/browser-logos/android-webview/android-webview.png);
 }
 `;

--- a/tests/spec/core/caniuse-spec.js
+++ b/tests/spec/core/caniuse-spec.js
@@ -177,7 +177,7 @@ describe("Core — Can I Use", () => {
     expect(exportedDoc.querySelector(".caniuse-browser")).toBeFalsy();
   });
 
-  it("loads every BROWSER logo from cdn.w3.org", async () => {
+  it("loads every BROWSER logo from www.w3.org", async () => {
     const ops = makeStandardOps({
       caniuse: {
         feature: "payment-request",
@@ -187,7 +187,7 @@ describe("Core — Can I Use", () => {
     const doc = await makeRSDoc(ops);
     const images = [
       ...doc.querySelectorAll(
-        `.caniuse-stats img.caniuse-browser[src^='https://cdn.w3.org/assets/logos/browser-logos/']`
+        `.caniuse-stats img.caniuse-browser[src^='https://www.w3.org/assets/logos/browser-logos/']`
       ),
     ];
     expect(images).toHaveSize(BROWSERS.size);


### PR DESCRIPTION
To fix [some performance issues](https://github.com/w3c/w3c-website/issues/289), we are now hosting the assets on www.w3.org instead of cdn.w3.org.
That PR updates all occurences of cdn.w3.org.

/cc @plehegar 