### PR TITLE
fix(w3c/sotd): switch to 2023-Nov process document

### DIFF
--- a/src/w3c/templates/sotd.js
+++ b/src/w3c/templates/sotd.js
@@ -54,7 +54,7 @@ const localizationStrings = {
 
 export const l10n = getIntlData(localizationStrings);
 
-const processLink = "https://www.w3.org/2023/Process-20230612/";
+const processLink = "https://www.w3.org/2023/Process-20231103/";
 
 function prefix(word) {
   return /^[aeiou]/i.test(word) ? `an ${word}` : `a ${word}`;
@@ -85,7 +85,7 @@ export default (conf, opts) => {
                 <p>
                   This document is governed by the
                   <a id="w3c_process_revision" href="${processLink}"
-                    >12 June 2023 W3C Process Document</a
+                    >03 November 2023 W3C Process Document</a
                   >.
                 </p>
               `}


### PR DESCRIPTION
Related to https://github.com/w3c/modern-tooling/issues/111