### PR TITLE
fix!(w3c/style): override color-scheme with meta tag

### DIFF
--- a/src/w3c/style.js
+++ b/src/w3c/style.js
@@ -114,30 +114,34 @@ export function run(conf) {
   // Make sure the W3C stylesheet is the last stylesheet, as required by W3C Pub Rules.
   sub("beforesave", styleMover(finalStyleURL));
 
+  // Add color scheme meta tag and style
   /** @type HTMLMetaElement */
   let colorScheme = document.querySelector("head meta[name=color-scheme]");
   if (!colorScheme) {
-    colorScheme = html`<meta name="color-scheme" content="light dark" />`;
+    // Default to light mode during transitional period.
+    colorScheme = html`<meta name="color-scheme" content="light" />`;
     document.head.appendChild(colorScheme);
   }
-  const darkModeStyleUrl = getStyleUrl("dark.css");
   const css = `:root {
     color-scheme: ${colorScheme.content};
   }`;
   document.head.appendChild(
-    html`<style>
+    html`<style id="respec-color-scheme-declaration">
       ${css}
     </style>`
   );
-  document.head.appendChild(
-    html`<link
-      rel="stylesheet"
-      href="${darkModeStyleUrl.href}"
-      media="(prefers-color-scheme: dark)"
-    />`
-  );
-  // As required by W3C Pub Rules.
-  sub("beforesave", styleMover(darkModeStyleUrl));
+  if (colorScheme.content.includes("dark")) {
+    const darkModeStyleUrl = getStyleUrl("dark.css");
+    document.head.appendChild(
+      html`<link
+        rel="stylesheet"
+        href="${darkModeStyleUrl.href}"
+        media="(prefers-color-scheme: dark)"
+      />`
+    );
+    // As required by W3C Pub Rules.
+    sub("beforesave", styleMover(darkModeStyleUrl));
+  }
 }
 
 /** @param {Conf} conf */

--- a/src/w3c/style.js
+++ b/src/w3c/style.js
@@ -122,14 +122,6 @@ export function run(conf) {
     colorScheme = html`<meta name="color-scheme" content="light" />`;
     document.head.appendChild(colorScheme);
   }
-  const css = `:root {
-    color-scheme: ${colorScheme.content};
-  }`;
-  document.head.appendChild(
-    html`<style id="respec-color-scheme-declaration">
-      ${css}
-    </style>`
-  );
   if (colorScheme.content.includes("dark")) {
     const darkModeStyleUrl = getStyleUrl("dark.css");
     document.head.appendChild(

--- a/src/w3c/style.js
+++ b/src/w3c/style.js
@@ -114,28 +114,30 @@ export function run(conf) {
   // Make sure the W3C stylesheet is the last stylesheet, as required by W3C Pub Rules.
   sub("beforesave", styleMover(finalStyleURL));
 
-  if (conf.darkMode) {
-    const darkModeStyleUrl = getStyleUrl("dark.css");
-    document.head.appendChild(
-      html`<style>
-        :root {
-          color-scheme: light dark;
-        }
-      </style>`
-    );
-    document.head.appendChild(
-      html`<meta name="color-scheme" content="light dark" />`
-    );
-    document.head.appendChild(
-      html`<link
-        rel="stylesheet"
-        href="${darkModeStyleUrl.href}"
-        media="(prefers-color-scheme: dark)"
-      />`
-    );
-    // As required by W3C Pub Rules.
-    sub("beforesave", styleMover(darkModeStyleUrl));
+  /** @type HTMLMetaElement */
+  let colorScheme = document.querySelector("head meta[name=color-scheme]");
+  if (!colorScheme) {
+    colorScheme = html`<meta name="color-scheme" content="light dark" />`;
+    document.head.appendChild(colorScheme);
   }
+  const darkModeStyleUrl = getStyleUrl("dark.css");
+  const css = `:root {
+    color-scheme: ${colorScheme.content};
+  }`;
+  document.head.appendChild(
+    html`<style>
+      ${css}
+    </style>`
+  );
+  document.head.appendChild(
+    html`<link
+      rel="stylesheet"
+      href="${darkModeStyleUrl.href}"
+      media="(prefers-color-scheme: dark)"
+    />`
+  );
+  // As required by W3C Pub Rules.
+  sub("beforesave", styleMover(darkModeStyleUrl));
 }
 
 /** @param {Conf} conf */

--- a/tests/spec/core/color-scheme.html
+++ b/tests/spec/core/color-scheme.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<meta charset='utf-8'/>
+<meta name="color-scheme" content="dark">
+<title>Simple Spec</title>
+<script class='remove'>
+var respecConfig = {
+  specStatus: "base",
+  shortName: "basics",
+};
+</script>
+<section id='abstract'>
+  <p>Basic doc</p>
+</section>
+<section id='sotd'>
+  <p>
+    Color scheme tester
+  </p>
+</section>

--- a/tests/spec/core/color-scheme.html
+++ b/tests/spec/core/color-scheme.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <meta charset='utf-8'/>
-<meta name="color-scheme" content="dark">
+<meta name="color-scheme" content="dark light">
 <title>Simple Spec</title>
 <script class='remove'>
 var respecConfig = {

--- a/tests/spec/w3c/style-spec.js
+++ b/tests/spec/w3c/style-spec.js
@@ -196,11 +196,12 @@ describe("W3C - Style", () => {
     });
   }
 
-  it("should add W3C stylesheets at end", async () => {
+  it("should add W3C stylesheet at the end", async () => {
     const ops = makeStandardOps({});
     const doc = await getExportedDoc(await makeRSDoc(ops));
     const url = "https://www.w3.org/StyleSheets/TR/2021/base";
     const elem = doc.querySelector(`link[href^='${url}'][rel="stylesheet"]`);
+    expect(elem).toBeTruthy();
     expect(elem?.nextElementSibling).toBe(null);
   });
 

--- a/tests/spec/w3c/style-spec.js
+++ b/tests/spec/w3c/style-spec.js
@@ -229,7 +229,7 @@ describe("W3C - Style", () => {
     const link = doc.querySelector(`link[href^='${url}'][rel="stylesheet"]`);
     expect(link).toBeTruthy();
     expect(link?.href).toBe(url);
-    expect(link?.getAttribute("media")).toBe("(prefers-color-scheme: dark)");
+    expect(link?.media).toBe("(prefers-color-scheme: dark)");
   });
 
   it("adds darkmode stylesheet at the end", async () => {

--- a/tests/spec/w3c/style-spec.js
+++ b/tests/spec/w3c/style-spec.js
@@ -250,7 +250,6 @@ describe("W3C - Style", () => {
     expect(linkBase.nextElementSibling).toBe(linkDarkMode);
   });
 
-
   it("shouldn't include fixup.js when noToc is set", async () => {
     const ops = makeStandardOps();
     const newProps = {

--- a/tests/spec/w3c/style-spec.js
+++ b/tests/spec/w3c/style-spec.js
@@ -196,33 +196,41 @@ describe("W3C - Style", () => {
     });
   }
 
-  it("should add W3C stylesheet at the end", async () => {
+  it("should add W3C stylesheets at end", async () => {
     const ops = makeStandardOps({});
     const doc = await getExportedDoc(await makeRSDoc(ops));
     const url = "https://www.w3.org/StyleSheets/TR/2021/base";
     const elem = doc.querySelector(`link[href^='${url}'][rel="stylesheet"]`);
-    expect(elem).toBeTruthy();
-    expect(elem.nextElementSibling).toBeFalsy();
+    const colorSchemaMeta = doc.querySelector("link[media='(prefers-color-scheme: dark)']");
+    expect(elem?.nextElementSibling).toBe(colorSchemaMeta);
+    expect(colorSchemaMeta?.nextElementSibling).toBe(null);
+  });
 
-    const colorSchemaMeta = doc.querySelector("meta[name='color-scheme']");
-    expect(colorSchemaMeta).toBeFalsy();
+  it("should respect existing color scheme", async () => {
+    const ops = makeStandardOps();
+    const doc = await makeRSDoc(ops, "spec/core/color-scheme.html");
+    const elem = doc.querySelector("meta[name='color-scheme']");
+    expect(elem).toBeTruthy();
+    expect(elem.content).toBe("dark");
   });
 
   it("should add dark mode stylesheet", async () => {
-    const ops = makeStandardOps({ darkMode: true });
+    const ops = makeStandardOps();
     const doc = await makeRSDoc(ops);
     const url = "https://www.w3.org/StyleSheets/TR/2021/dark.css";
+    /** @type HTMLLinkElement? */
     const elem = doc.querySelector(`link[href^='${url}'][rel="stylesheet"]`);
     expect(elem).toBeTruthy();
-    expect(elem.href).toBe(url);
-    expect(elem.getAttribute("media")).toBe("(prefers-color-scheme: dark)");
+    expect(elem?.href).toBe(url);
+    expect(elem?.getAttribute("media")).toBe("(prefers-color-scheme: dark)");
+    /** @type HTMLMetaElement? */
     const colorSchemaMeta = doc.querySelector("meta[name='color-scheme']");
     expect(colorSchemaMeta).toBeTruthy();
-    expect(colorSchemaMeta.content).toBe("light dark");
+    expect(colorSchemaMeta?.content).toBe("light dark");
   });
 
   it("should add W3C darkmode stylesheet at the end", async () => {
-    const ops = makeStandardOps({ darkMode: true });
+    const ops = makeStandardOps();
     const doc = await getExportedDoc(await makeRSDoc(ops));
     const linkBase = doc.querySelector(
       `link[href^='https://www.w3.org/StyleSheets/TR/2021/base'][rel="stylesheet"]`

--- a/tests/spec/w3c/style-spec.js
+++ b/tests/spec/w3c/style-spec.js
@@ -226,10 +226,11 @@ describe("W3C - Style", () => {
     const doc = await makeRSDoc(ops, "spec/core/color-scheme.html");
     const url = "https://www.w3.org/StyleSheets/TR/2021/dark.css";
     /** @type HTMLLinkElement? */
-    const link = doc.querySelector(`link[href^='${url}'][rel="stylesheet"]`);
+    const link = doc.querySelector(
+      `link[href^='${url}'][rel="stylesheet"][media="(prefers-color-scheme: dark)"]`
+    );
     expect(link).toBeTruthy();
     expect(link?.href).toBe(url);
-    expect(link?.media).toBe("(prefers-color-scheme: dark)");
   });
 
   it("adds darkmode stylesheet at the end", async () => {

--- a/tests/spec/w3c/style-spec.js
+++ b/tests/spec/w3c/style-spec.js
@@ -224,13 +224,11 @@ describe("W3C - Style", () => {
   it("adds dark mode stylesheet", async () => {
     const ops = makeStandardOps();
     const doc = await makeRSDoc(ops, "spec/core/color-scheme.html");
-    const url = "https://www.w3.org/StyleSheets/TR/2021/dark.css";
     /** @type HTMLLinkElement? */
     const link = doc.querySelector(
-      `link[href^='${url}'][rel="stylesheet"][media="(prefers-color-scheme: dark)"]`
+      `link[href="https://www.w3.org/StyleSheets/TR/2021/dark.css"]`
     );
     expect(link).toBeTruthy();
-    expect(link?.href).toBe(url);
   });
 
   it("adds darkmode stylesheet at the end", async () => {

--- a/tests/spec/w3c/style-spec.js
+++ b/tests/spec/w3c/style-spec.js
@@ -213,7 +213,7 @@ describe("W3C - Style", () => {
     expect(elem.content).toBe("dark light");
   });
 
-  it("respects includes light color scheme by default", async () => {
+  it("sets the document to light color scheme by default", async () => {
     const ops = makeStandardOps();
     const doc = await makeRSDoc(ops);
     const elem = doc.querySelector("meta[name='color-scheme']");
@@ -221,7 +221,7 @@ describe("W3C - Style", () => {
     expect(elem.content).toBe("light");
   });
 
-  it("add dark mode stylesheet", async () => {
+  it("adds dark mode stylesheet", async () => {
     const ops = makeStandardOps();
     const doc = await makeRSDoc(ops, "spec/core/color-scheme.html");
     const url = "https://www.w3.org/StyleSheets/TR/2021/dark.css";
@@ -232,7 +232,7 @@ describe("W3C - Style", () => {
     expect(link?.getAttribute("media")).toBe("(prefers-color-scheme: dark)");
   });
 
-  it("adds W3C darkmode stylesheet at the end", async () => {
+  it("adds darkmode stylesheet at the end", async () => {
     const ops = makeStandardOps();
     const doc = await getExportedDoc(
       await makeRSDoc(ops, "spec/core/color-scheme.html")
@@ -251,7 +251,7 @@ describe("W3C - Style", () => {
     expect(linkBase.nextElementSibling).toBe(linkDarkMode);
   });
 
-  it("ensures correct color scheme CSS rules are embedded in style", async () => {
+  it("includes the color-scheme CSS rule in a style tag", async () => {
     const ops = makeStandardOps();
     const doc = await makeRSDoc(ops, "spec/core/color-scheme.html");
 

--- a/tests/spec/w3c/style-spec.js
+++ b/tests/spec/w3c/style-spec.js
@@ -201,7 +201,9 @@ describe("W3C - Style", () => {
     const doc = await getExportedDoc(await makeRSDoc(ops));
     const url = "https://www.w3.org/StyleSheets/TR/2021/base";
     const elem = doc.querySelector(`link[href^='${url}'][rel="stylesheet"]`);
-    const colorSchemaMeta = doc.querySelector("link[media='(prefers-color-scheme: dark)']");
+    const colorSchemaMeta = doc.querySelector(
+      "link[media='(prefers-color-scheme: dark)']"
+    );
     expect(elem?.nextElementSibling).toBe(colorSchemaMeta);
     expect(colorSchemaMeta?.nextElementSibling).toBe(null);
   });

--- a/tests/spec/w3c/style-spec.js
+++ b/tests/spec/w3c/style-spec.js
@@ -250,21 +250,6 @@ describe("W3C - Style", () => {
     expect(linkBase.nextElementSibling).toBe(linkDarkMode);
   });
 
-  it("includes the color-scheme CSS rule in a style tag", async () => {
-    const ops = makeStandardOps();
-    const doc = await makeRSDoc(ops, "spec/core/color-scheme.html");
-
-    // Select the embedded style element
-    /** @type HTMLStyleElement? */
-    const styleElem = doc.querySelector(
-      "style#respec-color-scheme-declaration"
-    );
-    expect(styleElem).toBeTruthy();
-
-    // Check if the style content includes the correct color-scheme value
-    const actualCSSContent = styleElem?.textContent;
-    expect(actualCSSContent?.includes("color-scheme: dark light")).toBeTruthy();
-  });
 
   it("shouldn't include fixup.js when noToc is set", async () => {
     const ops = makeStandardOps();

--- a/tests/spec/w3c/style-spec.js
+++ b/tests/spec/w3c/style-spec.js
@@ -202,7 +202,7 @@ describe("W3C - Style", () => {
     const url = "https://www.w3.org/StyleSheets/TR/2021/base";
     const elem = doc.querySelector(`link[href^='${url}'][rel="stylesheet"]`);
     expect(elem).toBeTruthy();
-    expect(elem?.nextElementSibling).toBe(null);
+    expect(elem.nextElementSibling).toBe(null);
   });
 
   it("respects existing color scheme", async () => {

--- a/tests/spec/w3c/style-spec.js
+++ b/tests/spec/w3c/style-spec.js
@@ -209,7 +209,7 @@ describe("W3C - Style", () => {
     const doc = await makeRSDoc(ops, "spec/core/color-scheme.html");
     const elem = doc.querySelector("meta[name='color-scheme']");
     expect(elem).toBeTruthy();
-    expect(elem.content).toBe("dark");
+    expect(elem.content).toBe("dark light");
   });
 
   it("respects includes light color scheme by default", async () => {
@@ -229,10 +229,6 @@ describe("W3C - Style", () => {
     expect(link).toBeTruthy();
     expect(link?.href).toBe(url);
     expect(link?.getAttribute("media")).toBe("(prefers-color-scheme: dark)");
-    /** @type HTMLMetaElement? */
-    const colorSchemeMeta = doc.querySelector("meta[name='color-scheme']");
-    expect(colorSchemeMeta).toBeTruthy();
-    expect(colorSchemeMeta?.content).toBe("dark");
   });
 
   it("adds W3C darkmode stylesheet at the end", async () => {
@@ -254,7 +250,7 @@ describe("W3C - Style", () => {
     expect(linkBase.nextElementSibling).toBe(linkDarkMode);
   });
 
-  it("ensures correct CSS rules are embedded in style", async () => {
+  it("ensures correct color scheme CSS rules are embedded in style", async () => {
     const ops = makeStandardOps();
     const doc = await makeRSDoc(ops, "spec/core/color-scheme.html");
 
@@ -267,7 +263,7 @@ describe("W3C - Style", () => {
 
     // Check if the style content includes the correct color-scheme value
     const actualCSSContent = styleElem?.textContent;
-    expect(actualCSSContent?.includes("color-scheme: dark")).toBeTruthy();
+    expect(actualCSSContent?.includes("color-scheme: dark light")).toBeTruthy();
   });
 
   it("shouldn't include fixup.js when noToc is set", async () => {


### PR DESCRIPTION
Removes the opt in `respecConfig.darkMode` option, allowing HTML's  meta tag to be used instead. 