### PR TITLE
fix(core/linter/a11y): import axe from jsdelivr instead of unpkg

### DIFF
--- a/src/core/linter-rules/a11y.js
+++ b/src/core/linter-rules/a11y.js
@@ -89,7 +89,7 @@ async function getViolations(opts) {
 function importAxe() {
   const script = document.createElement("script");
   script.classList.add("remove");
-  script.src = "https://unpkg.com/axe-core@4/axe.min.js";
+  script.src = "https://cdn.jsdelivr.net/npm/axe-core@4/axe.min.js";
   document.head.appendChild(script);
   return new Promise((resolve, reject) => {
     script.onload = () => resolve(window.axe);


### PR DESCRIPTION
unpkg is down, and I'm not sure it's maintained. Tests are failing for a11y linter, and we get occasional timeouts. So, moving to "bigger player".