### PR TITLE
fix(respecDocWriter): use default `userDataDir`

### DIFF
--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -1,11 +1,10 @@
 /**
  * Exports toHTML() method, allowing programmatic control of the spec generator.
  */
-import { mkdtemp, readFile } from "fs/promises";
 import { fileURLToPath } from "url";
 import path from "path";
 import puppeteer from "puppeteer";
-import { tmpdir } from "os";
+import { readFile } from "fs/promises";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 

--- a/tools/respecDocWriter.js
+++ b/tools/respecDocWriter.js
@@ -58,13 +58,11 @@ export async function toHTML(src, options = {}) {
     options.onWarning(warning);
   };
 
-  const userDataDir = await mkdtemp(`${tmpdir()}/respec2html-`);
   const args = [];
   if (disableSandbox) args.push("--no-sandbox");
 
   log("Launching browser");
   const browser = await puppeteer.launch({
-    userDataDir,
     args,
     devtools,
     headless: "new",


### PR DESCRIPTION
It doesn't seem necessary to generate a different user data directory for each document.
spec-generator relies on `RespecDocWriter` to generate snapshots from respec documents and the recent increase of requests completely filled up the tmp partition.