### PR TITLE
fix(w3c/headers): update link for Software License

### DIFF
--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -81,7 +81,7 @@
 //          intended to be pushed to the WHATWG.
 //      - "w3c-software", a permissive and attributions license (but GPL-compatible).
 //      - "w3c-software-doc", (default) the W3C Software and Document License
-//            https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+//            https://www.w3.org/Consortium/Legal/2023/software-license.html
 import {
   ISODate,
   codedJoinAnd,
@@ -231,7 +231,7 @@ export const licenses = new Map([
     {
       name: "W3C Software and Document Notice and License",
       short: "permissive document license",
-      url: "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document",
+      url: "https://www.w3.org/Consortium/Legal/2023/software-license.html",
     },
   ],
   [

--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -81,7 +81,7 @@
 //          intended to be pushed to the WHATWG.
 //      - "w3c-software", a permissive and attributions license (but GPL-compatible).
 //      - "w3c-software-doc", (default) the W3C Software and Document License
-//            https://www.w3.org/Consortium/Legal/2023/software-license.html
+//            https://www.w3.org/Consortium/Legal/2023/software-license
 import {
   ISODate,
   codedJoinAnd,
@@ -231,7 +231,7 @@ export const licenses = new Map([
     {
       name: "W3C Software and Document Notice and License",
       short: "permissive document license",
-      url: "https://www.w3.org/Consortium/Legal/2023/software-license.html",
+      url: "https://www.w3.org/Consortium/Legal/2023/software-license",
     },
   ],
   [

--- a/tests/spec/w3c/seo-spec.js
+++ b/tests/spec/w3c/seo-spec.js
@@ -178,7 +178,7 @@ describe("W3C - SEO", () => {
       "https://www.w3.org/TR/2012/REC-some-spec-20120607/"
     );
     expect(jsonld.license).toBe(
-      "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"
+      "https://www.w3.org/Consortium/Legal/2023/software-license"
     );
     expect(jsonld.name).toBe("Basic Title");
     expect(jsonld.copyrightHolder).toEqual({


### PR DESCRIPTION
The link to the software license has been updated since Jan 1.
It should now be:
https://www.w3.org/Consortium/Legal/2023/software-license
intead of
https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document  (see the status warning at the top)
