### PR TITLE
fix(w3c/headers): history link now has a trailing slash

### DIFF
--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -746,7 +746,7 @@ async function deriveHistoryURI(conf) {
   }
 
   const historyURL = new URL(
-    conf.historyURI ?? conf.shortName,
+    conf.historyURI ?? `${conf.shortName}/`,
     "https://www.w3.org/standards/history/"
   );
 

--- a/tests/spec/w3c/headers-spec.js
+++ b/tests/spec/w3c/headers-spec.js
@@ -2459,10 +2459,10 @@ describe("W3C — Headers", () => {
       const historyLink = history.nextElementSibling.querySelector("a");
       expect(historyLink).toBeTruthy();
       expect(historyLink.href).toBe(
-        "https://www.w3.org/standards/history/appmanifest"
+        "https://www.w3.org/standards/history/appmanifest/"
       );
       expect(historyLink.textContent).toContain(
-        "https://www.w3.org/standards/history/appmanifest"
+        "https://www.w3.org/standards/history/appmanifest/"
       );
     });
 
@@ -2480,8 +2480,8 @@ describe("W3C — Headers", () => {
       expect(commitHistory).toBeTruthy();
       const [publicationHistory] = contains(
         doc,
-        ".head dd>a[href='https://www.w3.org/standards/history/appmanifest']",
-        "https://www.w3.org/standards/history/appmanifest"
+        ".head dd>a[href='https://www.w3.org/standards/history/appmanifest/']",
+        "https://www.w3.org/standards/history/appmanifest/"
       );
       expect(publicationHistory).toBeTruthy();
     });
@@ -2535,7 +2535,7 @@ describe("W3C — Headers", () => {
       const historyLink = history.nextElementSibling.querySelector("a");
       expect(historyLink).toBeTruthy();
       expect(historyLink.href).toBe(
-        "https://www.w3.org/standards/history/test"
+        "https://www.w3.org/standards/history/test/"
       );
     });
 
@@ -2587,7 +2587,7 @@ describe("W3C — Headers", () => {
       const historyLink = history.nextElementSibling.querySelector("a");
       expect(historyLink).toBeTruthy();
       expect(historyLink.href).toBe(
-        "https://www.w3.org/standards/history/payment-request"
+        "https://www.w3.org/standards/history/payment-request/"
       );
     });
 
@@ -2606,7 +2606,7 @@ describe("W3C — Headers", () => {
         const historyLink = history.nextElementSibling.querySelector("a");
         expect(historyLink).toBeTruthy();
         expect(historyLink.href).toBe(
-          `https://www.w3.org/standards/history/${shortName}`
+          `https://www.w3.org/standards/history/${shortName}/`
         );
       });
     }


### PR DESCRIPTION
After the [deployment of the new website](https://www.w3.org/news/2023/new-w3c-website-deployed/), most of the W3C URLs now have a trailing slash.
This is causing a problem when respec tries to fetch the history link for a spec as there's now a redirection and CORS is blocking the [HEAD](https://github.com/w3c/respec/blob/main/src/w3c/headers.js#L763) the check if the link exists.
That PR updates the history link to add the trailing slash