### PR TITLE
fix(core/inlines): allow quotes in inline var's types (for enums)

### DIFF
--- a/src/core/inlines.js
+++ b/src/core/inlines.js
@@ -65,7 +65,7 @@ const l10n = getIntlData(localizationStrings);
 // add support.
 const inlineCodeRegExp = /(?:`[^`]+`)(?!`)/; // `code`
 const inlineIdlReference = /(?:{{[^}]+\?*}})/; // {{ WebIDLThing }}, {{ WebIDLThing? }}
-const inlineVariable = /\B\|\w[\w\s]*(?:\s*:[\w\s&;<>]+\??)?\|\B/; // |var : Type?|
+const inlineVariable = /\B\|\w[\w\s]*(?:\s*:[\w\s&;"<>]+\??)?\|\B/; // |var : Type?|
 const inlineCitation = /(?:\[\[(?:!|\\|\?)?[\w.-]+(?:|[^\]]+)?\]\])/; // [[citation]]
 const inlineExpansion = /(?:\[\[\[(?:!|\\|\?)?#?[\w-.]+\]\]\])/; // [[[expand]]]
 const inlineAnchor = /(?:\[=[^=]+=\])/; // Inline [= For/link =]

--- a/tests/spec/core/inlines-spec.js
+++ b/tests/spec/core/inlines-spec.js
@@ -160,6 +160,7 @@ describe("Core - Inlines", () => {
       </section>
       <section>
         <p id="a4">TEXT |with spaces :  Type with spaces| TEXT</p>
+        <p id="a5">TEXT |typeWithQuotes: "valid" or "invalid"| TEXT</p>
         <p id="b">TEXT |variable| TEXT</p>
         <p id="c">TEXT | ignored | TEXT</p>
         <p id="d">TEXT|ignore: Ignore|TEXT</p>
@@ -189,6 +190,10 @@ describe("Core - Inlines", () => {
     const a4 = doc.querySelector("#a4 var");
     expect(a4.textContent).toBe("with spaces");
     expect(a4.dataset.type).toBe("Type with spaces");
+
+    const a5 = doc.querySelector("#a5 var");
+    expect(a5.textContent).toBe("typeWithQuotes");
+    expect(a5.dataset.type).toBe(`"valid" or "invalid"`);
 
     const b = doc.querySelector("#b var");
     expect(b.textContent).toBe("variable");


### PR DESCRIPTION
Fixes https://github.com/w3c/respec/issues/4632