### PR TITLE
fix(w3c/headers): update copyright links to avoid redirects

### DIFF
--- a/src/w3c/headers.js
+++ b/src/w3c/headers.js
@@ -81,7 +81,7 @@
 //          intended to be pushed to the WHATWG.
 //      - "w3c-software", a permissive and attributions license (but GPL-compatible).
 //      - "w3c-software-doc", (default) the W3C Software and Document License
-//            https://www.w3.org/Consortium/Legal/2023/software-license
+//            https://www.w3.org/copyright/software-license-2023/
 import {
   ISODate,
   codedJoinAnd,
@@ -223,7 +223,7 @@ export const licenses = new Map([
     {
       name: "W3C Software Notice and License",
       short: "W3C Software",
-      url: "https://www.w3.org/Consortium/Legal/2002/copyright-software-20021231",
+      url: "https://www.w3.org/copyright/software-license-2002/",
     },
   ],
   [
@@ -231,7 +231,7 @@ export const licenses = new Map([
     {
       name: "W3C Software and Document Notice and License",
       short: "permissive document license",
-      url: "https://www.w3.org/Consortium/Legal/2023/software-license",
+      url: "https://www.w3.org/copyright/software-license-2023/",
     },
   ],
   [
@@ -247,7 +247,7 @@ export const licenses = new Map([
     {
       name: "W3C Document License",
       short: "document use",
-      url: "https://www.w3.org/Consortium/Legal/copyright-documents",
+      url: "https://www.w3.org/copyright/document-license/",
     },
   ],
   [

--- a/src/w3c/templates/cgbg-headers.js
+++ b/src/w3c/templates/cgbg-headers.js
@@ -124,7 +124,7 @@ export default (conf, options) => {
     ${existingCopyright
       ? existingCopyright
       : html`<p class="copyright">
-          <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright"
+          <a href="https://www.w3.org/policies/#copyright"
             >Copyright</a
           >
           &copy;

--- a/src/w3c/templates/cgbg-headers.js
+++ b/src/w3c/templates/cgbg-headers.js
@@ -124,9 +124,7 @@ export default (conf, options) => {
     ${existingCopyright
       ? existingCopyright
       : html`<p class="copyright">
-          <a href="https://www.w3.org/policies/#copyright"
-            >Copyright</a
-          >
+          <a href="https://www.w3.org/policies/#copyright">Copyright</a>
           &copy;
           ${conf.copyrightStart
             ? `${conf.copyrightStart}-`

--- a/src/w3c/templates/headers.js
+++ b/src/w3c/templates/headers.js
@@ -439,7 +439,7 @@ function renderCopyright(conf) {
 
 function renderOfficialCopyright(conf) {
   return html`<p class="copyright">
-    <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright"
+    <a href="https://www.w3.org/policies/#copyright"
       >Copyright</a
     >
     &copy;
@@ -449,10 +449,10 @@ function renderOfficialCopyright(conf) {
       : ""}
     <a href="https://www.w3.org/">World Wide Web Consortium</a>.
     <abbr title="World Wide Web Consortium">W3C</abbr><sup>&reg;</sup>
-    <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer"
+    <a href="https://www.w3.org/policies/#Legal_Disclaimer"
       >liability</a
     >,
-    <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks"
+    <a href="https://www.w3.org/policies/#W3C_Trademarks"
       >trademark</a
     >${linkLicense(conf.licenseInfo)}
   </p>`;

--- a/src/w3c/templates/headers.js
+++ b/src/w3c/templates/headers.js
@@ -439,9 +439,7 @@ function renderCopyright(conf) {
 
 function renderOfficialCopyright(conf) {
   return html`<p class="copyright">
-    <a href="https://www.w3.org/policies/#copyright"
-      >Copyright</a
-    >
+    <a href="https://www.w3.org/policies/#copyright">Copyright</a>
     &copy;
     ${conf.copyrightStart ? `${conf.copyrightStart}-` : ""}${conf.publishYear}
     ${conf.additionalCopyrightHolders
@@ -449,11 +447,8 @@ function renderOfficialCopyright(conf) {
       : ""}
     <a href="https://www.w3.org/">World Wide Web Consortium</a>.
     <abbr title="World Wide Web Consortium">W3C</abbr><sup>&reg;</sup>
-    <a href="https://www.w3.org/policies/#Legal_Disclaimer"
-      >liability</a
-    >,
-    <a href="https://www.w3.org/policies/#W3C_Trademarks"
-      >trademark</a
+    <a href="https://www.w3.org/policies/#Legal_Disclaimer">liability</a>,
+    <a href="https://www.w3.org/policies/#W3C_Trademarks">trademark</a
     >${linkLicense(conf.licenseInfo)}
   </p>`;
 }

--- a/tests/spec/w3c/seo-spec.js
+++ b/tests/spec/w3c/seo-spec.js
@@ -178,7 +178,7 @@ describe("W3C - SEO", () => {
       "https://www.w3.org/TR/2012/REC-some-spec-20120607/"
     );
     expect(jsonld.license).toBe(
-      "https://www.w3.org/Consortium/Legal/2023/software-license"
+      "https://www.w3.org/copyright/software-license-2023/"
     );
     expect(jsonld.name).toBe("Basic Title");
     expect(jsonld.copyrightHolder).toEqual({


### PR DESCRIPTION
[Pubrules will soon require the new copyright links](https://github.com/w3c/specberus/pull/1783) to avoid redirects.

These changes also need to be sync'ed with bikeshed: https://github.com/speced/bikeshed-boilerplate/pull/53