### PR TITLE
fix(core/xref): fix rendering of hint in ambiguous term error

### DIFF
--- a/src/core/xref.js
+++ b/src/core/xref.js
@@ -478,7 +478,9 @@ function showErrors({ ambiguous, notFound }) {
     const formUrl = getPrefilledFormURL(originalTerm, query, specs);
     const forParent = query.for ? `, for **"${query.for}"**, ` : "";
     const moreInfo = howToFix(formUrl, originalTerm);
-    const hint = docLink`To fix, use the ${"[data-cite]"} attribute to pick the one you mean from the appropriate specification. ${moreInfo}.`;
+    const hint =
+      docLink`To fix, use the ${"[data-cite]"} attribute to pick the one you mean from the appropriate specification.` +
+      String.raw` ${moreInfo}`;
     const msg = `The term "**${originalTerm}**"${forParent} is ambiguous because it's defined in ${specsString}.`;
     const title = "Definition is ambiguous.";
     showError(msg, name, { title, elements: elems, hint });


### PR DESCRIPTION
Fixes https://github.com/w3c/respec/issues/4696
Fixes https://github.com/w3c/respec/issues/4720

Compare: [old](https://respec-preview.netlify.app/?spec=https%3A%2F%2Fw3c.github.io%2Fscreen-orientation%2F&version=https%3A%2F%2Fdeploy-preview-4700--respec-pr.netlify.app%2Frespec-w3c.js) | [new](https://respec-preview.netlify.app/?spec=https%3A%2F%2Fw3c.github.io%2Fscreen-orientation%2F&version=https%3A%2F%2Fdeploy-preview-4724--respec-pr.netlify.app%2Frespec-w3c.js)