### PR TITLE
fix(w3c/headers): don't crash on save if `.head details` doesn't exist

### DIFF
--- a/src/w3c/templates/headers.js
+++ b/src/w3c/templates/headers.js
@@ -190,7 +190,7 @@ export default (conf, options) => {
    */
   sub("beforesave", doc => {
     const details = doc.querySelector(".head details");
-    details.open = true;
+    if (details) details.open = true;
   });
   return html`<div class="head">
     ${conf.logos.length


### PR DESCRIPTION
See https://github.com/w3c/geolocation-api/pull/158#issuecomment-2149219993